### PR TITLE
pkg/storage: Make stacktraceKey []byte and use inlined map[string]

### DIFF
--- a/pkg/storage/benchmark/db-appends.txt
+++ b/pkg/storage/benchmark/db-appends.txt
@@ -2,20 +2,20 @@ goos: linux
 goarch: amd64
 pkg: github.com/parca-dev/parca/pkg/storage
 cpu: AMD Ryzen 9 3900X 12-Core Processor            
-BenchmarkAppends-24    	    2500	  16743501 ns/op	 9839116 B/op	  139925 allocs/op
+BenchmarkAppends-24    	    2500	  23191754 ns/op	11810337 B/op	  148637 allocs/op
 PASS
-ok  	github.com/parca-dev/parca/pkg/storage	55.886s
+ok  	github.com/parca-dev/parca/pkg/storage	72.441s
 goos: linux
 goarch: amd64
 pkg: github.com/parca-dev/parca/pkg/storage
 cpu: AMD Ryzen 9 3900X 12-Core Processor            
-BenchmarkAppends-24    	    2500	  16699756 ns/op	 9839168 B/op	  139926 allocs/op
+BenchmarkAppends-24    	    2500	  23070674 ns/op	11810247 B/op	  148637 allocs/op
 PASS
-ok  	github.com/parca-dev/parca/pkg/storage	55.735s
+ok  	github.com/parca-dev/parca/pkg/storage	72.493s
 goos: linux
 goarch: amd64
 pkg: github.com/parca-dev/parca/pkg/storage
 cpu: AMD Ryzen 9 3900X 12-Core Processor            
-BenchmarkAppends-24    	    2500	  16895825 ns/op	 9839081 B/op	  139925 allocs/op
+BenchmarkAppends-24    	    2500	  23371644 ns/op	11810516 B/op	  148638 allocs/op
 PASS
-ok  	github.com/parca-dev/parca/pkg/storage	56.375s
+ok  	github.com/parca-dev/parca/pkg/storage	72.910s

--- a/pkg/storage/benchmark/db-iterator.txt
+++ b/pkg/storage/benchmark/db-iterator.txt
@@ -2,20 +2,20 @@ goos: linux
 goarch: amd64
 pkg: github.com/parca-dev/parca/pkg/storage
 cpu: AMD Ryzen 9 3900X 12-Core Processor            
-BenchmarkIterator-24    	    2500	     62069 ns/op	     550 B/op	       3 allocs/op
+BenchmarkIterator-24    	    2500	     59297 ns/op	     489 B/op	       3 allocs/op
 PASS
-ok  	github.com/parca-dev/parca/pkg/storage	56.039s
+ok  	github.com/parca-dev/parca/pkg/storage	72.061s
 goos: linux
 goarch: amd64
 pkg: github.com/parca-dev/parca/pkg/storage
 cpu: AMD Ryzen 9 3900X 12-Core Processor            
-BenchmarkIterator-24    	    2500	     62161 ns/op	     550 B/op	       3 allocs/op
+BenchmarkIterator-24    	    2500	     60580 ns/op	     490 B/op	       3 allocs/op
 PASS
-ok  	github.com/parca-dev/parca/pkg/storage	57.280s
+ok  	github.com/parca-dev/parca/pkg/storage	72.811s
 goos: linux
 goarch: amd64
 pkg: github.com/parca-dev/parca/pkg/storage
 cpu: AMD Ryzen 9 3900X 12-Core Processor            
-BenchmarkIterator-24    	    2500	     61522 ns/op	     553 B/op	       3 allocs/op
+BenchmarkIterator-24    	    2500	     59989 ns/op	     490 B/op	       3 allocs/op
 PASS
-ok  	github.com/parca-dev/parca/pkg/storage	56.073s
+ok  	github.com/parca-dev/parca/pkg/storage	71.408s

--- a/pkg/storage/metastore/badger.go
+++ b/pkg/storage/metastore/badger.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"fmt"
 
-	badger "github.com/dgraph-io/badger/v3"
+	"github.com/dgraph-io/badger/v3"
 	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/trace"
