### PR TITLE
pkg/storage: Use map[string]*Profile in storage

### DIFF
--- a/pkg/storage/benchmark/db-appends.txt
+++ b/pkg/storage/benchmark/db-appends.txt
@@ -2,20 +2,20 @@ goos: linux
 goarch: amd64
 pkg: github.com/parca-dev/parca/pkg/storage
 cpu: AMD Ryzen 9 3900X 12-Core Processor            
-BenchmarkAppends-24    	    2500	  16743501 ns/op	 9839116 B/op	  139925 allocs/op
+BenchmarkAppends-24    	    2500	  23191754 ns/op	11810337 B/op	  148637 allocs/op
 PASS
-ok  	github.com/parca-dev/parca/pkg/storage	55.886s
+ok  	github.com/parca-dev/parca/pkg/storage	72.441s
 goos: linux
 goarch: amd64
 pkg: github.com/parca-dev/parca/pkg/storage
 cpu: AMD Ryzen 9 3900X 12-Core Processor            
-BenchmarkAppends-24    	    2500	  16699756 ns/op	 9839168 B/op	  139926 allocs/op
+BenchmarkAppends-24    	    2500	  23070674 ns/op	11810247 B/op	  148637 allocs/op
 PASS
-ok  	github.com/parca-dev/parca/pkg/storage	55.735s
+ok  	github.com/parca-dev/parca/pkg/storage	72.493s
 goos: linux
 goarch: amd64
 pkg: github.com/parca-dev/parca/pkg/storage
 cpu: AMD Ryzen 9 3900X 12-Core Processor            
-BenchmarkAppends-24    	    2500	  16895825 ns/op	 9839081 B/op	  139925 allocs/op
+BenchmarkAppends-24    	    2500	  23371644 ns/op	11810516 B/op	  148638 allocs/op
 PASS
-ok  	github.com/parca-dev/parca/pkg/storage	56.375s
+ok  	github.com/parca-dev/parca/pkg/storage	72.910s

--- a/pkg/storage/benchmark/db-appends.txt
+++ b/pkg/storage/benchmark/db-appends.txt
@@ -2,20 +2,20 @@ goos: linux
 goarch: amd64
 pkg: github.com/parca-dev/parca/pkg/storage
 cpu: AMD Ryzen 9 3900X 12-Core Processor            
-BenchmarkAppends-24    	    2500	  23191754 ns/op	11810337 B/op	  148637 allocs/op
+BenchmarkAppends-24    	    2500	  20853346 ns/op	10322541 B/op	  136306 allocs/op
 PASS
-ok  	github.com/parca-dev/parca/pkg/storage	72.441s
+ok  	github.com/parca-dev/parca/pkg/storage	66.479s
 goos: linux
 goarch: amd64
 pkg: github.com/parca-dev/parca/pkg/storage
 cpu: AMD Ryzen 9 3900X 12-Core Processor            
-BenchmarkAppends-24    	    2500	  23070674 ns/op	11810247 B/op	  148637 allocs/op
+BenchmarkAppends-24    	    2500	  21690232 ns/op	10323206 B/op	  136309 allocs/op
 PASS
-ok  	github.com/parca-dev/parca/pkg/storage	72.493s
+ok  	github.com/parca-dev/parca/pkg/storage	68.709s
 goos: linux
 goarch: amd64
 pkg: github.com/parca-dev/parca/pkg/storage
 cpu: AMD Ryzen 9 3900X 12-Core Processor            
-BenchmarkAppends-24    	    2500	  23371644 ns/op	11810516 B/op	  148638 allocs/op
+BenchmarkAppends-24    	    2500	  21884010 ns/op	10323401 B/op	  136310 allocs/op
 PASS
-ok  	github.com/parca-dev/parca/pkg/storage	72.910s
+ok  	github.com/parca-dev/parca/pkg/storage	69.024s

--- a/pkg/storage/benchmark/db-iterator.txt
+++ b/pkg/storage/benchmark/db-iterator.txt
@@ -2,20 +2,20 @@ goos: linux
 goarch: amd64
 pkg: github.com/parca-dev/parca/pkg/storage
 cpu: AMD Ryzen 9 3900X 12-Core Processor            
-BenchmarkIterator-24    	    2500	     59297 ns/op	     489 B/op	       3 allocs/op
+BenchmarkIterator-24    	    2500	     69412 ns/op	     497 B/op	       3 allocs/op
 PASS
-ok  	github.com/parca-dev/parca/pkg/storage	72.061s
+ok  	github.com/parca-dev/parca/pkg/storage	68.818s
 goos: linux
 goarch: amd64
 pkg: github.com/parca-dev/parca/pkg/storage
 cpu: AMD Ryzen 9 3900X 12-Core Processor            
-BenchmarkIterator-24    	    2500	     60580 ns/op	     490 B/op	       3 allocs/op
+BenchmarkIterator-24    	    2500	     60900 ns/op	     491 B/op	       3 allocs/op
 PASS
