### PR TITLE
Break query loop when timestamp 0

### DIFF
--- a/pkg/query/query.go
+++ b/pkg/query/query.go
@@ -127,7 +127,7 @@ func (q *Query) QueryRange(ctx context.Context, req *pb.QueryRangeRequest) (*pb.
 			}
 			if p.ProfileMeta().Timestamp == 0 {
 				level.Warn(q.logger).Log("msg", "timestamp is 0", "i", i)
-				continue
+				break
 			}
 			metricsSeries.Samples = append(metricsSeries.Samples, &pb.MetricsSample{
 				Timestamp: timestamppb.New(timestamp.Time(p.ProfileMeta().Timestamp)),


### PR DESCRIPTION
We had a few reports that their logs were spammed with "timestamp is 0" and to mitigate this, we can rather `break` than `continue`. The downside might be that you won't see any metrics if it's the first sample or in between, that's `0`. So far when I saw this happening it was always the last sample tough, so we can stop anyway.