### PR TITLE
jsonnet: make parca server config configurable

### DIFF
--- a/deploy/lib/parca/parca.libsonnet
+++ b/deploy/lib/parca/parca.libsonnet
@@ -11,6 +11,18 @@ local defaults = {
 
   configPath: '/var/parca/parca.yaml',
   configmapName: 'parca-config',
+  config: {
+    debug_info: {
+      bucket: {
+        type: 'FILESYSTEM',
+        config: { directory: './tmp' },
+      },
+      cache: {
+        type: 'FILESYSTEM',
+        config: { directory: './tmp' },
+      },
+    },
+  },
   corsAllowedOrigins: '',
   logLevel: 'info',
 
@@ -181,18 +193,7 @@ function(params) {
       namespace: prc.config.namespace,
     },
     data: {
-      'parca.yaml': std.manifestYamlDoc({
-        debug_info: {
-          bucket: {
-            type: 'FILESYSTEM',
-            config: { directory: './tmp' },
-          },
-          cache: {
-            type: 'FILESYSTEM',
-            config: { directory: './tmp' },
-          },
-        },
-      }),
+      'parca.yaml': std.manifestYamlDoc(prc.config.config),
     },
   },
 


### PR DESCRIPTION
Signed-off-by: Ben Ye <ben.ye@bytedance.com>

This allows adding scrape config for parca.