### PR TITLE
config: Validate timeout and interval of the scrape configuration

### DIFF
--- a/parca.yaml
+++ b/parca.yaml
@@ -10,6 +10,7 @@ debug_info:
 
 scrape_configs:
   - job_name: "default"
-    scrape_interval: "1s"
+    scrape_interval: "3s"
+    scrape_timeout: "2s"
     static_configs:
       - targets: [ '127.0.0.1:7070' ]

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -56,7 +56,7 @@ scrape_configs:
 		ScrapeConfigs: []*ScrapeConfig{{
 			JobName:        "conprof",
 			ScrapeInterval: model.Duration(10 * time.Second),
-			ScrapeTimeout:  model.Duration(11 * time.Second),
+			ScrapeTimeout:  model.Duration(10 * time.Second),
 			Scheme:         "http",
 			ProfilingConfig: &ProfilingConfig{
 				PprofConfig: PprofConfig{

--- a/pkg/scrape/target.go
+++ b/pkg/scrape/target.go
@@ -370,7 +370,7 @@ func targetsFromGroup(tg *targetgroup.Group, cfg *config.ScrapeConfig) ([]*Targe
 				}
 
 				if pcfg, found := cfg.ProfilingConfig.PprofConfig[profType]; found && pcfg.Delta {
-					params.Add("seconds", strconv.Itoa(int(time.Duration(cfg.ScrapeInterval)/time.Second)))
+					params.Add("seconds", strconv.Itoa(int(time.Duration(cfg.ScrapeTimeout)/time.Second)-1))
 				}
 
 				targets = append(targets, NewTarget(lbls, origLabels, params))


### PR DESCRIPTION
In general we want to stick to the configured interval and don't
overrun because of slow or timing out scraping.

Go's /debug/pprof/profile endpoint will start profiling when being
invoked, has no support for concurrency and the timeout can only
be configured in seconds. The existing code alternated between using
"Seconds", "Delta"+ScrapeInterval but none of these work correctly
when enforcing timeout <= interval.

Make sure that "seconds" < ScrapeTimeout <= ScrapeInterval and adjust
the default configuration to honor this. In the long run we should
consider treating this endpoint entirely different to the others (e.g.
jitter scraping instead of sticking to interval, profile for a longer
duration).