### PR TITLE
pkg/storage: Querying flat profiles

### DIFF
--- a/pkg/parca/parca.go
+++ b/pkg/parca/parca.go
@@ -65,6 +65,7 @@ type Flags struct {
 
 	StorageTSDBRetentionTime    time.Duration `default:"6h" help:"How long to retain samples in storage."`
 	StorageTSDBExpensiveMetrics bool          `default:"false" help:"Enable really heavy metrics. Only do this for debugging as the metrics are slowing Parca down by a lot." hidden:"true"`
+	StorageTSDBProfileTrees     bool          `default:"true" help:"Enable profile tree storage in the TSDB" hidden:"true"`
 
 	SymbolizerDemangleMode  string `default:"simple" help:"Mode to demangle C++ symbols. Default mode is simplified: no parameters, no templates, no return type" enum:"simple,full,none,templates"`
 	SymbolizerNumberOfTries int    `default:"3" help:"Number of tries to attempt to symbolize an unsybolized location"`
@@ -126,6 +127,7 @@ func Run(ctx context.Context, logger log.Logger, reg *prometheus.Registry, flags
 		tracerProvider.Tracer("profilestore"),
 		db,
 		mStr,
+		flags.StorageTSDBProfileTrees,
 	)
 	q := query.New(
 		logger,

--- a/pkg/parca/parca.go
+++ b/pkg/parca/parca.go
@@ -134,6 +134,7 @@ func Run(ctx context.Context, logger log.Logger, reg *prometheus.Registry, flags
 		tracerProvider.Tracer("query-service"),
 		db,
 		mStr,
+		flags.StorageTSDBProfileTrees,
 	)
 
 	ctx, cancel := context.WithCancel(ctx)

--- a/pkg/profilestore/profilestore.go
+++ b/pkg/profilestore/profilestore.go
@@ -80,7 +80,7 @@ func (s *ProfileStore) WriteRaw(ctx context.Context, r *profilestorepb.WriteRawR
 				return nil, status.Errorf(codes.InvalidArgument, "invalid profile: %v", err)
 			}
 
-			if !s.profileTrees {
+			if s.profileTrees {
 				convertCtx, convertSpan := s.tracer.Start(ctx, "profile-tree-from-pprof")
 				profiles, err := storage.ProfilesFromPprof(convertCtx, s.logger, s.metaStore, p)
 				if err != nil {
@@ -157,11 +157,11 @@ func (s *ProfileStore) WriteRaw(ctx context.Context, r *profilestorepb.WriteRawR
 						return nil, err
 					}
 
-					if app.AppendFlat(appendCtx, prof); err != nil {
+					if err := app.AppendFlat(appendCtx, prof); err != nil {
 						return nil, status.Errorf(codes.Internal, "failed to append sample: %v", err)
 					}
 				}
-
+				appendSpan.End()
 			}
 		}
 	}

--- a/pkg/query/query_test.go
+++ b/pkg/query/query_test.go
@@ -46,6 +46,7 @@ func Test_QueryRange_EmptyStore(t *testing.T) {
 		trace.NewNoopTracerProvider().Tracer(""),
 		db,
 		nil,
+		true,
 	)
 
 	// Query last 5 minutes
@@ -79,6 +80,7 @@ func Test_QueryRange_Valid(t *testing.T) {
 		trace.NewNoopTracerProvider().Tracer(""),
 		db,
 		s,
+		true,
 	)
 
 	app, err := db.Appender(ctx, labels.Labels{
@@ -144,6 +146,7 @@ func Test_QueryRange_Limited(t *testing.T) {
 		trace.NewNoopTracerProvider().Tracer(""),
 		db,
 		s,
+		true,
 	)
 
 	f, err := os.Open("testdata/alloc_objects.pb.gz")
@@ -230,7 +233,7 @@ func Test_QueryRange_Ranged(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	q := New(logger, tracer, db, s)
+	q := New(logger, tracer, db, s, true)
 
 	resp, err := q.QueryRange(ctx, &pb.QueryRangeRequest{
 		Query: "allocs",
@@ -291,6 +294,7 @@ func Test_QueryRange_InputValidation(t *testing.T) {
 		trace.NewNoopTracerProvider().Tracer(""),
 		nil,
 		nil,
+		true,
 	)
 
 	t.Parallel()
@@ -348,6 +352,7 @@ func Test_Query_InputValidation(t *testing.T) {
 		trace.NewNoopTracerProvider().Tracer(""),
 		nil,
 		nil,
+		true,
 	)
 
 	t.Parallel()
@@ -378,6 +383,7 @@ func Test_Query_Simple(t *testing.T) {
 		trace.NewNoopTracerProvider().Tracer(""),
 		db,
 		s,
+		true,
 	)
 
 	app, err := db.Appender(ctx, labels.Labels{
@@ -437,6 +443,7 @@ func Test_Query_Diff(t *testing.T) {
 		trace.NewNoopTracerProvider().Tracer(""),
 		db,
 		s,
+		true,
 	)
 
 	app, err := db.Appender(ctx, labels.Labels{
@@ -543,6 +550,7 @@ func Benchmark_Query_Merge(b *testing.B) {
 					trace.NewNoopTracerProvider().Tracer(""),
 					db,
 					s,
+					true,
 				)
 
 				app, err := db.Appender(ctx, labels.Labels{
@@ -606,6 +614,7 @@ func Test_Query_Merge(t *testing.T) {
 			trace.NewNoopTracerProvider().Tracer(""),
 			db,
 			s,
+			true,
 		)
 
 		app, err := db.Appender(ctx, labels.Labels{
@@ -657,6 +666,7 @@ func Test_QueryRange_MultipleLabels_NoMatch(t *testing.T) {
 		trace.NewNoopTracerProvider().Tracer(""),
 		db,
 		s,
+		true,
 	)
 
 	ls1 := labels.Labels{

--- a/pkg/storage/benchmark/db-appends.txt
+++ b/pkg/storage/benchmark/db-appends.txt
@@ -2,20 +2,20 @@ goos: linux
 goarch: amd64
 pkg: github.com/parca-dev/parca/pkg/storage
 cpu: AMD Ryzen 9 3900X 12-Core Processor            
-BenchmarkAppends-24    	    2500	  12136418 ns/op	 6255307 B/op	  121604 allocs/op
+BenchmarkAppends-24    	    2500	  16743501 ns/op	 9839116 B/op	  139925 allocs/op
 PASS
-ok  	github.com/parca-dev/parca/pkg/storage	44.651s
+ok  	github.com/parca-dev/parca/pkg/storage	55.886s
 goos: linux
 goarch: amd64
 pkg: github.com/parca-dev/parca/pkg/storage
 cpu: AMD Ryzen 9 3900X 12-Core Processor            
-BenchmarkAppends-24    	    2500	  12731492 ns/op	 6255228 B/op	  121604 allocs/op
+BenchmarkAppends-24    	    2500	  16699756 ns/op	 9839168 B/op	  139926 allocs/op
 PASS
-ok  	github.com/parca-dev/parca/pkg/storage	45.716s
+ok  	github.com/parca-dev/parca/pkg/storage	55.735s
 goos: linux
 goarch: amd64
 pkg: github.com/parca-dev/parca/pkg/storage
 cpu: AMD Ryzen 9 3900X 12-Core Processor            
-BenchmarkAppends-24    	    2500	  12628846 ns/op	 6255283 B/op	  121604 allocs/op
+BenchmarkAppends-24    	    2500	  16895825 ns/op	 9839081 B/op	  139925 allocs/op
 PASS
-ok  	github.com/parca-dev/parca/pkg/storage	45.743s
+ok  	github.com/parca-dev/parca/pkg/storage	56.375s

--- a/pkg/storage/benchmark/db-iterator.txt
+++ b/pkg/storage/benchmark/db-iterator.txt
@@ -2,20 +2,20 @@ goos: linux
 goarch: amd64
 pkg: github.com/parca-dev/parca/pkg/storage
 cpu: AMD Ryzen 9 3900X 12-Core Processor            
-BenchmarkIterator-24    	    2500	    108299 ns/op	   28022 B/op	    1699 allocs/op
+BenchmarkIterator-24    	    2500	     62069 ns/op	     550 B/op	       3 allocs/op
 PASS
-ok  	github.com/parca-dev/parca/pkg/storage	46.250s
+ok  	github.com/parca-dev/parca/pkg/storage	56.039s
 goos: linux
 goarch: amd64
 pkg: github.com/parca-dev/parca/pkg/storage
 cpu: AMD Ryzen 9 3900X 12-Core Processor            
-BenchmarkIterator-24    	    2500	     99102 ns/op	   28022 B/op	    1699 allocs/op
+BenchmarkIterator-24    	    2500	     62161 ns/op	     550 B/op	       3 allocs/op
 PASS
-ok  	github.com/parca-dev/parca/pkg/storage	46.385s
+ok  	github.com/parca-dev/parca/pkg/storage	57.280s
 goos: linux
 goarch: amd64
 pkg: github.com/parca-dev/parca/pkg/storage
 cpu: AMD Ryzen 9 3900X 12-Core Processor            
-BenchmarkIterator-24    	    2500	    103160 ns/op	   28022 B/op	    1699 allocs/op
+BenchmarkIterator-24    	    2500	     61522 ns/op	     553 B/op	       3 allocs/op
 PASS
-ok  	github.com/parca-dev/parca/pkg/storage	45.857s
+ok  	github.com/parca-dev/parca/pkg/storage	56.073s

--- a/pkg/storage/benchmark_test.go
+++ b/pkg/storage/benchmark_test.go
@@ -104,11 +104,19 @@ func BenchmarkAppends(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 
+	//for i := 0; i < b.N; i++ {
+	//	p := profiles[i%len(profiles)]
+	//	pprof, err := storage.ProfileFromPprof(ctx, logger, l, p, 0)
+	//	require.NoError(b, err)
+	//	err = app.Append(ctx, pprof)
+	//	require.NoError(b, err)
+	//}
+
 	for i := 0; i < b.N; i++ {
 		p := profiles[i%len(profiles)]
-		pprof, err := storage.ProfileFromPprof(ctx, logger, l, p, 0)
+		pprof, err := storage.FlatProfileFromPprof(ctx, logger, l, p, 0)
 		require.NoError(b, err)
-		err = app.Append(ctx, pprof)
+		err = app.AppendFlat(ctx, pprof)
 		require.NoError(b, err)
 	}
 
@@ -140,9 +148,9 @@ func BenchmarkIterator(b *testing.B) {
 	require.NoError(b, err)
 	for i := 0; i < b.N; i++ {
 		pprof := profiles[i%len(profiles)]
-		p, err := storage.ProfileFromPprof(ctx, logger, l, pprof, 0)
+		p, err := storage.FlatProfileFromPprof(ctx, logger, l, pprof, 0)
 		require.NoError(b, err)
-		err = app.Append(ctx, p)
+		err = app.AppendFlat(ctx, p)
 		require.NoError(b, err)
 	}
 
@@ -152,9 +160,9 @@ func BenchmarkIterator(b *testing.B) {
 
 	var q storage.Querier
 	if b.N == 1 {
-		q = db.Querier(context.Background(), math.MinInt64, math.MaxInt64, true)
+		q = db.Querier(context.Background(), math.MinInt64, math.MaxInt64, false)
 	} else {
-		q = db.Querier(context.Background(), 1614253659535, 1614262838920, true)
+		q = db.Querier(context.Background(), 1614253659535, 1614262838920, false)
 	}
 
 	b.ReportAllocs()

--- a/pkg/storage/benchmark_test.go
+++ b/pkg/storage/benchmark_test.go
@@ -152,9 +152,9 @@ func BenchmarkIterator(b *testing.B) {
 
 	var q storage.Querier
 	if b.N == 1 {
-		q = db.Querier(context.Background(), math.MinInt64, math.MaxInt64)
+		q = db.Querier(context.Background(), math.MinInt64, math.MaxInt64, true)
 	} else {
-		q = db.Querier(context.Background(), 1614253659535, 1614262838920)
+		q = db.Querier(context.Background(), 1614253659535, 1614262838920, true)
 	}
 
 	b.ReportAllocs()

--- a/pkg/storage/db.go
+++ b/pkg/storage/db.go
@@ -37,7 +37,7 @@ type SelectHints struct {
 }
 
 type Queryable interface {
-	Querier(ctx context.Context, mint, maxt int64) Querier
+	Querier(ctx context.Context, mint, maxt int64, trees bool) Querier
 }
 
 type Querier interface {
@@ -143,8 +143,8 @@ func (db *DB) Appender(ctx context.Context, lset labels.Labels) (Appender, error
 	return db.head.Appender(ctx, lset)
 }
 
-func (db *DB) Querier(ctx context.Context, mint, maxt int64) Querier {
-	return db.head.Querier(ctx, mint, maxt)
+func (db *DB) Querier(ctx context.Context, mint, maxt int64, trees bool) Querier {
+	return db.head.Querier(ctx, mint, maxt, trees)
 }
 
 func (db *DB) Run(ctx context.Context) error {

--- a/pkg/storage/db.go
+++ b/pkg/storage/db.go
@@ -95,6 +95,7 @@ type Labels interface {
 
 type Appender interface {
 	Append(ctx context.Context, p *Profile) error
+	AppendFlat(ctx context.Context, p *FlatProfile) error
 }
 
 type SliceSeriesSet struct {

--- a/pkg/storage/db_test.go
+++ b/pkg/storage/db_test.go
@@ -72,6 +72,7 @@ func TestDB(t *testing.T) {
 		ctx,
 		timestamp.FromTime(time.Now().Add(-10*time.Second)),
 		timestamp.FromTime(time.Now().Add(10*time.Second)),
+		true,
 	)
 	m, err := labels.NewMatcher(labels.MatchEqual, "namespace", "default")
 	require.NoError(t, err)

--- a/pkg/storage/diff.go
+++ b/pkg/storage/diff.go
@@ -55,6 +55,10 @@ func (d *DiffProfile) ProfileMeta() InstantProfileMeta {
 	return d.meta
 }
 
+func (d *DiffProfile) Samples() []*Sample {
+	panic("implement me")
+}
+
 type DiffProfileTree struct {
 	d *DiffProfile
 }

--- a/pkg/storage/flamegraph_flat.go
+++ b/pkg/storage/flamegraph_flat.go
@@ -33,6 +33,10 @@ type FlatProfile struct {
 	samples []*Sample
 }
 
+func (fp *FlatProfile) ProfileTree() InstantProfileTree {
+	panic("won't be implement - use Profile instead")
+}
+
 func (fp *FlatProfile) ProfileMeta() InstantProfileMeta {
 	return fp.Meta
 }
@@ -121,5 +125,5 @@ func GenerateFlamegraphFlat(ctx context.Context, tracer trace.Tracer, locations 
 	flamegraph.Root.Diff = rootNode.Diff
 	flamegraph.Root.Children = rootNode.Children
 
-	return flamegraph, nil
+	return aggregateByFunction(flamegraph), nil
 }

--- a/pkg/storage/head.go
+++ b/pkg/storage/head.go
@@ -331,12 +331,13 @@ func (h *Head) appender(ctx context.Context, lset labels.Labels) (Appender, erro
 	return s.Appender()
 }
 
-func (h *Head) Querier(ctx context.Context, mint, maxt int64) Querier {
+func (h *Head) Querier(ctx context.Context, mint, maxt int64, trees bool) Querier {
 	return &HeadQuerier{
-		head: h,
-		ctx:  ctx,
-		mint: mint,
-		maxt: maxt,
+		head:  h,
+		ctx:   ctx,
+		mint:  mint,
+		maxt:  maxt,
+		trees: trees,
 	}
 }
 
@@ -344,6 +345,7 @@ type HeadQuerier struct {
 	head       *Head
 	ctx        context.Context
 	mint, maxt int64
+	trees      bool
 }
 
 func (q *HeadQuerier) LabelNames(ms ...*labels.Matcher) ([]string, Warnings, error) {
@@ -421,10 +423,10 @@ func (q *HeadQuerier) Select(hints *SelectHints, ms ...*labels.Matcher) SeriesSe
 			continue
 		}
 		if hints != nil && hints.Root {
-			ss = append(ss, &MemRootSeries{s: s, mint: mint, maxt: maxt})
+			ss = append(ss, &MemRootSeries{s: s, mint: mint, maxt: maxt, trees: q.trees})
 			continue
 		}
-		ss = append(ss, &MemRangeSeries{s: s, mint: mint, maxt: maxt})
+		ss = append(ss, &MemRangeSeries{s: s, mint: mint, maxt: maxt, trees: q.trees})
 	}
 
 	return &SliceSeriesSet{

--- a/pkg/storage/head.go
+++ b/pkg/storage/head.go
@@ -255,6 +255,22 @@ func (a *initAppender) Append(ctx context.Context, p *Profile) error {
 	return a.app.Append(ctx, p)
 }
 
+func (a *initAppender) AppendFlat(ctx context.Context, p *FlatProfile) error {
+	if a.app != nil {
+		return a.app.AppendFlat(ctx, p)
+	}
+
+	a.head.initTime(p.Meta.Timestamp)
+
+	var err error
+	a.app, err = a.head.appender(ctx, a.lset)
+	if err != nil {
+		return err
+	}
+
+	return a.app.AppendFlat(ctx, p)
+}
+
 // MinTime returns the lowest time bound on visible data in the head.
 func (h *Head) MinTime() int64 {
 	return h.minTime.Load()

--- a/pkg/storage/interface.go
+++ b/pkg/storage/interface.go
@@ -131,6 +131,7 @@ func CopyInstantProfileTree(pt InstantProfileTree) *ProfileTree {
 type InstantProfile interface {
 	ProfileTree() InstantProfileTree
 	ProfileMeta() InstantProfileMeta
+	Samples() []*Sample
 }
 
 type ProfileSeriesIterator interface {
@@ -154,6 +155,10 @@ func (p *Profile) ProfileTree() InstantProfileTree {
 
 func (p *Profile) ProfileMeta() InstantProfileMeta {
 	return p.Meta
+}
+
+func (p *Profile) Samples() []*Sample {
+	panic("won't be implemented - use FlatProfile instead")
 }
 
 type SliceProfileSeriesIterator struct {
@@ -242,6 +247,10 @@ func (p *ScaledInstantProfile) ProfileTree() InstantProfileTree {
 		tree:  p.p.ProfileTree(),
 		ratio: p.ratio,
 	}
+}
+
+func (p *ScaledInstantProfile) Samples() []*Sample {
+	return p.p.Samples()
 }
 
 type ScaledInstantProfileTree struct {

--- a/pkg/storage/merge.go
+++ b/pkg/storage/merge.go
@@ -291,6 +291,10 @@ func (m *MergeProfileTree) RootCumulativeValue() int64 {
 	return 0
 }
 
+func (m *MergeProfile) Samples() []*Sample {
+	panic("implement me")
+}
+
 func (m *MergeProfileTree) Iterator() InstantProfileTreeIterator {
 	return &MergeProfileTreeIterator{
 		a:      m.m.a.ProfileTree().Iterator(),

--- a/pkg/storage/profile_flat.go
+++ b/pkg/storage/profile_flat.go
@@ -1,0 +1,271 @@
+// Copyright 2021 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"context"
+
+	"github.com/go-kit/log"
+	"github.com/google/pprof/profile"
+	"github.com/google/uuid"
+	"github.com/parca-dev/parca/pkg/storage/metastore"
+)
+
+type MetaStore interface {
+	CreateFunction(ctx context.Context, f *metastore.Function) (uuid.UUID, error)
+	GetFunctionByKey(ctx context.Context, key metastore.FunctionKey) (*metastore.Function, error)
+
+	CreateLocation(ctx context.Context, l *metastore.Location) (uuid.UUID, error)
+	GetLocationByKey(ctx context.Context, k metastore.LocationKey) (*metastore.Location, error)
+
+	CreateMapping(ctx context.Context, m *metastore.Mapping) (uuid.UUID, error)
+	GetMappingByKey(ctx context.Context, key metastore.MappingKey) (*metastore.Mapping, error)
+}
+
+func FlatProfileFromPprof(ctx context.Context, logger log.Logger, metaStore MetaStore, p *profile.Profile, sampleIndex int) (*FlatProfile, error) {
+	pfn := &profileFlatNormalizer{
+		logger:    logger,
+		metaStore: metaStore,
+
+		samples:       make(map[stacktraceKey]*Sample, len(p.Sample)),
+		locationsByID: make(map[uint64]*metastore.Location, len(p.Location)),
+		functionsByID: make(map[uint64]*metastore.Function, len(p.Function)),
+		mappingsByID:  make(map[uint64]mapInfo, len(p.Mapping)),
+	}
+
+	samples := make([]*Sample, 0, len(p.Sample))
+	for _, s := range p.Sample {
+		if !isZeroSample(s) {
+			sa, isNew, err := pfn.mapSample(ctx, s, sampleIndex)
+			if err != nil {
+				return nil, err
+			}
+			if isNew {
+				samples = append(samples, sa)
+			}
+		}
+	}
+
+	return &FlatProfile{
+		Meta:    InstantProfileMeta{},
+		samples: samples,
+	}, nil
+}
+
+type profileFlatNormalizer struct {
+	logger    log.Logger
+	metaStore MetaStore
+
+	samples map[stacktraceKey]*Sample
+	// Memoization tables within a profile.
+	locationsByID map[uint64]*metastore.Location
+	functionsByID map[uint64]*metastore.Function
+	mappingsByID  map[uint64]mapInfo
+}
+
+func (pn *profileFlatNormalizer) mapSample(ctx context.Context, src *profile.Sample, sampleIndex int) (*Sample, bool, error) {
+	var err error
+
+	s := &Sample{
+		Location: make([]*metastore.Location, len(src.Location)),
+		Label:    make(map[string][]string, len(src.Label)),
+		NumLabel: make(map[string][]int64, len(src.NumLabel)),
+		NumUnit:  make(map[string][]string, len(src.NumLabel)),
+	}
+	for i, l := range src.Location {
+		s.Location[i], err = pn.mapLocation(ctx, l)
+		if err != nil {
+			return nil, false, err
+		}
+	}
+	for k, v := range src.Label {
+		vv := make([]string, len(v))
+		copy(vv, v)
+		s.Label[k] = vv
+	}
+	for k, v := range src.NumLabel {
+		u := src.NumUnit[k]
+		vv := make([]int64, len(v))
+		uu := make([]string, len(u))
+		copy(vv, v)
+		copy(uu, u)
+		s.NumLabel[k] = vv
+		s.NumUnit[k] = uu
+	}
+	// Check memoization table. Must be done on the remapped location to
+	// account for the remapped mapping. Add current values to the
+	// existing sample.
+	k := makeStacktraceKey(s)
+	sa, found := pn.samples[k]
+	if found {
+		sa.Value += src.Value[sampleIndex]
+		return sa, false, nil
+	}
+
+	s.Value += src.Value[sampleIndex]
+	pn.samples[k] = s
+	return s, true, nil
+}
+
+func (pn *profileFlatNormalizer) mapLocation(ctx context.Context, src *profile.Location) (*metastore.Location, error) {
+	var err error
+
+	if src == nil {
+		return nil, nil
+	}
+
+	if l, ok := pn.locationsByID[src.ID]; ok {
+		return l, nil
+	}
+
+	mi, err := pn.mapMapping(ctx, src.Mapping)
+	if err != nil {
+		return nil, err
+	}
+	l := &metastore.Location{
+		Mapping:  mi.m,
+		Address:  uint64(int64(src.Address) + mi.offset),
+		Lines:    make([]metastore.LocationLine, len(src.Line)),
+		IsFolded: src.IsFolded,
+	}
+	for i, ln := range src.Line {
+		l.Lines[i], err = pn.mapLine(ctx, ln)
+		if err != nil {
+			return nil, err
+		}
+	}
+	// Check memoization table. Must be done on the remapped location to
+	// account for the remapped mapping ID.
+	k := metastore.MakeLocationKey(l)
+	loc, err := pn.metaStore.GetLocationByKey(ctx, k)
+	if err != nil && err != metastore.ErrLocationNotFound {
+		return nil, err
+	}
+	if loc != nil {
+		pn.locationsByID[src.ID] = loc
+		return loc, nil
+	}
+	pn.locationsByID[src.ID] = l
+
+	id, err := pn.metaStore.CreateLocation(ctx, l)
+	if err != nil {
+		return nil, err
+	}
+
+	l.ID = id
+	return l, nil
+}
+
+func (pn *profileFlatNormalizer) mapMapping(ctx context.Context, src *profile.Mapping) (mapInfo, error) {
+	if src == nil {
+		return mapInfo{}, nil
+	}
+
+	if mi, ok := pn.mappingsByID[src.ID]; ok {
+		return mi, nil
+	}
+
+	// Check memoization tables.
+	mk := metastore.MakeMappingKey(&metastore.Mapping{
+		Start:   src.Start,
+		Limit:   src.Limit,
+		Offset:  src.Offset,
+		File:    src.File,
+		BuildID: src.BuildID,
+	})
+	m, err := pn.metaStore.GetMappingByKey(ctx, mk)
+	if err != nil && err != metastore.ErrMappingNotFound {
+		return mapInfo{}, err
+	}
+	if m != nil {
+		mi := mapInfo{m, int64(m.Start) - int64(src.Start)}
+		pn.mappingsByID[src.ID] = mi
+		return mi, nil
+	}
+	m = &metastore.Mapping{
+		Start:           src.Start,
+		Limit:           src.Limit,
+		Offset:          src.Offset,
+		File:            src.File,
+		BuildID:         src.BuildID,
+		HasFunctions:    src.HasFunctions,
+		HasFilenames:    src.HasFilenames,
+		HasLineNumbers:  src.HasLineNumbers,
+		HasInlineFrames: src.HasInlineFrames,
+	}
+
+	// Update memoization tables.
+	id, err := pn.metaStore.CreateMapping(ctx, m)
+	if err != nil {
+		return mapInfo{}, err
+	}
+	m.ID = id
+	mi := mapInfo{m, 0}
+	pn.mappingsByID[src.ID] = mi
+	return mi, nil
+}
+
+func (pn *profileFlatNormalizer) mapLine(ctx context.Context, src profile.Line) (metastore.LocationLine, error) {
+	f, err := pn.mapFunction(ctx, src.Function)
+	if err != nil {
+		return metastore.LocationLine{}, err
+	}
+
+	return metastore.LocationLine{
+		Function: f,
+		Line:     src.Line,
+	}, nil
+}
+
+func (pn *profileFlatNormalizer) mapFunction(ctx context.Context, src *profile.Function) (*metastore.Function, error) {
+	if src == nil {
+		return nil, nil
+	}
+	if f, ok := pn.functionsByID[src.ID]; ok {
+		return f, nil
+	}
+	k := metastore.MakeFunctionKey(&metastore.Function{
+		FunctionKey: metastore.FunctionKey{
+			Name:       src.Name,
+			SystemName: src.SystemName,
+			Filename:   src.Filename,
+			StartLine:  src.StartLine,
+		},
+	})
+	f, err := pn.metaStore.GetFunctionByKey(ctx, k)
+	if err != nil && err != metastore.ErrFunctionNotFound {
+		return nil, err
+	}
+	if f != nil {
+		pn.functionsByID[src.ID] = f
+		return f, nil
+	}
+	f = &metastore.Function{
+		FunctionKey: metastore.FunctionKey{
+			Name:       src.Name,
+			SystemName: src.SystemName,
+			Filename:   src.Filename,
+			StartLine:  src.StartLine,
+		},
+	}
+
+	id, err := pn.metaStore.CreateFunction(ctx, f)
+	if err != nil {
+		return nil, err
+	}
+	f.ID = id
+
+	pn.functionsByID[src.ID] = f
+	return f, nil
+}

--- a/pkg/storage/profile_flat.go
+++ b/pkg/storage/profile_flat.go
@@ -76,7 +76,7 @@ func FlatProfileFromPprof(ctx context.Context, logger log.Logger, metaStore Meta
 	// More over, the map's key should be the stacktrace's unique UUID as mapped by the metastore.
 
 	return &FlatProfile{
-		Meta:    InstantProfileMeta{},
+		Meta:    ProfileMetaFromPprof(p, sampleIndex),
 		samples: samples,
 	}, nil
 }

--- a/pkg/storage/profile_flat_test.go
+++ b/pkg/storage/profile_flat_test.go
@@ -1,0 +1,50 @@
+// Copyright 2021 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/google/pprof/profile"
+	"github.com/parca-dev/parca/pkg/storage/metastore"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestProfileFlatNormalizer(t *testing.T) {
+	f, err := os.Open("testdata/profile1.pb.gz")
+	require.NoError(t, err)
+	p1, err := profile.Parse(f)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	l, err := metastore.NewInMemorySQLiteProfileMetaStore(
+		prometheus.NewRegistry(),
+		trace.NewNoopTracerProvider().Tracer(""),
+		"copyinstantprofiletree",
+	)
+	t.Cleanup(func() {
+		l.Close()
+	})
+	require.NoError(t, err)
+
+	p, err := FlatProfileFromPprof(context.Background(), log.NewNopLogger(), l, p1, 0)
+	require.NoError(t, err)
+	fmt.Printf("%+v\n", p)
+}

--- a/pkg/storage/profile_flat_test.go
+++ b/pkg/storage/profile_flat_test.go
@@ -15,9 +15,9 @@ package storage
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/google/pprof/profile"
@@ -46,5 +46,14 @@ func TestProfileFlatNormalizer(t *testing.T) {
 
 	p, err := FlatProfileFromPprof(context.Background(), log.NewNopLogger(), l, p1, 0)
 	require.NoError(t, err)
-	fmt.Printf("%+v\n", p)
+
+	require.Equal(t, InstantProfileMeta{
+		PeriodType: ValueType{Type: "cpu", Unit: "nanoseconds"},
+		SampleType: ValueType{Type: "samples", Unit: "count"},
+		Timestamp:  1626013307085,
+		Duration:   30000181568,
+		Period:     10 * time.Millisecond.Nanoseconds(),
+	}, p.ProfileMeta())
+
+	require.Len(t, p.Samples(), 32)
 }

--- a/pkg/storage/querier_bench_test.go
+++ b/pkg/storage/querier_bench_test.go
@@ -52,7 +52,7 @@ func BenchmarkHeadQuerier_Select(b *testing.B) {
 
 	for s := 1; s <= numSeries; s *= 10 {
 		b.Run(fmt.Sprintf("%dof%d", s, numSeries), func(b *testing.B) {
-			q := h.Querier(ctx, 0, int64(s))
+			q := h.Querier(ctx, 0, int64(s), false)
 
 			b.ReportAllocs()
 			b.ResetTimer()

--- a/pkg/storage/series.go
+++ b/pkg/storage/series.go
@@ -374,9 +374,9 @@ func (a *MemSeriesAppender) AppendFlat(ctx context.Context, p *FlatProfile) erro
 		}
 		a.root = rootApp
 
-		for k := range a.s.flatValues {
-			for len(a.s.flatValues[k]) < len(a.s.timestamps) {
-				a.s.flatValues[k] = append(a.s.flatValues[k], a.s.chunkPool.GetXOR())
+		for k, _ := range a.s.samples {
+			for len(a.s.samples[k]) < len(a.s.timestamps) {
+				a.s.samples[k] = append(a.s.samples[k], a.s.chunkPool.GetXOR())
 			}
 		}
 

--- a/pkg/storage/series.go
+++ b/pkg/storage/series.go
@@ -374,7 +374,7 @@ func (a *MemSeriesAppender) AppendFlat(ctx context.Context, p *FlatProfile) erro
 		}
 		a.root = rootApp
 
-		for k, _ := range a.s.samples {
+		for k := range a.s.samples {
 			for len(a.s.samples[k]) < len(a.s.timestamps) {
 				a.s.samples[k] = append(a.s.samples[k], a.s.chunkPool.GetXOR())
 			}

--- a/pkg/storage/series.go
+++ b/pkg/storage/series.go
@@ -45,13 +45,17 @@ type MemSeries struct {
 
 	// mu locks the following maps for concurrent access.
 	mu sync.RWMutex
+
+	samples map[stacktraceKey][]chunkenc.Chunk
+
+	// TODO: part of profileTree - eventually remove it
 	// Flat values as well as labels by the node's ProfileTreeValueNodeKey.
 	flatValues map[ProfileTreeValueNodeKey][]chunkenc.Chunk
 	labels     map[ProfileTreeValueNodeKey]map[string][]string
 	numLabels  map[ProfileTreeValueNodeKey]map[string][]int64
 	numUnits   map[ProfileTreeValueNodeKey]map[string][]string
-
 	seriesTree *MemSeriesTree
+
 	numSamples uint16
 
 	updateMaxTime func(int64)
@@ -73,6 +77,10 @@ func NewMemSeries(id uint64, lset labels.Labels, updateMaxTime func(int64), chun
 		durations:  make([]chunkenc.Chunk, 0, 1),
 		periods:    make([]chunkenc.Chunk, 0, 1),
 		root:       make([]chunkenc.Chunk, 0, 1),
+
+		samples: make(map[stacktraceKey][]chunkenc.Chunk),
+
+		// TODO: part of profileTree - eventually remove it
 		flatValues: make(map[ProfileTreeValueNodeKey][]chunkenc.Chunk),
 		labels:     make(map[ProfileTreeValueNodeKey]map[string][]string),
 		numLabels:  make(map[ProfileTreeValueNodeKey]map[string][]int64),
@@ -151,7 +159,7 @@ type MemSeriesAppender struct {
 const samplesPerChunk = 120
 
 func (a *MemSeriesAppender) Append(ctx context.Context, p *Profile) error {
-	ctx, span := a.s.tracer.Start(ctx, "Append")
+	ctx, span := a.s.tracer.Start(ctx, "AppendTree")
 	defer span.End()
 
 	a.s.mu.Lock()
@@ -282,6 +290,161 @@ func (a *MemSeriesAppender) Append(ctx context.Context, p *Profile) error {
 		return err
 	}
 	appendTreeSpan.End()
+
+	a.s.storeMaxTime(timestamp)
+
+	a.s.numSamples++
+
+	if a.s.samplesAppended != nil {
+		a.s.samplesAppended.Inc()
+	}
+	return nil
+}
+
+func (a *MemSeriesAppender) AppendFlat(ctx context.Context, p *FlatProfile) error {
+	ctx, span := a.s.tracer.Start(ctx, "AppendFlat")
+	defer span.End()
+
+	a.s.mu.Lock()
+	defer a.s.mu.Unlock()
+
+	if a.s.numSamples == 0 {
+		a.s.periodType = p.Meta.PeriodType
+		a.s.sampleType = p.Meta.SampleType
+	}
+
+	if !equalValueType(a.s.periodType, p.Meta.PeriodType) {
+		return ErrPeriodTypeMismatch
+	}
+
+	if !equalValueType(a.s.sampleType, p.Meta.SampleType) {
+		return ErrSampleTypeMismatch
+	}
+
+	timestamp := p.Meta.Timestamp
+
+	if timestamp <= a.s.maxTime {
+		return ErrOutOfOrderSample
+	}
+
+	newChunks := false
+	if len(a.s.timestamps) == 0 {
+		newChunks = true
+	} else if a.s.timestamps[len(a.s.timestamps)-1].chunk.NumSamples() == 0 {
+		newChunks = true
+	} else if a.s.timestamps[len(a.s.timestamps)-1].chunk.NumSamples() >= samplesPerChunk {
+		newChunks = true
+	}
+
+	if newChunks {
+		_, newChunksSpan := a.s.tracer.Start(ctx, "newChunks")
+		defer newChunksSpan.End()
+
+		tc := a.s.chunkPool.GetTimestamp()
+		tc.minTime = timestamp
+		tc.maxTime = timestamp
+		a.s.timestamps = append(a.s.timestamps, tc)
+		timeApp, err := a.s.timestamps[len(a.s.timestamps)-1].chunk.Appender()
+		if err != nil {
+			return fmt.Errorf("failed to add the next timestamp chunk: %w", err)
+		}
+		a.timestamps = timeApp
+
+		a.s.durations = append(a.s.durations, a.s.chunkPool.GetRLE())
+		durationApp, err := a.s.durations[len(a.s.durations)-1].Appender()
+		if err != nil {
+			return fmt.Errorf("failed to add the next durations chunk: %w", err)
+		}
+		a.duration = durationApp
+
+		a.s.periods = append(a.s.periods, a.s.chunkPool.GetRLE())
+		periodsApp, err := a.s.periods[len(a.s.periods)-1].Appender()
+		if err != nil {
+			return fmt.Errorf("failed to add the next periods chunk: %w", err)
+		}
+		a.periods = periodsApp
+
+		a.s.root = append(a.s.root, a.s.chunkPool.GetXOR())
+		rootApp, err := a.s.root[len(a.s.root)-1].Appender()
+		if err != nil {
+			return fmt.Errorf("failed to add the next root chunk: %w", err)
+		}
+		a.root = rootApp
+
+		for k := range a.s.flatValues {
+			for len(a.s.flatValues[k]) < len(a.s.timestamps) {
+				a.s.flatValues[k] = append(a.s.flatValues[k], a.s.chunkPool.GetXOR())
+			}
+		}
+
+		newChunksSpan.End()
+	}
+
+	if a.timestamps == nil {
+		app, err := a.s.timestamps[len(a.s.timestamps)-1].chunk.Appender()
+		if err != nil {
+			return fmt.Errorf("failed to add the next timestamp chunk: %w", err)
+		}
+		a.timestamps = app
+	}
+	if a.duration == nil {
+		app, err := a.s.durations[len(a.s.durations)-1].Appender()
+		if err != nil {
+			return fmt.Errorf("failed to add the next duration chunk: %w", err)
+		}
+		a.duration = app
+	}
+	if a.periods == nil {
+		app, err := a.s.periods[len(a.s.periods)-1].Appender()
+		if err != nil {
+			return fmt.Errorf("failed to add the next periods chunk: %w", err)
+		}
+		a.periods = app
+	}
+	if a.root == nil {
+		app, err := a.s.root[len(a.s.root)-1].Appender()
+		if err != nil {
+			return fmt.Errorf("failed to add the next root chunk: %w", err)
+		}
+		a.root = app
+	}
+
+	a.timestamps.AppendAt(a.s.numSamples%samplesPerChunk, timestamp)
+	a.duration.AppendAt(a.s.numSamples%samplesPerChunk, p.Meta.Duration)
+	a.periods.AppendAt(a.s.numSamples%samplesPerChunk, p.Meta.Period)
+
+	// TODO: Figure out how to get the root sample and then append it's value
+	// Additionally, we might not even need this extra chunk anymore
+	//a.root.AppendAt(a.s.numSamples%samplesPerChunk, p.ProfileTree().RootCumulativeValue())
+
+	if a.s.timestamps[len(a.s.timestamps)-1].minTime > timestamp {
+		a.s.timestamps[len(a.s.timestamps)-1].minTime = timestamp
+	}
+	if a.s.timestamps[len(a.s.timestamps)-1].maxTime < timestamp {
+		a.s.timestamps[len(a.s.timestamps)-1].maxTime = timestamp
+	}
+
+	// Set the timestamp as minTime if timestamp != 0
+	if a.s.minTime == math.MaxInt64 && timestamp != 0 {
+		a.s.minTime = timestamp
+	}
+
+	for _, s := range p.Samples() {
+		k := makeStacktraceKey(s)
+
+		if len(a.s.samples[k]) == 0 {
+			a.s.samples[k] = make([]chunkenc.Chunk, len(a.s.timestamps))
+			for i := 0; i < len(a.s.timestamps); i++ {
+				a.s.samples[k][i] = a.s.chunkPool.GetXOR()
+			}
+		}
+
+		app, err := a.s.samples[k][len(a.s.samples[k])-1].Appender()
+		if err != nil {
+			return fmt.Errorf("failed to open flat sample appender: %w", err)
+		}
+		app.AppendAt(a.s.numSamples%samplesPerChunk, s.Value)
+	}
 
 	a.s.storeMaxTime(timestamp)
 

--- a/pkg/storage/series_iterator_merge_test.go
+++ b/pkg/storage/series_iterator_merge_test.go
@@ -71,6 +71,7 @@ func TestMergeMemSeriesConsistency(t *testing.T) {
 		ctx,
 		int64(0),
 		int64(n),
+		true,
 	).Select(nil, &labels.Matcher{
 		Type:  labels.MatchEqual,
 		Name:  "__name__",
@@ -84,6 +85,7 @@ func TestMergeMemSeriesConsistency(t *testing.T) {
 		ctx,
 		int64(0),
 		int64(n),
+		true,
 	).Select(&SelectHints{
 		Start: int64(0),
 		End:   int64(n),

--- a/pkg/storage/series_iterator_range_test.go
+++ b/pkg/storage/series_iterator_range_test.go
@@ -47,7 +47,7 @@ func TestMemRangeSeries_Iterator(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	it := (&MemRangeSeries{s: s, mint: 74, maxt: 420}).Iterator()
+	it := (&MemRangeSeries{s: s, mint: 74, maxt: 420, trees: true}).Iterator()
 
 	seen := int64(75)
 	for it.Next() {

--- a/pkg/storage/series_iterator_root_test.go
+++ b/pkg/storage/series_iterator_root_test.go
@@ -50,7 +50,7 @@ func TestMemRootSeries_Iterator(t *testing.T) {
 
 	// Query subset of timestamps
 	{
-		it := (&MemRootSeries{s: s, mint: 74, maxt: 420}).Iterator()
+		it := (&MemRootSeries{s: s, mint: 74, maxt: 420, trees: true}).Iterator()
 
 		seen := int64(75)
 		for it.Next() {

--- a/pkg/symbolizer/symbolizer_test.go
+++ b/pkg/symbolizer/symbolizer_test.go
@@ -445,6 +445,7 @@ func setup(t *testing.T) (*grpc.ClientConn, *debuginfo.Store, TestProfileMetaSto
 		trace.NewNoopTracerProvider().Tracer(""),
 		db,
 		mStr,
+		true,
 	)
 
 	lis, err := net.Listen("tcp", ":0")


### PR DESCRIPTION
Implement querying the new, more simple, `[]*Sample` from the QueryRange and Query.singleProfile handlers.

For now, we pass a `profileTrees` bool into some structs to decide whether or not to use the new storage or old storage way of representing trees. Eventually, we'll clean it up by removing the profileTree entirely.