### PR TITLE
Docs: add Yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Check Parca's website for updated and in-depth installation guides and documenta
 
 ## Development
 
-You need to have [Go](https://golang.org/) and [Node](https://nodejs.org/en/download/) installed.
+You need to have [Go](https://golang.org/), [Node](https://nodejs.org/en/download/) and [Yarn](https://classic.yarnpkg.com/en/) installed.
 
 Clone the project
 


### PR DESCRIPTION
When trying to build locally I got:

```bash
jessica@cupsofwonder:~/workspace/parca|main ⇒  make build
make: Circular ui/packages/app/web/dist <- ui dependency dropped.
cd ui && yarn install && yarn workspace @parca/web build
/bin/sh: 1: yarn: not found
make: *** [Makefile:51: ui/packages/app/web/dist] Error 127
```

This just adds a link to the docs referring to Yarn too :) 

Signed-off-by: Jéssica Lins <jlins@redhat.com>