### PR TITLE
pkg/storage/metastore: Fix location key

### DIFF
--- a/pkg/storage/metastore/metastore.go
+++ b/pkg/storage/metastore/metastore.go
@@ -72,7 +72,7 @@ func MakeLocationKey(l *profile.Location) LocationKey {
 	// runtime/language eg. ruby or python. In those cases we have no better
 	// uniqueness factor than the actual functions, and since there is no
 	// address there is no potential for asynchronously symbolizing.
-	if key.NormalizedAddress != 0 {
+	if key.NormalizedAddress == 0 {
 		lines := make([]string, len(l.Line)*2)
 		for i, line := range l.Line {
 			if line.Function != nil {


### PR DESCRIPTION
I think this should fix https://github.com/parca-dev/parca/issues/261

In dynamic languages (such as javascript, ruby, python) we don't actually have a memory address that we can resolve to a symbol in a stable way, so the address is not a useful identifier for the location, only the true file, function, and line number is.