### PR TITLE
Update dependabot to only send weekly npm PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@ updates:
     directory: "/ui"
     # Check the npm registry for updates every day (weekdays)
     schedule:
-      interval: "daily"
+      interval: "weekly"
 
   # Enable version updates for npm
   - package-ecosystem: "npm"
@@ -22,7 +22,7 @@ updates:
     directory: "/ui/packages/app/web"
     # Check the npm registry for updates every day (weekdays)
     schedule:
-      interval: "daily"
+      interval: "weekly"
 
   # Enable version updates for Docker
   - package-ecosystem: "docker"


### PR DESCRIPTION
@kakkoyun and I felt like npm updates are quite a lot, so we propose to only run them weekly.