@@ -62,7 +62,11 @@ func NewBadgerMetastore(
 	tracer trace.Tracer,
 	uuidGenerator UUIDGenerator,
 ) *BadgerMetastore {
-	db, err := badger.Open(badger.DefaultOptions("").WithInMemory(true))
+	db, err := badger.Open(
+		badger.DefaultOptions("").
+			WithInMemory(true).
+			WithLoggingLevel(badger.ERROR),
+	)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/storage/profile_flat.go
+++ b/pkg/storage/profile_flat.go
@@ -40,7 +40,7 @@ func FlatProfileFromPprof(ctx context.Context, logger log.Logger, metaStore meta
 		logger:    logger,
 		metaStore: metaStore,
 
-		samples:       make(map[stacktraceKey]*Sample, len(p.Sample)),
+		samples:       make(map[string]*Sample, len(p.Sample)),
 		locationsByID: make(map[uint64]*metastore.Location, len(p.Location)),
 		functionsByID: make(map[uint64]*metastore.Function, len(p.Function)),
 		mappingsByID:  make(map[uint64]mapInfo, len(p.Mapping)),
@@ -73,7 +73,7 @@ type profileFlatNormalizer struct {
 	logger    log.Logger
 	metaStore metastore.ProfileMetaStore
 
-	samples map[stacktraceKey]*Sample
+	samples map[string]*Sample
 	// Memoization tables within a profile.
 	locationsByID map[uint64]*metastore.Location
 	functionsByID map[uint64]*metastore.Function
@@ -113,14 +113,14 @@ func (pn *profileFlatNormalizer) mapSample(ctx context.Context, src *profile.Sam
 	// account for the remapped mapping. Add current values to the
 	// existing sample.
 	k := makeStacktraceKey(s)
-	sa, found := pn.samples[k]
+	sa, found := pn.samples[string(k)]
 	if found {
 		sa.Value += src.Value[sampleIndex]
 		return sa, false, nil
 	}
 
 	s.Value += src.Value[sampleIndex]
-	pn.samples[k] = s
+	pn.samples[string(k)] = s
 	return s, true, nil
 }
 

--- a/pkg/storage/profile_normalizer.go
+++ b/pkg/storage/profile_normalizer.go
@@ -278,3 +278,103 @@ func makeStacktraceKey(sample *Sample) stacktraceKey {
 		numlabels: strings.Join(numlabels, ""),
 	}
 }
+
+type stacktraceKeyBytes []byte
+
+// key generates stacktraceKeyBytes to be used as a key for maps.
+func makeStacktraceKeyBytes(sample *Sample) stacktraceKeyBytes {
+	numLocations := len(sample.Location)
+	locationLength := (16 * numLocations) + (numLocations - 1)
+
+	labelsLength := 0
+	labelName := make([]string, 0, len(sample.Label))
+	for l, vs := range sample.Label {
+		labelName = append(labelName, l)
+
+		labelsLength += len(l) + 2 // +2 for the quotes
+		for _, v := range vs {
+			labelsLength += len(v) + 2 // +2 for the quotes
+		}
+		labelsLength += len(vs) - 1 // spaces
+		labelsLength += 2           // square brackets
+	}
+	sort.Strings(labelName)
+
+	numLabelsLength := 0
+	numLabelNames := make([]string, 0, len(sample.NumLabel))
+	for l, int64s := range sample.NumLabel {
+		numLabelNames = append(numLabelNames, l)
+
+		numLabelsLength += len(l) + 2      // +2 for the quotes
+		numLabelsLength += 2               // square brackets
+		numLabelsLength += 8 * len(int64s) // 8*8=64bit
+
+		for _, i := range int64s {
+			numLabelsLength += len(sample.NumUnit[l][i]) + 2 // numUnit string +2 for quotes
+		}
+		numLabelsLength += 2               // square brackets
+		numLabelsLength += len(int64s) - 1 // spaces
+	}
+	sort.Strings(numLabelNames)
+
+	length := locationLength + labelsLength + numLabelsLength
+	key := make([]byte, 0, length)
+
+	for i, l := range sample.Location {
+		key = append(key, l.ID[:]...)
+		if i != len(sample.Location)-1 {
+			key = append(key, '|')
+		}
+	}
+
+	for i := 0; i < len(sample.Label); i++ {
+		l := labelName[i]
+		vs := sample.Label[l]
+		key = append(key, '"')
+		key = append(key, l...)
+		key = append(key, '"')
+
+		key = append(key, '[')
+		for i, v := range vs {
+			key = append(key, '"')
+			key = append(key, v...)
+			key = append(key, '"')
+			if i != len(vs)-1 {
+				key = append(key, ' ')
+			}
+		}
+		key = append(key, ']')
+	}
+
+	for i := 0; i < len(sample.NumLabel); i++ {
+		l := numLabelNames[i]
+		int64s := sample.NumLabel[l]
+
+		key = append(key, '"')
+		key = append(key, l...)
+		key = append(key, '"')
+
+		key = append(key, '[')
+		for _, v := range int64s {
+			// Writing int64 to pre-allocated key by shifting per byte
+			for shift := 56; shift >= 0; shift -= 8 {
+				key = append(key, byte(v>>shift))
+			}
+		}
+		key = append(key, ']')
+
+		key = append(key, '[')
+		for index, i := range int64s {
+			s := sample.NumUnit[l][i]
+			key = append(key, '"')
+			key = append(key, s...)
+			key = append(key, '"')
+			if index != len(int64s)-1 {
+				key = append(key, ' ')
+			}
+		}
+		key = append(key, ']')
+	}
+
+	return key
+}

--- a/pkg/storage/profile_normalizer.go
+++ b/pkg/storage/profile_normalizer.go
@@ -15,9 +15,7 @@ package storage
 
 import (
 	"context"
-	"fmt"
 	"sort"
-	"strings"
 
 	"github.com/go-kit/log"
 	"github.com/google/pprof/profile"
@@ -247,42 +245,10 @@ func (pn *profileNormalizer) mapFunction(ctx context.Context, src *profile.Funct
 	return f, nil
 }
 
-type stacktraceKey struct {
-	locations string
-	labels    string
-	numlabels string
-}
+type stacktraceKey []byte
 
 // key generates stacktraceKey to be used as a key for maps.
 func makeStacktraceKey(sample *Sample) stacktraceKey {
-	ids := make([]string, len(sample.Location))
-	for i, l := range sample.Location {
-		ids[i] = l.ID.String()
-	}
-
-	labels := make([]string, 0, len(sample.Label))
-	for k, v := range sample.Label {
-		labels = append(labels, fmt.Sprintf("%q%q", k, v))
-	}
-	sort.Strings(labels)
-
-	numlabels := make([]string, 0, len(sample.NumLabel))
-	for k, v := range sample.NumLabel {
-		numlabels = append(numlabels, fmt.Sprintf("%q%x%x", k, v, sample.NumUnit[k]))
-	}
-	sort.Strings(numlabels)
-
-	return stacktraceKey{
-		locations: strings.Join(ids, "|"),
-		labels:    strings.Join(labels, ""),
-		numlabels: strings.Join(numlabels, ""),
-	}
-}
-
-type stacktraceKeyBytes []byte
-
-// key generates stacktraceKeyBytes to be used as a key for maps.
-func makeStacktraceKeyBytes(sample *Sample) stacktraceKeyBytes {
 	numLocations := len(sample.Location)
 	locationLength := (16 * numLocations) + (numLocations - 1)
 

--- a/pkg/storage/profile_normalizer_test.go
+++ b/pkg/storage/profile_normalizer_test.go
@@ -1,3 +1,16 @@
+// Copyright 2021 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package storage
 
 import (

--- a/pkg/storage/profile_normalizer_test.go
+++ b/pkg/storage/profile_normalizer_test.go
@@ -17,7 +17,7 @@ func TestMakeStacktraceKey(t *testing.T) {
 		NumUnit:  map[string][]string{"foo": {"cpu", "memory"}},
 	}
 
-	k := []byte(makeStacktraceKeyBytes(s))
+	k := []byte(makeStacktraceKey(s))
 
 	require.Len(t, k, 119)
 
@@ -63,6 +63,6 @@ func BenchmarkMakeStacktraceKey(b *testing.B) {
 	b.StartTimer()
 
 	for i := 0; i < b.N; i++ {
-		_ = makeStacktraceKeyBytes(s)
+		_ = makeStacktraceKey(s)
 	}
 }

--- a/pkg/storage/profile_normalizer_test.go
+++ b/pkg/storage/profile_normalizer_test.go
@@ -1,0 +1,68 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/parca-dev/parca/pkg/storage/metastore"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMakeStacktraceKey(t *testing.T) {
+	g := NewLinearUUIDGenerator()
+
+	s := &Sample{
+		Location: []*metastore.Location{{ID: g.New()}, {ID: g.New()}, {ID: g.New()}},
+		Label:    map[string][]string{"foo": {"bar", "baz"}, "bar": {"baz"}},
+		NumLabel: map[string][]int64{"foo": {0, 1}},
+		NumUnit:  map[string][]string{"foo": {"cpu", "memory"}},
+	}
+
+	k := []byte(makeStacktraceKeyBytes(s))
+
+	require.Len(t, k, 119)
+
+	require.Equal(t,
+		[]byte{
+			0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
+			'|',
+			0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2,
+			'|',
+			0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x3,
+		},
+		k[0:50],
+	)
+
+	require.Equal(t,
+		[]byte(`"bar"["baz"]"foo"["bar" "baz"]`),
+		k[50:80],
+	)
+
+	require.Equal(t,
+		[]byte{
+			'"', 'f', 'o', 'o', '"',
+			'[',
+			0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 1,
+			']',
+			'[', '"', 'c', 'p', 'u', '"', ' ', '"', 'm', 'e', 'm', 'o', 'r', 'y', '"', ']',
+		},
+		k[80:],
+	)
+}
+
+func BenchmarkMakeStacktraceKey(b *testing.B) {
+	g := NewLinearUUIDGenerator()
+	s := &Sample{
+		Location: []*metastore.Location{{ID: g.New()}, {ID: g.New()}, {ID: g.New()}},
+		Label:    map[string][]string{"foo": {"bar", "baz"}},
+		NumLabel: map[string][]int64{"foo": {0, 1}},
+		NumUnit:  map[string][]string{"foo": {"cpu", "memory"}},
+	}
+
+	b.ReportAllocs()
+	b.StartTimer()
+
+	for i := 0; i < b.N; i++ {
+		_ = makeStacktraceKeyBytes(s)
+	}
+}

--- a/pkg/storage/profile_tree.go
+++ b/pkg/storage/profile_tree.go
@@ -43,7 +43,7 @@ func ProfileTreeFromPprof(ctx context.Context, l log.Logger, s metastore.Profile
 		logger:    l,
 		metaStore: s,
 
-		samples: make(map[stacktraceKey]*Sample, len(p.Sample)),
+		samples: make(map[string]*Sample, len(p.Sample)),
 
 		// Profile-specific hash tables for each profile inserted.
 		locationsByID: make(map[uint64]*metastore.Location, len(p.Location)),

--- a/pkg/storage/series_iterator.go
+++ b/pkg/storage/series_iterator.go
@@ -376,8 +376,8 @@ type MemSeriesInstantFlatProfile struct {
 	durationsIterator  MemSeriesValuesIterator
 	periodsIterator    MemSeriesValuesIterator
 
-	sampleIterators map[stacktraceKey]MemSeriesValuesIterator
-	locations       map[stacktraceKey][]*metastore.Location
+	sampleIterators map[string]MemSeriesValuesIterator
+	locations       map[string][]*metastore.Location
 }
 
 func (m MemSeriesInstantFlatProfile) ProfileMeta() InstantProfileMeta {

--- a/pkg/storage/series_iterator_range.go
+++ b/pkg/storage/series_iterator_range.go
@@ -60,7 +60,7 @@ func (rs *MemRangeSeries) Iterator() ProfileSeriesIterator {
 		rootIt.Seek(start)
 	}
 
-	var sampleIterators map[stacktraceKey]MemSeriesValuesIterator
+	var sampleIterators map[string]MemSeriesValuesIterator
 
 	root := &MemSeriesIteratorTreeNode{}
 	if rs.trees {
@@ -109,9 +109,9 @@ func (rs *MemRangeSeries) Iterator() ProfileSeriesIterator {
 			memItStack.Pop()
 		}
 	} else {
-		sampleIterators = make(map[stacktraceKey]MemSeriesValuesIterator, len(rs.s.samples))
+		sampleIterators = make(map[string]MemSeriesValuesIterator, len(rs.s.samples))
 		for key, chunks := range rs.s.samples {
-			sampleIterators[key] = NewMultiChunkIterator(chunks)
+			sampleIterators[string(key)] = NewMultiChunkIterator(chunks)
 		}
 	}
 
@@ -159,13 +159,13 @@ type MemRangeSeriesIterator struct {
 	durationsIterator  MemSeriesValuesIterator
 	periodsIterator    MemSeriesValuesIterator
 
-	sampleIterators map[stacktraceKey]MemSeriesValuesIterator
+	sampleIterators map[string]MemSeriesValuesIterator
 
 	numSamples uint64 // uint16 might not be enough for many chunks (~500+)
 	err        error
 
 	trees     bool
-	locations map[stacktraceKey][]*metastore.Location
+	locations map[string][]*metastore.Location
 }
 
 func (it *MemRangeSeriesIterator) Next() bool {

--- a/pkg/storage/series_test.go
+++ b/pkg/storage/series_test.go
@@ -70,8 +70,8 @@ func TestMemSeries(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, s.samples, 2)
-	require.Equal(t, chunkenc.FromValuesXOR(1), s.samples[k11][0])
-	require.Equal(t, chunkenc.FromValuesXOR(2), s.samples[k12][0])
+	require.Equal(t, chunkenc.FromValuesXOR(1), s.samples[string(k11)][0])
+	require.Equal(t, chunkenc.FromValuesXOR(2), s.samples[string(k12)][0])
 
 	s2 := makeSample(3, []uuid.UUID{uuid2, uuid1})
 	fp2 := &FlatProfile{
@@ -89,8 +89,8 @@ func TestMemSeries(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, s.samples, 2)
-	require.Equal(t, chunkenc.FromValuesXOR(1, 3), s.samples[k11][0])
-	require.Equal(t, chunkenc.FromValuesXOR(2), s.samples[k12][0]) // sparse - nothing added
+	require.Equal(t, chunkenc.FromValuesXOR(1, 3), s.samples[string(k11)][0])
+	require.Equal(t, chunkenc.FromValuesXOR(2), s.samples[string(k12)][0]) // sparse - nothing added
 
 	// Add another sample with one new Location
 	s3 := makeSample(4, []uuid.UUID{uuid3, uuid1})
@@ -111,9 +111,9 @@ func TestMemSeries(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, s.samples, 3)
-	require.Equal(t, chunkenc.FromValuesXOR(1, 3), s.samples[k11][0]) // sparse - nothing added
-	require.Equal(t, chunkenc.FromValuesXOR(2), s.samples[k12][0])    // sparse - nothing added
-	require.Equal(t, chunkenc.FromValuesXORAt(2, 4), s.samples[k3][0])
+	require.Equal(t, chunkenc.FromValuesXOR(1, 3), s.samples[string(k11)][0]) // sparse - nothing added
+	require.Equal(t, chunkenc.FromValuesXOR(2), s.samples[string(k12)][0])    // sparse - nothing added
+	require.Equal(t, chunkenc.FromValuesXORAt(2, 4), s.samples[string(k3)][0])
 
 	// Merging another profileTree onto the existing one with one new Location
 	s4 := makeSample(6, []uuid.UUID{uuid5, uuid2, uuid1})
@@ -133,10 +133,10 @@ func TestMemSeries(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, s.samples, 4)
-	require.Equal(t, chunkenc.FromValuesXOR(1, 3), s.samples[k11][0])  // sparse - nothing added
-	require.Equal(t, chunkenc.FromValuesXOR(2), s.samples[k12][0])     // sparse - nothing added
-	require.Equal(t, chunkenc.FromValuesXORAt(2, 4), s.samples[k3][0]) // sparse - nothing added
-	require.Equal(t, chunkenc.FromValuesXORAt(3, 6), s.samples[k4][0])
+	require.Equal(t, chunkenc.FromValuesXOR(1, 3), s.samples[string(k11)][0])  // sparse - nothing added
+	require.Equal(t, chunkenc.FromValuesXOR(2), s.samples[string(k12)][0])     // sparse - nothing added
+	require.Equal(t, chunkenc.FromValuesXORAt(2, 4), s.samples[string(k3)][0]) // sparse - nothing added
+	require.Equal(t, chunkenc.FromValuesXORAt(3, 6), s.samples[string(k4)][0])
 
 	// Merging another profileTree onto the existing one with one new Location
 	s5 := makeSample(7, []uuid.UUID{uuid2, uuid1})
@@ -154,10 +154,10 @@ func TestMemSeries(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, s.samples, 4)
-	require.Equal(t, chunkenc.FromValuesXOR(1, 3, 0, 0, 7), s.samples[k11][0])
-	require.Equal(t, chunkenc.FromValuesXOR(2), s.samples[k12][0])     // sparse - nothing added
-	require.Equal(t, chunkenc.FromValuesXORAt(2, 4), s.samples[k3][0]) // sparse - nothing added
-	require.Equal(t, chunkenc.FromValuesXORAt(3, 6), s.samples[k4][0]) // sparse - nothing added
+	require.Equal(t, chunkenc.FromValuesXOR(1, 3, 0, 0, 7), s.samples[string(k11)][0])
+	require.Equal(t, chunkenc.FromValuesXOR(2), s.samples[string(k12)][0])     // sparse - nothing added
+	require.Equal(t, chunkenc.FromValuesXORAt(2, 4), s.samples[string(k3)][0]) // sparse - nothing added
+	require.Equal(t, chunkenc.FromValuesXORAt(3, 6), s.samples[string(k4)][0]) // sparse - nothing added
 
 	require.Equal(t, uint16(5), s.numSamples)
 	require.Equal(t, chunkenc.FromValuesDelta(1000, 2000, 3000, 4000, 5000), s.timestamps[0].chunk)
@@ -206,12 +206,12 @@ func TestMemSeriesMany(t *testing.T) {
 
 	require.Len(t, s.samples, 2)
 
-	it = NewMultiChunkIterator(s.samples[k1])
+	it = NewMultiChunkIterator(s.samples[string(k1)])
 	for i := 1; i < 200; i++ {
 		require.True(t, it.Next())
 		require.Equal(t, int64(i), it.At())
 	}
-	it = NewMultiChunkIterator(s.samples[k2])
+	it = NewMultiChunkIterator(s.samples[string(k2)])
 	for i := 1; i < 200; i++ {
 		require.True(t, it.Next())
 		require.Equal(t, int64(2*i), it.At())


### PR DESCRIPTION
StacktraceKey benchmarks: :tada: 
```
name                  old time/op    new time/op    delta
MakeStacktraceKey-24    2.07µs ± 1%    0.37µs ± 6%   ~     (p=0.100 n=3+3)

name                  old alloc/op   new alloc/op   delta
MakeStacktraceKey-24      625B ± 0%      192B ± 0%   ~     (p=0.100 n=3+3)

name                  old allocs/op  new allocs/op  delta
MakeStacktraceKey-24      22.0 ± 0%       5.0 ± 0%   ~     (p=0.100 n=3+3)
```

DB Appends: :thinking: 
```
name        old time/op    new time/op    delta
Appends-24    16.8ms ± 1%    23.2ms ± 1%   ~     (p=0.100 n=3+3)

name        old alloc/op   new alloc/op   delta
Appends-24    9.84MB ± 0%   11.81MB ± 0%   ~     (p=0.100 n=3+3)

name        old allocs/op  new allocs/op  delta
Appends-24      140k ± 0%      149k ± 0%   ~     (p=0.100 n=3+3)
```
I don't really have a good explanation for this one really. Has to be something where the compiler cannot optimize the `[]byte` to `map[string]...`. I'll follow up with a PR that will only compute the stacktraceKeys once and it'll probably get way better anyway, plus changing to UUIDs for stacktrace IDs soon. 

DB Iterator: :tada: 
```
name         old time/op    new time/op    delta
Iterator-24    61.9µs ± 1%    60.0µs ± 1%   ~     (p=0.100 n=3+3)

name         old alloc/op   new alloc/op   delta
Iterator-24      551B ± 0%      490B ± 0%   ~     (p=0.100 n=3+3)

name         old allocs/op  new allocs/op  delta
Iterator-24      3.00 ± 0%      3.00 ± 0%   ~     (all equal)
```