### PR TITLE
pkg/storage/metastore: Optimize SQL query building of locations by ids

### DIFF
--- a/pkg/storage/metastore/sql_bench_test.go
+++ b/pkg/storage/metastore/sql_bench_test.go
@@ -47,7 +47,7 @@ func BenchmarkBuildLocationsByIDsQuery(b *testing.B) {
 			}
 
 			for i := 0; i < b.N; i++ {
-				result = buildLocationsByIDsQuery(input)
+				result = buildLocationsByIDsQuery(input[len(input)-1], input)
 			}
 		})
 	}

--- a/pkg/storage/metastore/sql_bench_test.go
+++ b/pkg/storage/metastore/sql_bench_test.go
@@ -36,3 +36,19 @@ func BenchmarkBuildLinesByLocationIDsQuery(b *testing.B) {
 		})
 	}
 }
+
+func BenchmarkBuildLocationsByIDsQuery(b *testing.B) {
+	for k := 0.; k <= 5; k++ {
+		n := uint64(math.Pow(10, k))
+		b.Run(fmt.Sprintf("%d", n), func(b *testing.B) {
+			input := make([]uint64, 0, n)
+			for i := uint64(0); i < n; i++ {
+				input = append(input, i)
+			}
+
+			for i := 0; i < b.N; i++ {
+				result = buildLocationsByIDsQuery(input)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This often shows up in large queries of previously unqueried data.

```
name                               old time/op    new time/op    delta
BuildLocationsByIDsQuery/1-8          378ns ± 0%      89ns ± 0%   ~     (p=1.000 n=1+1)
BuildLocationsByIDsQuery/10-8        1.42µs ± 0%    0.17µs ± 0%   ~     (p=1.000 n=1+1)
BuildLocationsByIDsQuery/100-8       20.8µs ± 0%     0.9µs ± 0%   ~     (p=1.000 n=1+1)
BuildLocationsByIDsQuery/1000-8      1.46ms ± 0%    0.02ms ± 0%   ~     (p=1.000 n=1+1)
BuildLocationsByIDsQuery/10000-8      129ms ± 0%       0ms ± 0%   ~     (p=1.000 n=1+1)
BuildLocationsByIDsQuery/100000-8     12.5s ± 0%      0.0s ± 0%   ~     (p=1.000 n=1+1)

name                               old alloc/op   new alloc/op   delta
BuildLocationsByIDsQuery/1-8           144B ± 0%      128B ± 0%   ~     (p=1.000 n=1+1)
BuildLocationsByIDsQuery/10-8          392B ± 0%      144B ± 0%   ~     (p=1.000 n=1+1)
BuildLocationsByIDsQuery/100-8       30.0kB ± 0%     0.4kB ± 0%   ~     (p=1.000 n=1+1)
BuildLocationsByIDsQuery/1000-8      4.07MB ± 0%    0.00MB ± 0%   ~     (p=1.000 n=1+1)
BuildLocationsByIDsQuery/10000-8      517MB ± 0%       0MB ± 0%   ~     (p=1.000 n=1+1)
BuildLocationsByIDsQuery/100000-8    58.7GB ± 0%     0.0GB ± 0%   ~     (p=1.000 n=1+1)

name                               old allocs/op  new allocs/op  delta
BuildLocationsByIDsQuery/1-8           2.00 ± 0%      1.00 ± 0%   ~     (p=1.000 n=1+1)
BuildLocationsByIDsQuery/10-8          20.0 ± 0%       1.0 ± 0%   ~     (p=1.000 n=1+1)
BuildLocationsByIDsQuery/100-8          200 ± 0%         1 ± 0%   ~     (p=1.000 n=1+1)
BuildLocationsByIDsQuery/1000-8       2.90k ± 0%     0.00k ± 0%   ~     (p=1.000 n=1+1)
BuildLocationsByIDsQuery/10000-8      29.9k ± 0%      0.0k ± 0%   ~     (p=1.000 n=1+1)
BuildLocationsByIDsQuery/100000-8      301k ± 0%        0k ± 0%   ~     (p=1.000 n=1+1)
```