### PR TITLE
deploy/lib/parca: pin to amd64 nodes only

### DIFF
--- a/deploy/lib/parca/parca.libsonnet
+++ b/deploy/lib/parca/parca.libsonnet
@@ -255,6 +255,7 @@ function(params) {
             }],
             nodeSelector: {
               'kubernetes.io/os': 'linux',
+              'kubernetes.io/arch': 'amd64',
             },
           },
         },


### PR DESCRIPTION
Since container images are present only for x86_64 it might be good to pin k8s manifests to that architecture.