### PR TITLE
pkg/storage: Handle errors in iterators early

### DIFF
--- a/pkg/query/query.go
+++ b/pkg/query/query.go
@@ -120,7 +120,7 @@ func (q *Query) QueryRange(ctx context.Context, req *pb.QueryRangeRequest) (*pb.
 		profileSpan.SetAttributes(attribute.Int("i", i))
 		profileSpan.End()
 		if err := it.Err(); err != nil {
-			return nil, status.Error(codes.Internal, "failed to iterate")
+			return nil, status.Error(codes.Internal, fmt.Errorf("failed to iterate: %w", err).Error())
 		}
 
 		res.Series = append(res.Series, metricsSeries)

--- a/pkg/storage/interface.go
+++ b/pkg/storage/interface.go
@@ -162,6 +162,10 @@ type SliceProfileSeriesIterator struct {
 }
 
 func (i *SliceProfileSeriesIterator) Next() bool {
+	if i.err != nil {
+		return false
+	}
+
 	i.i++
 	return i.i < len(i.samples)
 }

--- a/pkg/storage/series_iterator.go
+++ b/pkg/storage/series_iterator.go
@@ -112,12 +112,12 @@ func (s *MemSeries) Iterator() ProfileSeriesIterator {
 }
 
 func (it *MemSeriesIterator) Next() bool {
-	it.series.mu.RLock()
-	defer it.series.mu.RUnlock()
-
-	if it.numSamples == 0 {
+	if it.err != nil || it.numSamples == 0 {
 		return false
 	}
+
+	it.series.mu.RLock()
+	defer it.series.mu.RUnlock()
 
 	if !it.timestampsIterator.Next() {
 		it.err = errors.New("unexpected end of timestamps iterator")

--- a/pkg/storage/series_iterator_range.go
+++ b/pkg/storage/series_iterator_range.go
@@ -146,12 +146,12 @@ type MemRangeSeriesIterator struct {
 }
 
 func (it *MemRangeSeriesIterator) Next() bool {
-	it.s.mu.RLock()
-	defer it.s.mu.RUnlock()
-
-	if it.numSamples == 0 {
+	if it.err != nil || it.numSamples == 0 {
 		return false
 	}
+
+	it.s.mu.RLock()
+	defer it.s.mu.RUnlock()
 
 	if !it.timestampsIterator.Next() {
 		it.err = errors.New("unexpected end of timestamps iterator")


### PR DESCRIPTION
We weren't properly handling errors in the iterators and in some edge cases that caused funny behavior like endless loops.