-ok  	github.com/parca-dev/parca/pkg/storage	72.811s
+ok  	github.com/parca-dev/parca/pkg/storage	68.709s
 goos: linux
 goarch: amd64
 pkg: github.com/parca-dev/parca/pkg/storage
 cpu: AMD Ryzen 9 3900X 12-Core Processor            
-BenchmarkIterator-24    	    2500	     59989 ns/op	     490 B/op	       3 allocs/op
+BenchmarkIterator-24    	    2500	     70459 ns/op	     499 B/op	       3 allocs/op
 PASS
-ok  	github.com/parca-dev/parca/pkg/storage	71.408s
+ok  	github.com/parca-dev/parca/pkg/storage	68.806s

--- a/pkg/storage/benchmark/db-iterator.txt
+++ b/pkg/storage/benchmark/db-iterator.txt
@@ -2,20 +2,20 @@ goos: linux
 goarch: amd64
 pkg: github.com/parca-dev/parca/pkg/storage
 cpu: AMD Ryzen 9 3900X 12-Core Processor            
-BenchmarkIterator-24    	    2500	     62069 ns/op	     550 B/op	       3 allocs/op
+BenchmarkIterator-24    	    2500	     59297 ns/op	     489 B/op	       3 allocs/op
 PASS
-ok  	github.com/parca-dev/parca/pkg/storage	56.039s
+ok  	github.com/parca-dev/parca/pkg/storage	72.061s
 goos: linux
 goarch: amd64
 pkg: github.com/parca-dev/parca/pkg/storage
 cpu: AMD Ryzen 9 3900X 12-Core Processor            
-BenchmarkIterator-24    	    2500	     62161 ns/op	     550 B/op	       3 allocs/op
+BenchmarkIterator-24    	    2500	     60580 ns/op	     490 B/op	       3 allocs/op
 PASS
-ok  	github.com/parca-dev/parca/pkg/storage	57.280s
+ok  	github.com/parca-dev/parca/pkg/storage	72.811s
 goos: linux
 goarch: amd64
 pkg: github.com/parca-dev/parca/pkg/storage
 cpu: AMD Ryzen 9 3900X 12-Core Processor            
-BenchmarkIterator-24    	    2500	     61522 ns/op	     553 B/op	       3 allocs/op
+BenchmarkIterator-24    	    2500	     59989 ns/op	     490 B/op	       3 allocs/op
 PASS
-ok  	github.com/parca-dev/parca/pkg/storage	56.073s
+ok  	github.com/parca-dev/parca/pkg/storage	71.408s

--- a/pkg/storage/diff.go
+++ b/pkg/storage/diff.go
@@ -55,7 +55,7 @@ func (d *DiffProfile) ProfileMeta() InstantProfileMeta {
 	return d.meta
 }
 
