### PR TITLE
Fixes parsing discovery configs

### DIFF
--- a/pkg/debuginfo/validation.go
+++ b/pkg/debuginfo/validation.go
@@ -33,7 +33,7 @@ func (v ValidRule) Validate(value interface{}) error {
 		return errors.New("DebugInfo is invalid")
 	}
 	return validation.ValidateStruct(c,
-		validation.Field(c.Bucket, validation.Required, BucketValid),
+		validation.Field(&c.Bucket, validation.Required, BucketValid),
 	)
 }
 

--- a/pkg/parca/parca.go
+++ b/pkg/parca/parca.go
@@ -85,7 +85,7 @@ func Run(ctx context.Context, logger log.Logger, reg *prometheus.Registry, flags
 	}
 
 	cfg := config.Config{}
-	if err := yaml.UnmarshalStrict(cfgContent, &cfg); err != nil {
+	if err := yaml.Unmarshal(cfgContent, &cfg); err != nil {
 		level.Error(logger).Log("msg", "failed to parse config", "err", err, "path", flags.ConfigPath)
 		return err
 	}


### PR DESCRIPTION
They can't be strictly unmarshalled due to their lack of typing