### PR TITLE
deploy/lib/parca: fix serviceMonitor port

### DIFF
--- a/deploy/lib/parca/parca.libsonnet
+++ b/deploy/lib/parca/parca.libsonnet
@@ -61,8 +61,7 @@ function(params) {
       ports: [
         {
           assert std.isNumber(prc.config.port),
-
-          name: 'all',
+          name: 'http',
           port: prc.config.port,
           targetPort: prc.config.port,
         },
@@ -279,7 +278,7 @@ function(params) {
       },
       endpoints: [
         {
-          port: 'http',
+          port: prc.service.spec.ports[0].name,
           relabelings: [{
             sourceLabels: ['namespace', 'pod'],
             separator: '/',


### PR DESCRIPTION
Change the port name to `http` and fix ServiceMonitor endpoint to match SVC port name.