### PR TITLE
pkg/storage: Implement merging of flat profiles

### DIFF
--- a/pkg/query/query.go
+++ b/pkg/query/query.go
@@ -403,7 +403,7 @@ func (q *Query) merge(ctx context.Context, sel []*labels.Matcher, start, end tim
 		Merge: true,
 	}, sel...)
 
-	return storage.MergeSeriesSetProfiles(q.tracer, ctx, set)
+	return storage.MergeSeriesSetProfiles(ctx, q.tracer, q.profileTrees, set)
 }
 
 // Series issues a series request against the storage

--- a/pkg/storage/head.go
+++ b/pkg/storage/head.go
@@ -418,7 +418,9 @@ func (q *HeadQuerier) Select(hints *SelectHints, ms ...*labels.Matcher) SeriesSe
 		if seriesMinTime > maxt {
 			continue
 		}
-		if hints != nil && hints.Merge {
+		// Only need for profile trees now,
+		// flat profiles can simply use the generic MemRangeSeries.
+		if hints != nil && hints.Merge && q.trees {
 			ss = append(ss, &MemMergeSeries{s: s, mint: mint, maxt: maxt})
 			continue
 		}

--- a/pkg/storage/interface.go
+++ b/pkg/storage/interface.go
@@ -72,10 +72,17 @@ func WalkProfileTree(pt InstantProfileTree, f func(n InstantProfileTreeNode) err
 	return nil
 }
 
-func CopyInstantProfile(p InstantProfile) *Profile {
+func CopyInstantTreeProfile(p InstantProfile) *Profile {
 	return &Profile{
 		Meta: p.ProfileMeta(),
 		Tree: CopyInstantProfileTree(p.ProfileTree()),
+	}
+}
+
+func CopyInstantFlatProfile(p InstantProfile) *FlatProfile {
+	return &FlatProfile{
+		Meta:    p.ProfileMeta(),
+		samples: p.Samples(),
 	}
 }
 

--- a/pkg/storage/merge.go
+++ b/pkg/storage/merge.go
@@ -292,7 +292,40 @@ func (m *MergeProfileTree) RootCumulativeValue() int64 {
 }
 
 func (m *MergeProfile) Samples() map[string]*Sample {
-	panic("implement me")
+	as := m.a.Samples()
+	bs := m.b.Samples()
+
+	samples := make(map[string]*Sample, len(as)+len(bs)) // TODO: Don't allocate a new map, and especially not worst case
+
+	// Merge intersection for A to B
+	for k, s := range as {
+		samples[k] = &Sample{
+			Value:    s.Value,
+			Location: s.Location,
+			Label:    s.Label,
+			NumLabel: s.NumLabel,
+			NumUnit:  s.NumUnit,
+		}
+		if b, found := bs[k]; found {
+			// Sum the actual values if k is found in bs
+			samples[k].Value += b.Value
+		}
+	}
+	for k, s := range bs {
+		if _, found := samples[k]; found {
+			// skip samples that exist in the final map, they've been merged already
+			continue
+		}
+		samples[k] = &Sample{
+			Value:    s.Value,
+			Location: s.Location,
+			Label:    s.Label,
+			NumLabel: s.NumLabel,
+			NumUnit:  s.NumUnit,
+		}
+	}
+
+	return samples
 }
 
 func (m *MergeProfileTree) Iterator() InstantProfileTreeIterator {

--- a/pkg/storage/merge_flat_test.go
+++ b/pkg/storage/merge_flat_test.go
@@ -1,0 +1,271 @@
+// Copyright 2021 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/parca-dev/parca/pkg/storage/metastore"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeFlatProfileSimple(t *testing.T) {
+	uuid1 := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+	uuid2 := uuid.MustParse("00000000-0000-0000-0000-000000000002")
+	uuid3 := uuid.MustParse("00000000-0000-0000-0000-000000000003")
+
+	s1 := makeSample(2, []uuid.UUID{uuid2, uuid1})
+	k1 := makeStacktraceKey(s1)
+
+	p1 := &FlatProfile{
+		Meta: InstantProfileMeta{
+			PeriodType: ValueType{Type: "cpu", Unit: "cycles"},
+			SampleType: ValueType{Type: "samples", Unit: "count"},
+			Timestamp:  1,
+			Duration:   int64(time.Second * 10),
+			Period:     100,
+		},
+		samples: map[string]*Sample{
+			string(k1): s1,
+		},
+	}
+
+	s2 := makeSample(1, []uuid.UUID{uuid3, uuid1})
+	k2 := makeStacktraceKey(s2)
+
+	p2 := &FlatProfile{
+		Meta: InstantProfileMeta{
+			PeriodType: ValueType{Type: "cpu", Unit: "cycles"},
+			SampleType: ValueType{Type: "samples", Unit: "count"},
+			Timestamp:  1,
+			Duration:   int64(time.Second * 10),
+			Period:     100,
+		},
+		samples: map[string]*Sample{
+			string(k2): s2,
+		},
+	}
+
+	//mp, err := MergeProfiles(p1, p2)
+	mp, err := NewMergeProfile(p1, p2)
+	require.NoError(t, err)
+	require.Equal(t, InstantProfileMeta{
+		PeriodType: ValueType{Type: "cpu", Unit: "cycles"},
+		SampleType: ValueType{Type: "samples", Unit: "count"},
+		Timestamp:  1,
+		Duration:   int64(time.Second * 20),
+		Period:     100,
+	}, mp.ProfileMeta())
+
+	merged := mp.Samples()
+	require.Len(t, merged, 2)
+
+	require.Equal(t, &Sample{
+		Value:    2,
+		Location: []*metastore.Location{{ID: uuid2}, {ID: uuid1}},
+	}, merged[string(k1)])
+	require.Equal(t, &Sample{
+		Value:    1,
+		Location: []*metastore.Location{{ID: uuid3}, {ID: uuid1}},
+	}, merged[string(k2)])
+}
+
+func TestMergeFlatProfileDeep(t *testing.T) {
+	uuid1 := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+	uuid2 := uuid.MustParse("00000000-0000-0000-0000-000000000002")
+	uuid3 := uuid.MustParse("00000000-0000-0000-0000-000000000003")
+	uuid6 := uuid.MustParse("00000000-0000-0000-0000-000000000006")
+
+	s1 := makeSample(3, []uuid.UUID{uuid1, uuid3})
+	s2 := makeSample(3, []uuid.UUID{uuid2, uuid3})
+	s3 := makeSample(3, []uuid.UUID{uuid3, uuid3, uuid2})
+	s4 := makeSample(3, []uuid.UUID{uuid6, uuid2})
+
+	k1 := makeStacktraceKey(s1)
+	k2 := makeStacktraceKey(s2)
+	k3 := makeStacktraceKey(s3)
+	k4 := makeStacktraceKey(s4)
+
+	p1 := &FlatProfile{
+		Meta: InstantProfileMeta{
+			PeriodType: ValueType{Type: "cpu", Unit: "cycles"},
+			SampleType: ValueType{Type: "samples", Unit: "count"},
+			Timestamp:  1,
+			Duration:   int64(time.Second * 10),
+			Period:     100,
+		},
+		samples: map[string]*Sample{
+			string(k1): s1,
+			string(k2): s2,
+			string(k3): s3,
+			string(k4): s4,
+		},
+	}
+
+	s5 := makeSample(3, []uuid.UUID{uuid3, uuid2, uuid2})
+	k5 := makeStacktraceKey(s5)
+
+	p2 := &FlatProfile{
+		Meta: InstantProfileMeta{
+			PeriodType: ValueType{Type: "cpu", Unit: "cycles"},
+			SampleType: ValueType{Type: "samples", Unit: "count"},
+			Timestamp:  1,
+			Duration:   int64(time.Second * 10),
+			Period:     100,
+		},
+		samples: map[string]*Sample{
+			string(k5): s5,
+		},
+	}
+
+	mp, err := NewMergeProfile(p1, p2)
+	require.NoError(t, err)
+	require.Equal(t, InstantProfileMeta{
+		PeriodType: ValueType{Type: "cpu", Unit: "cycles"},
+		SampleType: ValueType{Type: "samples", Unit: "count"},
+		Timestamp:  1,
+		Duration:   int64(time.Second * 20),
+		Period:     100,
+	}, mp.ProfileMeta())
+
+	merged := mp.Samples()
+
+	require.Len(t, merged, 5)
+
+	require.Equal(t, &Sample{
+		Value:    3,
+		Location: []*metastore.Location{{ID: uuid1}, {ID: uuid3}},
+	}, merged[string(k1)])
+	require.Equal(t, &Sample{
+		Value:    3,
+		Location: []*metastore.Location{{ID: uuid2}, {ID: uuid3}},
+	}, merged[string(k2)])
+	require.Equal(t, &Sample{
+		Value:    3,
+		Location: []*metastore.Location{{ID: uuid3}, {ID: uuid3}, {ID: uuid2}},
+	}, merged[string(k3)])
+	require.Equal(t, &Sample{
+		Value:    3,
+		Location: []*metastore.Location{{ID: uuid6}, {ID: uuid2}},
+	}, merged[string(k4)])
+	require.Equal(t, &Sample{
+		Value:    3,
+		Location: []*metastore.Location{{ID: uuid3}, {ID: uuid2}, {ID: uuid2}},
+	}, merged[string(k5)])
+}
+
+func TestMergeFlatProfile(t *testing.T) {
+	uuid1 := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+	uuid2 := uuid.MustParse("00000000-0000-0000-0000-000000000002")
+	uuid3 := uuid.MustParse("00000000-0000-0000-0000-000000000003")
+	uuid4 := uuid.MustParse("00000000-0000-0000-0000-000000000004")
+	uuid5 := uuid.MustParse("00000000-0000-0000-0000-000000000005")
+	uuid6 := uuid.MustParse("00000000-0000-0000-0000-000000000006")
+
+	s1 := makeSample(2, []uuid.UUID{uuid2, uuid1})
+	s2 := makeSample(1, []uuid.UUID{uuid6, uuid3, uuid2, uuid1})
+	s3 := makeSample(3, []uuid.UUID{uuid4, uuid3, uuid2, uuid1})
+	s4 := makeSample(3, []uuid.UUID{uuid3, uuid3, uuid2})
+	s5 := makeSample(3, []uuid.UUID{uuid6, uuid2})
+
+	k1 := makeStacktraceKey(s1)
+	k2 := makeStacktraceKey(s2)
+	k3 := makeStacktraceKey(s3)
+	k4 := makeStacktraceKey(s4)
+	k5 := makeStacktraceKey(s5)
+
+	p1 := &FlatProfile{
+		Meta: InstantProfileMeta{
+			PeriodType: ValueType{Type: "cpu", Unit: "cycles"},
+			SampleType: ValueType{Type: "samples", Unit: "count"},
+			Timestamp:  1,
+			Duration:   int64(time.Second * 10),
+			Period:     100,
+		},
+		samples: map[string]*Sample{
+			string(k1): s1,
+			string(k2): s2,
+			string(k3): s3,
+			string(k4): s4,
+			string(k5): s5,
+		},
+	}
+
+	s6 := makeSample(1, []uuid.UUID{uuid5, uuid3, uuid2, uuid1})
+	s7 := makeSample(3, []uuid.UUID{uuid3, uuid2, uuid2})
+
+	k6 := makeStacktraceKey(s6)
+	k7 := makeStacktraceKey(s7)
+
+	p2 := &FlatProfile{
+		Meta: InstantProfileMeta{
+			PeriodType: ValueType{Type: "cpu", Unit: "cycles"},
+			SampleType: ValueType{Type: "samples", Unit: "count"},
+			Timestamp:  1,
+			Duration:   int64(time.Second * 10),
+			Period:     100,
+		},
+		samples: map[string]*Sample{
+			string(k1): s1,
+			string(k3): s3,
+			string(k6): s6,
+			string(k7): s7,
+		},
+	}
+
+	//mp, err := MergeProfiles(p1, p2)
+	mp, err := NewMergeProfile(p1, p2)
+	require.NoError(t, err)
+	require.Equal(t, InstantProfileMeta{
+		PeriodType: ValueType{Type: "cpu", Unit: "cycles"},
+		SampleType: ValueType{Type: "samples", Unit: "count"},
+		Timestamp:  1,
+		Duration:   int64(time.Second * 20),
+		Period:     100,
+	}, mp.ProfileMeta())
+
+	merged := mp.Samples()
+	require.Len(t, merged, 7)
+
+	require.Equal(t, &Sample{
+		Value:    4, // 2 + 2
+		Location: []*metastore.Location{{ID: uuid2}, {ID: uuid1}},
+	}, merged[string(k1)])
+	require.Equal(t, &Sample{
+		Value:    1,
+		Location: []*metastore.Location{{ID: uuid6}, {ID: uuid3}, {ID: uuid2}, {ID: uuid1}},
+	}, merged[string(k2)])
+	require.Equal(t, &Sample{
+		Value:    6, // 3 + 3
+		Location: []*metastore.Location{{ID: uuid4}, {ID: uuid3}, {ID: uuid2}, {ID: uuid1}},
+	}, merged[string(k3)])
+	require.Equal(t, &Sample{
+		Value:    3,
+		Location: []*metastore.Location{{ID: uuid3}, {ID: uuid3}, {ID: uuid2}},
+	}, merged[string(k4)])
+	require.Equal(t, &Sample{
+		Value:    3,
+		Location: []*metastore.Location{{ID: uuid6}, {ID: uuid2}},
+	}, merged[string(k5)])
+	require.Equal(t, &Sample{
+		Value:    1,
+		Location: []*metastore.Location{{ID: uuid5}, {ID: uuid3}, {ID: uuid2}, {ID: uuid1}},
+	}, merged[string(k6)])
+	require.Equal(t, &Sample{
+		Value:    3,
+		Location: []*metastore.Location{{ID: uuid3}, {ID: uuid2}, {ID: uuid2}},
+	}, merged[string(k7)])
+}

--- a/pkg/storage/series_iterator_merge_test.go
+++ b/pkg/storage/series_iterator_merge_test.go
@@ -78,7 +78,7 @@ func TestMergeMemSeriesConsistency(t *testing.T) {
 		Value: "allocs",
 	})
 
-	p1, err := MergeSeriesSetProfiles(tracer, ctx, set)
+	p1, err := MergeSeriesSetProfiles(ctx, tracer, true, set)
 	require.NoError(t, err)
 
 	set = db.Querier(
@@ -95,7 +95,7 @@ func TestMergeMemSeriesConsistency(t *testing.T) {
 		Name:  "__name__",
 		Value: "allocs",
 	})
-	p2, err := MergeSeriesSetProfiles(tracer, ctx, set)
+	p2, err := MergeSeriesSetProfiles(ctx, tracer, true, set)
 	require.NoError(t, err)
 
 	require.Equal(t, p1, p2)
@@ -153,7 +153,7 @@ func TestMemMergeSeriesTree(t *testing.T) {
 	}
 	it := ms.Iterator()
 	require.True(t, it.Next())
-	p := CopyInstantProfile(it.At())
+	p := CopyInstantTreeProfile(it.At())
 
 	require.Equal(t, &Profile{
 		Meta: InstantProfileMeta{


### PR DESCRIPTION
It's fast. So fast, I literally can't tell the difference between a single profile and a merge profile anymore right now (on my machine with a couple of minutes of profiles :smile:) :rocket: 
```
name              old time/op    new time/op    delta
MergeMany/1-24      99.3µs ± 2%    26.7µs ± 2%   ~     (p=0.100 n=3+3)
MergeMany/2-24       306µs ± 3%      52µs ± 1%   ~     (p=0.100 n=3+3)
MergeMany/4-24       632µs ± 7%      99µs ± 2%   ~     (p=0.100 n=3+3)
MergeMany/8-24      1.30ms ± 3%    0.18ms ± 2%   ~     (p=0.100 n=3+3)
MergeMany/16-24     2.80ms ± 2%    0.34ms ± 2%   ~     (p=0.100 n=3+3)
MergeMany/32-24     5.61ms ± 3%    0.63ms ± 1%   ~     (p=0.100 n=3+3)
MergeMany/64-24     11.1ms ± 2%     1.1ms ± 4%   ~     (p=0.100 n=3+3)
MergeMany/128-24    22.3ms ± 1%     2.1ms ± 3%   ~     (p=0.100 n=3+3)
MergeMany/256-24    43.2ms ± 2%     4.2ms ± 3%   ~     (p=0.100 n=3+3)

name              old alloc/op   new alloc/op   delta
MergeMany/1-24      47.7kB ± 0%    10.4kB ± 0%   ~     (p=0.100 n=3+3)
MergeMany/2-24       132kB ± 0%      17kB ± 0%   ~     (p=0.100 n=3+3)
MergeMany/4-24       299kB ± 0%      30kB ± 0%   ~     (p=0.100 n=3+3)
MergeMany/8-24       634kB ± 0%      56kB ± 0%   ~     (p=0.100 n=3+3)
MergeMany/16-24     1.30MB ± 0%    0.11MB ± 0%   ~     (p=0.100 n=3+3)
MergeMany/32-24     2.64MB ± 0%    0.21MB ± 0%   ~     (p=0.100 n=3+3)
MergeMany/64-24     5.33MB ± 0%    0.42MB ± 0%   ~     (p=0.100 n=3+3)
MergeMany/128-24    10.7MB ± 0%     0.8MB ± 0%   ~     (p=0.100 n=3+3)
MergeMany/256-24    21.4MB ± 0%     1.7MB ± 0%   ~     (p=0.100 n=3+3)

name              old allocs/op  new allocs/op  delta
MergeMany/1-24       1.10k ± 0%     0.06k ± 0%   ~     (p=0.100 n=3+3)
MergeMany/2-24       3.25k ± 0%     0.10k ± 0%   ~     (p=0.100 n=3+3)
MergeMany/4-24       7.54k ± 0%     0.18k ± 0%   ~     (p=0.100 n=3+3)
MergeMany/8-24       16.1k ± 0%      0.3k ± 0%   ~     (p=0.100 n=3+3)
MergeMany/16-24      33.3k ± 0%      0.6k ± 0%   ~     (p=0.100 n=3+3)
MergeMany/32-24      67.7k ± 0%      1.2k ± 0%   ~     (p=0.100 n=3+3)
MergeMany/64-24       137k ± 0%        2k ± 0%   ~     (p=0.100 n=3+3)
MergeMany/128-24      274k ± 0%        5k ± 0%   ~     (p=0.100 n=3+3)
MergeMany/256-24      549k ± 0%       10k ± 0%   ~     (p=0.100 n=3+3)
```

```
CPU:    43.2ms -> 4.2ms
alloc:  21.4MB -> 1.7MB
allocs: 549k -> 10k
```
:exploding_head: :rocket: :sunglasses: 