### PR TITLE
add retries to insert

### DIFF
--- a/pkg/storage/metastore/sql.go
+++ b/pkg/storage/metastore/sql.go
@@ -639,7 +639,10 @@ func (s *sqlMetaStore) CreateLocation(ctx context.Context, l *profile.Location) 
 		}
 	}
 
-	backoff.Retry(f, backoff.WithContext(backoff.WithMaxRetries(backoff.NewConstantBackOff(10*time.Millisecond), 3), ctx))
+	if err := backoff.Retry(f, backoff.WithContext(backoff.WithMaxRetries(backoff.NewConstantBackOff(10*time.Millisecond), 3), ctx)); err != nil {
+		return 0, fmt.Errorf("backoff SQL statement: %w", err)
+	}
+
 	if err != nil {
 		return 0, fmt.Errorf("execute SQL statement: %w", err)
 	}


### PR DESCRIPTION
Retry inserts to avoid the race condition found in #286 

I think it would be better to detect a unique constraint error and simply ignore it. But I think this works for now, as it's hard to create a database portable error detection solution.