-func (d *DiffProfile) Samples() []*Sample {
+func (d *DiffProfile) Samples() map[string]*Sample {
 	panic("implement me")
 }
 

--- a/pkg/storage/flamegraph_flat.go
+++ b/pkg/storage/flamegraph_flat.go
@@ -26,12 +26,12 @@ import (
 
 type InstantFlatProfile interface {
 	ProfileMeta() InstantProfileMeta
-	Samples() []*Sample
+	Samples() map[string]*Sample
 }
 
 type FlatProfile struct {
 	Meta    InstantProfileMeta
-	samples []*Sample
+	samples map[string]*Sample
 }
 
 func (fp *FlatProfile) ProfileTree() InstantProfileTree {
@@ -42,7 +42,7 @@ func (fp *FlatProfile) ProfileMeta() InstantProfileMeta {
 	return fp.Meta
 }
 
-func (fp *FlatProfile) Samples() []*Sample {
+func (fp *FlatProfile) Samples() map[string]*Sample {
 	return fp.samples
 }
 

--- a/pkg/storage/flamegraph_flat_test.go
+++ b/pkg/storage/flamegraph_flat_test.go
@@ -171,9 +171,17 @@ func TestGenerateFlamegraphFlat(t *testing.T) {
 	s1 := makeSample(1, []uuid.UUID{l5.ID, l3.ID, l2.ID, l1.ID})
 	s2 := makeSample(3, []uuid.UUID{l4.ID, l3.ID, l2.ID, l1.ID})
 
+	k0 := makeStacktraceKey(s0)
+	k1 := makeStacktraceKey(s1)
+	k2 := makeStacktraceKey(s2)
+
 	fp := &FlatProfile{
-		Meta:    InstantProfileMeta{},
-		samples: []*Sample{s0, s1, s2},
+		Meta: InstantProfileMeta{},
+		samples: map[string]*Sample{
+			string(k0): s0,
+			string(k1): s1,
+			string(k2): s2,
+		},
 	}
 
 	tracer := trace.NewNoopTracerProvider().Tracer("")
@@ -296,10 +304,13 @@ func TestGenerateInlinedFunctionFlamegraphFlat(t *testing.T) {
 
 	tracer := trace.NewNoopTracerProvider().Tracer("")
 
+	s0 := makeSample(2, []uuid.UUID{l2.ID, l1.ID})
+	k0 := makeStacktraceKey(s0)
+
 	fp := &FlatProfile{
 		Meta: InstantProfileMeta{},
-		samples: []*Sample{
-			makeSample(2, []uuid.UUID{l2.ID, l1.ID}),
+		samples: map[string]*Sample{
+			string(k0): s0,
 		},
 	}
 

--- a/pkg/storage/interface.go
+++ b/pkg/storage/interface.go
@@ -131,7 +131,7 @@ func CopyInstantProfileTree(pt InstantProfileTree) *ProfileTree {
 type InstantProfile interface {
 	ProfileTree() InstantProfileTree
 	ProfileMeta() InstantProfileMeta
-	Samples() []*Sample
+	Samples() map[string]*Sample
 }
 
 type ProfileSeriesIterator interface {
@@ -157,7 +157,7 @@ func (p *Profile) ProfileMeta() InstantProfileMeta {
 	return p.Meta
 }
 
-func (p *Profile) Samples() []*Sample {
+func (p *Profile) Samples() map[string]*Sample {
 	panic("won't be implemented - use FlatProfile instead")
 }
 
@@ -249,7 +249,7 @@ func (p *ScaledInstantProfile) ProfileTree() InstantProfileTree {
 	}
 }
 
-func (p *ScaledInstantProfile) Samples() []*Sample {
+func (p *ScaledInstantProfile) Samples() map[string]*Sample {
 	return p.p.Samples()
 }
 

--- a/pkg/storage/merge.go
+++ b/pkg/storage/merge.go
@@ -291,7 +291,7 @@ func (m *MergeProfileTree) RootCumulativeValue() int64 {
 	return 0
 }
 
-func (m *MergeProfile) Samples() []*Sample {
+func (m *MergeProfile) Samples() map[string]*Sample {
 	panic("implement me")
 }
 

--- a/pkg/storage/metastore/badger.go
+++ b/pkg/storage/metastore/badger.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"fmt"
 
-	badger "github.com/dgraph-io/badger/v3"
+	"github.com/dgraph-io/badger/v3"
 	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/trace"
@@ -62,7 +62,11 @@ func NewBadgerMetastore(
 	tracer trace.Tracer,
 	uuidGenerator UUIDGenerator,
 ) *BadgerMetastore {
-	db, err := badger.Open(badger.DefaultOptions("").WithInMemory(true))
+	db, err := badger.Open(
+		badger.DefaultOptions("").
+			WithInMemory(true).
+			WithLoggingLevel(badger.ERROR),
+	)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/storage/profile_flat.go
+++ b/pkg/storage/profile_flat.go
@@ -40,7 +40,7 @@ func FlatProfileFromPprof(ctx context.Context, logger log.Logger, metaStore meta
 		logger:    logger,
 		metaStore: metaStore,
 
-		samples:       make(map[stacktraceKey]*Sample, len(p.Sample)),
+		samples:       make(map[string]*Sample, len(p.Sample)),
 		locationsByID: make(map[uint64]*metastore.Location, len(p.Location)),
 		functionsByID: make(map[uint64]*metastore.Function, len(p.Function)),
 		mappingsByID:  make(map[uint64]mapInfo, len(p.Mapping)),
@@ -73,7 +73,7 @@ type profileFlatNormalizer struct {
 	logger    log.Logger
 	metaStore metastore.ProfileMetaStore
 
-	samples map[stacktraceKey]*Sample
+	samples map[string]*Sample
 	// Memoization tables within a profile.
 	locationsByID map[uint64]*metastore.Location
 	functionsByID map[uint64]*metastore.Function
@@ -113,14 +113,14 @@ func (pn *profileFlatNormalizer) mapSample(ctx context.Context, src *profile.Sam
 	// account for the remapped mapping. Add current values to the
 	// existing sample.
 	k := makeStacktraceKey(s)
-	sa, found := pn.samples[k]
+	sa, found := pn.samples[string(k)]
 	if found {
 		sa.Value += src.Value[sampleIndex]
 		return sa, false, nil
 	}
 
 	s.Value += src.Value[sampleIndex]
-	pn.samples[k] = s
+	pn.samples[string(k)] = s
 	return s, true, nil
 }
 

--- a/pkg/storage/profile_flat.go
+++ b/pkg/storage/profile_flat.go
@@ -46,26 +46,18 @@ func FlatProfileFromPprof(ctx context.Context, logger log.Logger, metaStore meta
 		mappingsByID:  make(map[uint64]mapInfo, len(p.Mapping)),
 	}
 
-	samples := make([]*Sample, 0, len(p.Sample))
 	for _, s := range p.Sample {
 		if !isZeroSample(s) {
-			sa, isNew, err := pfn.mapSample(ctx, s, sampleIndex)
+			_, _, err := pfn.mapSample(ctx, s, sampleIndex)
 			if err != nil {
 				return nil, err
-			}
-			if isNew {
-				samples = append(samples, sa)
 			}
 		}
 	}
 
-	// IDEA: Return samples as map[stacktraceKey]*Sample since that's what we're storing later.
-	// Then we wouldn't need to recompute the stacktraceKey, I don't see why a slice would be needed either.
-	// More over, the map's key should be the stacktrace's unique UUID as mapped by the metastore.
-
 	return &FlatProfile{
 		Meta:    ProfileMetaFromPprof(p, sampleIndex),
-		samples: samples,
+		samples: pfn.samples,
 	}, nil
 }
 

--- a/pkg/storage/profile_normalizer.go
+++ b/pkg/storage/profile_normalizer.go
@@ -278,3 +278,103 @@ func makeStacktraceKey(sample *Sample) stacktraceKey {
 		numlabels: strings.Join(numlabels, ""),
 	}
 }
+
+type stacktraceKeyBytes []byte
+
+// key generates stacktraceKeyBytes to be used as a key for maps.
+func makeStacktraceKeyBytes(sample *Sample) stacktraceKeyBytes {
+	numLocations := len(sample.Location)
+	locationLength := (16 * numLocations) + (numLocations - 1)
+
+	labelsLength := 0
+	labelName := make([]string, 0, len(sample.Label))
+	for l, vs := range sample.Label {
+		labelName = append(labelName, l)
+
+		labelsLength += len(l) + 2 // +2 for the quotes
+		for _, v := range vs {
+			labelsLength += len(v) + 2 // +2 for the quotes
+		}
+		labelsLength += len(vs) - 1 // spaces
+		labelsLength += 2           // square brackets
+	}
+	sort.Strings(labelName)
+
+	numLabelsLength := 0
+	numLabelNames := make([]string, 0, len(sample.NumLabel))
+	for l, int64s := range sample.NumLabel {
+		numLabelNames = append(numLabelNames, l)
+
+		numLabelsLength += len(l) + 2      // +2 for the quotes
+		numLabelsLength += 2               // square brackets
+		numLabelsLength += 8 * len(int64s) // 8*8=64bit
+
+		for _, i := range int64s {
+			numLabelsLength += len(sample.NumUnit[l][i]) + 2 // numUnit string +2 for quotes
+		}
+		numLabelsLength += 2               // square brackets
+		numLabelsLength += len(int64s) - 1 // spaces
+	}
+	sort.Strings(numLabelNames)
+
+	length := locationLength + labelsLength + numLabelsLength
+	key := make([]byte, 0, length)
+
+	for i, l := range sample.Location {
+		key = append(key, l.ID[:]...)
+		if i != len(sample.Location)-1 {
+			key = append(key, '|')
+		}
+	}
+
+	for i := 0; i < len(sample.Label); i++ {
+		l := labelName[i]
+		vs := sample.Label[l]
+		key = append(key, '"')
+		key = append(key, l...)
+		key = append(key, '"')
+
+		key = append(key, '[')
+		for i, v := range vs {
+			key = append(key, '"')
+			key = append(key, v...)
+			key = append(key, '"')
+			if i != len(vs)-1 {
+				key = append(key, ' ')
+			}
+		}
+		key = append(key, ']')
+	}
+
+	for i := 0; i < len(sample.NumLabel); i++ {
+		l := numLabelNames[i]
+		int64s := sample.NumLabel[l]
+
+		key = append(key, '"')
+		key = append(key, l...)
+		key = append(key, '"')
+
+		key = append(key, '[')
+		for _, v := range int64s {
+			// Writing int64 to pre-allocated key by shifting per byte
+			for shift := 56; shift >= 0; shift -= 8 {
+				key = append(key, byte(v>>shift))
+			}
+		}
+		key = append(key, ']')
+
+		key = append(key, '[')
+		for index, i := range int64s {
+			s := sample.NumUnit[l][i]
+			key = append(key, '"')
+			key = append(key, s...)
+			key = append(key, '"')
+			if index != len(int64s)-1 {
+				key = append(key, ' ')
+			}
+		}
+		key = append(key, ']')
+	}
+
+	return key
+}

--- a/pkg/storage/profile_normalizer.go
+++ b/pkg/storage/profile_normalizer.go
@@ -15,9 +15,7 @@ package storage
 
 import (
 	"context"
-	"fmt"
 	"sort"
-	"strings"
 
 	"github.com/go-kit/log"
 	"github.com/google/pprof/profile"
@@ -247,42 +245,10 @@ func (pn *profileNormalizer) mapFunction(ctx context.Context, src *profile.Funct
 	return f, nil
 }
 
-type stacktraceKey struct {
-	locations string
-	labels    string
-	numlabels string
-}
+type stacktraceKey []byte
 
 // key generates stacktraceKey to be used as a key for maps.
 func makeStacktraceKey(sample *Sample) stacktraceKey {
-	ids := make([]string, len(sample.Location))
-	for i, l := range sample.Location {
-		ids[i] = l.ID.String()
-	}
-
-	labels := make([]string, 0, len(sample.Label))
-	for k, v := range sample.Label {
-		labels = append(labels, fmt.Sprintf("%q%q", k, v))
-	}
-	sort.Strings(labels)
-
-	numlabels := make([]string, 0, len(sample.NumLabel))
-	for k, v := range sample.NumLabel {
-		numlabels = append(numlabels, fmt.Sprintf("%q%x%x", k, v, sample.NumUnit[k]))
-	}
-	sort.Strings(numlabels)
-
-	return stacktraceKey{
-		locations: strings.Join(ids, "|"),
-		labels:    strings.Join(labels, ""),
-		numlabels: strings.Join(numlabels, ""),
-	}
-}
-
-type stacktraceKeyBytes []byte
-
-// key generates stacktraceKeyBytes to be used as a key for maps.
-func makeStacktraceKeyBytes(sample *Sample) stacktraceKeyBytes {
 	numLocations := len(sample.Location)
 	locationLength := (16 * numLocations) + (numLocations - 1)
 

--- a/pkg/storage/profile_normalizer_test.go
+++ b/pkg/storage/profile_normalizer_test.go
@@ -1,3 +1,16 @@
+// Copyright 2021 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package storage
 
 import (

--- a/pkg/storage/profile_normalizer_test.go
+++ b/pkg/storage/profile_normalizer_test.go
@@ -17,7 +17,7 @@ func TestMakeStacktraceKey(t *testing.T) {
 		NumUnit:  map[string][]string{"foo": {"cpu", "memory"}},
 	}
 
-	k := []byte(makeStacktraceKeyBytes(s))
+	k := []byte(makeStacktraceKey(s))
 
 	require.Len(t, k, 119)
 
@@ -63,6 +63,6 @@ func BenchmarkMakeStacktraceKey(b *testing.B) {
 	b.StartTimer()
 
 	for i := 0; i < b.N; i++ {
-		_ = makeStacktraceKeyBytes(s)
+		_ = makeStacktraceKey(s)
 	}
 }

--- a/pkg/storage/profile_normalizer_test.go
+++ b/pkg/storage/profile_normalizer_test.go
@@ -1,0 +1,68 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/parca-dev/parca/pkg/storage/metastore"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMakeStacktraceKey(t *testing.T) {
+	g := NewLinearUUIDGenerator()
+
+	s := &Sample{
+		Location: []*metastore.Location{{ID: g.New()}, {ID: g.New()}, {ID: g.New()}},
+		Label:    map[string][]string{"foo": {"bar", "baz"}, "bar": {"baz"}},
+		NumLabel: map[string][]int64{"foo": {0, 1}},
+		NumUnit:  map[string][]string{"foo": {"cpu", "memory"}},
+	}
+
+	k := []byte(makeStacktraceKeyBytes(s))
+
+	require.Len(t, k, 119)
+
+	require.Equal(t,
+		[]byte{
+			0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
+			'|',
+			0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2,
+			'|',
+			0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x3,
+		},
+		k[0:50],
+	)
+
+	require.Equal(t,
+		[]byte(`"bar"["baz"]"foo"["bar" "baz"]`),
+		k[50:80],
+	)
+
+	require.Equal(t,
+		[]byte{
+			'"', 'f', 'o', 'o', '"',
+			'[',
+			0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 1,
+			']',
+			'[', '"', 'c', 'p', 'u', '"', ' ', '"', 'm', 'e', 'm', 'o', 'r', 'y', '"', ']',
+		},
+		k[80:],
+	)
+}
+
+func BenchmarkMakeStacktraceKey(b *testing.B) {
+	g := NewLinearUUIDGenerator()
+	s := &Sample{
+		Location: []*metastore.Location{{ID: g.New()}, {ID: g.New()}, {ID: g.New()}},
+		Label:    map[string][]string{"foo": {"bar", "baz"}},
+		NumLabel: map[string][]int64{"foo": {0, 1}},
+		NumUnit:  map[string][]string{"foo": {"cpu", "memory"}},
+	}
+
+	b.ReportAllocs()
+	b.StartTimer()
+
+	for i := 0; i < b.N; i++ {
+		_ = makeStacktraceKeyBytes(s)
+	}
+}

--- a/pkg/storage/profile_tree.go
+++ b/pkg/storage/profile_tree.go
@@ -43,7 +43,7 @@ func ProfileTreeFromPprof(ctx context.Context, l log.Logger, s metastore.Profile
 		logger:    l,
 		metaStore: s,
 
-		samples: make(map[stacktraceKey]*Sample, len(p.Sample)),
+		samples: make(map[string]*Sample, len(p.Sample)),
 
 		// Profile-specific hash tables for each profile inserted.
 		locationsByID: make(map[uint64]*metastore.Location, len(p.Location)),

--- a/pkg/storage/series.go
+++ b/pkg/storage/series.go
@@ -430,24 +430,23 @@ func (a *MemSeriesAppender) AppendFlat(ctx context.Context, p *FlatProfile) erro
 
 	var rootCumulative int64
 
-	for _, s := range p.Samples() {
-		k := makeStacktraceKey(s)
-		if a.s.samples[string(k)] == nil {
-			a.s.samples[string(k)] = make([]chunkenc.Chunk, len(a.s.timestamps))
+	for k, s := range p.Samples() {
+		if a.s.samples[k] == nil {
+			a.s.samples[k] = make([]chunkenc.Chunk, len(a.s.timestamps))
 			for i := 0; i < len(a.s.timestamps); i++ {
-				a.s.samples[string(k)][i] = a.s.chunkPool.GetXOR()
+				a.s.samples[k][i] = a.s.chunkPool.GetXOR()
 			}
 		}
 
-		app, err := a.s.samples[string(k)][len(a.s.samples[string(k)])-1].Appender()
+		app, err := a.s.samples[k][len(a.s.samples[k])-1].Appender()
 		if err != nil {
 			return fmt.Errorf("failed to open flat sample appender: %w", err)
 		}
 		app.AppendAt(a.s.numSamples%samplesPerChunk, s.Value)
 
 		// TODO: Eventually this should be referenced by stacktrace key with the new metastore
-		if _, found := a.s.locations[string(k)]; !found {
-			a.s.locations[string(k)] = s.Location
+		if _, found := a.s.locations[k]; !found {
+			a.s.locations[k] = s.Location
 		}
 
 		rootCumulative += s.Value

--- a/pkg/storage/series_iterator.go
+++ b/pkg/storage/series_iterator.go
@@ -353,7 +353,7 @@ func (p *MemSeriesInstantProfile) ProfileMeta() InstantProfileMeta {
 	}
 }
 
-func (p *MemSeriesInstantProfile) Samples() []*Sample {
+func (p *MemSeriesInstantProfile) Samples() map[string]*Sample {
 	panic("won't be implemented - use MemSeriesInstantFlatProfile instead")
 }
 
@@ -390,16 +390,16 @@ func (m MemSeriesInstantFlatProfile) ProfileMeta() InstantProfileMeta {
 	}
 }
 
-func (m MemSeriesInstantFlatProfile) Samples() []*Sample {
-	samples := make([]*Sample, 0, len(m.sampleIterators))
+func (m MemSeriesInstantFlatProfile) Samples() map[string]*Sample {
+	samples := make(map[string]*Sample, len(m.sampleIterators))
 	for k, it := range m.sampleIterators {
-		samples = append(samples, &Sample{
+		samples[k] = &Sample{
 			Value:    it.At(),
 			Location: m.locations[k],
 			Label:    nil, // TODO
 			NumLabel: nil, // TODO
 			NumUnit:  nil, // TODO
-		})
+		}
 	}
 	return samples
 }

--- a/pkg/storage/series_iterator.go
+++ b/pkg/storage/series_iterator.go
@@ -376,8 +376,8 @@ type MemSeriesInstantFlatProfile struct {
 	durationsIterator  MemSeriesValuesIterator
 	periodsIterator    MemSeriesValuesIterator
 
-	sampleIterators map[stacktraceKey]MemSeriesValuesIterator
-	locations       map[stacktraceKey][]*metastore.Location
+	sampleIterators map[string]MemSeriesValuesIterator
+	locations       map[string][]*metastore.Location
 }
 
 func (m MemSeriesInstantFlatProfile) ProfileMeta() InstantProfileMeta {

--- a/pkg/storage/series_iterator_range.go
+++ b/pkg/storage/series_iterator_range.go
@@ -60,7 +60,7 @@ func (rs *MemRangeSeries) Iterator() ProfileSeriesIterator {
 		rootIt.Seek(start)
 	}
 
-	var sampleIterators map[stacktraceKey]MemSeriesValuesIterator
+	var sampleIterators map[string]MemSeriesValuesIterator
 
 	root := &MemSeriesIteratorTreeNode{}
 	if rs.trees {
@@ -109,9 +109,9 @@ func (rs *MemRangeSeries) Iterator() ProfileSeriesIterator {
 			memItStack.Pop()
 		}
 	} else {
-		sampleIterators = make(map[stacktraceKey]MemSeriesValuesIterator, len(rs.s.samples))
+		sampleIterators = make(map[string]MemSeriesValuesIterator, len(rs.s.samples))
 		for key, chunks := range rs.s.samples {
-			sampleIterators[key] = NewMultiChunkIterator(chunks)
+			sampleIterators[string(key)] = NewMultiChunkIterator(chunks)
 		}
 	}
 
@@ -159,13 +159,13 @@ type MemRangeSeriesIterator struct {
 	durationsIterator  MemSeriesValuesIterator
 	periodsIterator    MemSeriesValuesIterator
 
-	sampleIterators map[stacktraceKey]MemSeriesValuesIterator
+	sampleIterators map[string]MemSeriesValuesIterator
 
 	numSamples uint64 // uint16 might not be enough for many chunks (~500+)
 	err        error
 
 	trees     bool
-	locations map[stacktraceKey][]*metastore.Location
+	locations map[string][]*metastore.Location
 }
 
 func (it *MemRangeSeriesIterator) Next() bool {

--- a/pkg/storage/series_iterator_root.go
+++ b/pkg/storage/series_iterator_root.go
@@ -156,9 +156,9 @@ func (it *MemRootSeriesIterator) At() InstantProfile {
 				PeriodType: it.s.periodType,
 				SampleType: it.s.sampleType,
 			},
-			samples: []*Sample{{
-				Value: it.rootIterator.At(),
-			}},
+			samples: map[string]*Sample{
+				"": {Value: it.rootIterator.At()},
+			},
 		}
 	}
 }

--- a/pkg/storage/series_test.go
+++ b/pkg/storage/series_test.go
@@ -70,8 +70,8 @@ func TestMemSeries(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, s.samples, 2)
-	require.Equal(t, chunkenc.FromValuesXOR(1), s.samples[k11][0])
-	require.Equal(t, chunkenc.FromValuesXOR(2), s.samples[k12][0])
+	require.Equal(t, chunkenc.FromValuesXOR(1), s.samples[string(k11)][0])
+	require.Equal(t, chunkenc.FromValuesXOR(2), s.samples[string(k12)][0])
 
 	s2 := makeSample(3, []uuid.UUID{uuid2, uuid1})
 	fp2 := &FlatProfile{
@@ -89,8 +89,8 @@ func TestMemSeries(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, s.samples, 2)
-	require.Equal(t, chunkenc.FromValuesXOR(1, 3), s.samples[k11][0])
-	require.Equal(t, chunkenc.FromValuesXOR(2), s.samples[k12][0]) // sparse - nothing added
+	require.Equal(t, chunkenc.FromValuesXOR(1, 3), s.samples[string(k11)][0])
+	require.Equal(t, chunkenc.FromValuesXOR(2), s.samples[string(k12)][0]) // sparse - nothing added
 
 	// Add another sample with one new Location
 	s3 := makeSample(4, []uuid.UUID{uuid3, uuid1})
@@ -111,9 +111,9 @@ func TestMemSeries(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, s.samples, 3)
-	require.Equal(t, chunkenc.FromValuesXOR(1, 3), s.samples[k11][0]) // sparse - nothing added
-	require.Equal(t, chunkenc.FromValuesXOR(2), s.samples[k12][0])    // sparse - nothing added
-	require.Equal(t, chunkenc.FromValuesXORAt(2, 4), s.samples[k3][0])
+	require.Equal(t, chunkenc.FromValuesXOR(1, 3), s.samples[string(k11)][0]) // sparse - nothing added
+	require.Equal(t, chunkenc.FromValuesXOR(2), s.samples[string(k12)][0])    // sparse - nothing added
+	require.Equal(t, chunkenc.FromValuesXORAt(2, 4), s.samples[string(k3)][0])
 
 	// Merging another profileTree onto the existing one with one new Location
 	s4 := makeSample(6, []uuid.UUID{uuid5, uuid2, uuid1})
@@ -133,10 +133,10 @@ func TestMemSeries(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, s.samples, 4)
-	require.Equal(t, chunkenc.FromValuesXOR(1, 3), s.samples[k11][0])  // sparse - nothing added
-	require.Equal(t, chunkenc.FromValuesXOR(2), s.samples[k12][0])     // sparse - nothing added
-	require.Equal(t, chunkenc.FromValuesXORAt(2, 4), s.samples[k3][0]) // sparse - nothing added
-	require.Equal(t, chunkenc.FromValuesXORAt(3, 6), s.samples[k4][0])
+	require.Equal(t, chunkenc.FromValuesXOR(1, 3), s.samples[string(k11)][0])  // sparse - nothing added
+	require.Equal(t, chunkenc.FromValuesXOR(2), s.samples[string(k12)][0])     // sparse - nothing added
+	require.Equal(t, chunkenc.FromValuesXORAt(2, 4), s.samples[string(k3)][0]) // sparse - nothing added
+	require.Equal(t, chunkenc.FromValuesXORAt(3, 6), s.samples[string(k4)][0])
 
 	// Merging another profileTree onto the existing one with one new Location
 	s5 := makeSample(7, []uuid.UUID{uuid2, uuid1})
@@ -154,10 +154,10 @@ func TestMemSeries(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, s.samples, 4)
-	require.Equal(t, chunkenc.FromValuesXOR(1, 3, 0, 0, 7), s.samples[k11][0])
-	require.Equal(t, chunkenc.FromValuesXOR(2), s.samples[k12][0])     // sparse - nothing added
-	require.Equal(t, chunkenc.FromValuesXORAt(2, 4), s.samples[k3][0]) // sparse - nothing added
-	require.Equal(t, chunkenc.FromValuesXORAt(3, 6), s.samples[k4][0]) // sparse - nothing added
+	require.Equal(t, chunkenc.FromValuesXOR(1, 3, 0, 0, 7), s.samples[string(k11)][0])
+	require.Equal(t, chunkenc.FromValuesXOR(2), s.samples[string(k12)][0])     // sparse - nothing added
+	require.Equal(t, chunkenc.FromValuesXORAt(2, 4), s.samples[string(k3)][0]) // sparse - nothing added
+	require.Equal(t, chunkenc.FromValuesXORAt(3, 6), s.samples[string(k4)][0]) // sparse - nothing added
 
 	require.Equal(t, uint16(5), s.numSamples)
 	require.Equal(t, chunkenc.FromValuesDelta(1000, 2000, 3000, 4000, 5000), s.timestamps[0].chunk)
@@ -206,12 +206,12 @@ func TestMemSeriesMany(t *testing.T) {
 
 	require.Len(t, s.samples, 2)
 
-	it = NewMultiChunkIterator(s.samples[k1])
+	it = NewMultiChunkIterator(s.samples[string(k1)])
 	for i := 1; i < 200; i++ {
 		require.True(t, it.Next())
 		require.Equal(t, int64(i), it.At())
 	}
-	it = NewMultiChunkIterator(s.samples[k2])
+	it = NewMultiChunkIterator(s.samples[string(k2)])
 	for i := 1; i < 200; i++ {
 		require.True(t, it.Next())
 		require.Equal(t, int64(2*i), it.At())

--- a/pkg/storage/series_test.go
+++ b/pkg/storage/series_test.go
@@ -63,7 +63,10 @@ func TestMemSeries(t *testing.T) {
 			Duration:   time.Second.Nanoseconds(),
 			Period:     time.Second.Nanoseconds(),
 		},
-		samples: []*Sample{s11, s12},
+		samples: map[string]*Sample{
+			string(k11): s11,
+			string(k12): s12,
+		},
 	}
 
 	err = app.AppendFlat(ctx, fp1)
@@ -82,7 +85,9 @@ func TestMemSeries(t *testing.T) {
 			Duration:   time.Second.Nanoseconds(),
 			Period:     time.Second.Nanoseconds(),
 		},
-		samples: []*Sample{s2},
+		samples: map[string]*Sample{
+			string(k11): s2,
+		},
 	}
 
 	err = app.AppendFlat(ctx, fp2)
@@ -104,7 +109,9 @@ func TestMemSeries(t *testing.T) {
 			Duration:   time.Second.Nanoseconds(),
 			Period:     time.Second.Nanoseconds(),
 		},
-		samples: []*Sample{s3},
+		samples: map[string]*Sample{
+			string(k3): s3,
+		},
 	}
 
 	err = app.AppendFlat(ctx, fp3)
@@ -126,7 +133,9 @@ func TestMemSeries(t *testing.T) {
 			Duration:   time.Second.Nanoseconds(),
 			Period:     time.Second.Nanoseconds(),
 		},
-		samples: []*Sample{s4},
+		samples: map[string]*Sample{
+			string(k4): s4,
+		},
 	}
 
 	err = app.AppendFlat(ctx, fp4)
@@ -148,7 +157,9 @@ func TestMemSeries(t *testing.T) {
 			Duration:   time.Second.Nanoseconds(),
 			Period:     time.Second.Nanoseconds(),
 		},
-		samples: []*Sample{s5},
+		samples: map[string]*Sample{
+			string(k11): s5,
+		},
 	}
 	err = app.AppendFlat(ctx, fp5)
 	require.NoError(t, err)
@@ -193,7 +204,10 @@ func TestMemSeriesMany(t *testing.T) {
 				Duration:  snano,
 				Period:    snano,
 			},
-			samples: []*Sample{s1, s2},
+			samples: map[string]*Sample{
+				string(k1): s1,
+				string(k2): s2,
+			},
 		})
 		require.NoError(t, err)
 	}


### PR DESCRIPTION
This PR depends on #448 

```
name        old time/op    new time/op    delta
Appends-24    23.2ms ± 1%    21.5ms ± 3%   ~     (p=0.100 n=3+3)

name        old alloc/op   new alloc/op   delta
Appends-24    11.8MB ± 0%    10.3MB ± 0%   ~     (p=0.100 n=3+3)

name        old allocs/op  new allocs/op  delta
Appends-24      149k ± 0%      136k ± 0%   ~     (p=0.100 n=3+3)
```
```
name         old time/op    new time/op    delta
Iterator-24    60.0µs ± 1%    66.9µs ± 9%   ~     (p=0.100 n=3+3)

name         old alloc/op   new alloc/op   delta
Iterator-24      490B ± 0%      496B ± 1%   ~     (p=0.100 n=3+3)

name         old allocs/op  new allocs/op  delta
Iterator-24      3.00 ± 0%      3.00 ± 0%   ~     (all equal)
```

Overall I'm surprised this entire endeavor of moving from stacktraceKey as struct to []byte didn't pay off more... :man_shrugging: 
On to using UUIDs as stacktrace ID.