### PR TITLE
pkg/storage: Implement diffs for flat profiles

### DIFF
--- a/pkg/storage/diff.go
+++ b/pkg/storage/diff.go
@@ -56,7 +56,21 @@ func (d *DiffProfile) ProfileMeta() InstantProfileMeta {
 }
 
 func (d *DiffProfile) Samples() map[string]*Sample {
-	panic("implement me")
+	bs := d.base.Samples()
+	cs := d.compare.Samples()
+
+	ss := make(map[string]*Sample, len(bs))
+
+	for k, s := range cs {
+		if sb, ok := bs[k]; ok {
+			s.DiffValue = s.Value - sb.Value
+			ss[k] = s
+		} else {
+			ss[k] = s
+		}
+	}
+
+	return ss
 }
 
 type DiffProfileTree struct {

--- a/pkg/storage/diff_flat_test.go
+++ b/pkg/storage/diff_flat_test.go
@@ -1,0 +1,200 @@
+// Copyright 2021 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/google/pprof/profile"
+	"github.com/google/uuid"
+	"github.com/parca-dev/parca/pkg/storage/metastore"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestDiffFlatProfileSimple(t *testing.T) {
+	uuid1 := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+	uuid2 := uuid.MustParse("00000000-0000-0000-0000-000000000002")
+	uuid3 := uuid.MustParse("00000000-0000-0000-0000-000000000003")
+
+	s1 := makeSample(3, []uuid.UUID{uuid2, uuid1})
+	k1 := makeStacktraceKey(s1)
+
+	p1 := &FlatProfile{
+		Meta: InstantProfileMeta{
+			PeriodType: ValueType{Type: "cpu", Unit: "cycles"},
+			SampleType: ValueType{Type: "samples", Unit: "count"},
+			Timestamp:  1,
+			Duration:   int64(time.Second * 10),
+			Period:     100,
+		},
+		samples: map[string]*Sample{
+			string(k1): s1,
+		},
+	}
+
+	s2 := makeSample(1, []uuid.UUID{uuid3, uuid1})
+	k2 := makeStacktraceKey(s2)
+
+	p2 := &FlatProfile{
+		Meta: InstantProfileMeta{
+			PeriodType: ValueType{Type: "cpu", Unit: "cycles"},
+			SampleType: ValueType{Type: "samples", Unit: "count"},
+			Timestamp:  1,
+			Duration:   int64(time.Second * 10),
+			Period:     100,
+		},
+		samples: map[string]*Sample{
+			string(k2): s2,
+		},
+	}
+
+	dp, err := NewDiffProfile(p1, p2)
+	require.NoError(t, err)
+	require.Equal(t, InstantProfileMeta{
+		PeriodType: ValueType{Type: "cpu", Unit: "cycles"},
+		SampleType: ValueType{Type: "samples", Unit: "count"},
+	}, dp.ProfileMeta())
+
+	diffed := dp.Samples()
+	require.Len(t, diffed, 1)
+
+	require.Equal(t, &Sample{
+		Value:     1,
+		DiffValue: 0,
+		Location:  []*metastore.Location{{ID: uuid3}, {ID: uuid1}},
+	}, diffed[string(k2)])
+}
+
+func TestDiffFlatProfileDeep(t *testing.T) {
+	uuid1 := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+	uuid2 := uuid.MustParse("00000000-0000-0000-0000-000000000002")
+	uuid3 := uuid.MustParse("00000000-0000-0000-0000-000000000003")
+	uuid6 := uuid.MustParse("00000000-0000-0000-0000-000000000006")
+
+	s0 := makeSample(3, []uuid.UUID{uuid3, uuid3, uuid2})
+	s1 := makeSample(3, []uuid.UUID{uuid6, uuid2})
+	s2 := makeSample(3, []uuid.UUID{uuid2, uuid3})
+	s3 := makeSample(3, []uuid.UUID{uuid1, uuid3})
+
+	k0 := makeStacktraceKey(s0)
+	k1 := makeStacktraceKey(s1)
+	k2 := makeStacktraceKey(s2)
+	k3 := makeStacktraceKey(s3)
+
+	p1 := &FlatProfile{
+		Meta: InstantProfileMeta{
+			PeriodType: ValueType{Type: "cpu", Unit: "cycles"},
+			SampleType: ValueType{Type: "samples", Unit: "count"},
+			Timestamp:  1,
+			Duration:   int64(time.Second * 10),
+			Period:     100,
+		},
+		samples: map[string]*Sample{
+			string(k0): s0,
+			string(k1): s1,
+			string(k2): s2,
+			string(k3): s3,
+		},
+	}
+
+	s4 := makeSample(3, []uuid.UUID{uuid3, uuid2, uuid2})
+	s5 := makeSample(5, []uuid.UUID{uuid2, uuid3})
+
+	k4 := makeStacktraceKey(s4)
+	k5 := makeStacktraceKey(s5)
+
+	p2 := &FlatProfile{
+		Meta: InstantProfileMeta{
+			PeriodType: ValueType{Type: "cpu", Unit: "cycles"},
+			SampleType: ValueType{Type: "samples", Unit: "count"},
+			Timestamp:  1,
+			Duration:   int64(time.Second * 10),
+			Period:     100,
+		},
+		samples: map[string]*Sample{
+			string(k4): s4,
+			string(k5): s5,
+		},
+	}
+
+	dp, err := NewDiffProfile(p1, p2)
+	require.NoError(t, err)
+	require.Equal(t, InstantProfileMeta{
+		PeriodType: ValueType{Type: "cpu", Unit: "cycles"},
+		SampleType: ValueType{Type: "samples", Unit: "count"},
+	}, dp.ProfileMeta())
+
+	diffed := dp.Samples()
+	require.Len(t, diffed, 2)
+
+	require.Equal(t, &Sample{
+		Value:     3,
+		DiffValue: 0,
+		Location:  []*metastore.Location{{ID: uuid3}, {ID: uuid2}, {ID: uuid2}},
+	}, diffed[string(k4)])
+	require.Equal(t, &Sample{
+		Value:     5,
+		DiffValue: 2,
+		Location:  []*metastore.Location{{ID: uuid2}, {ID: uuid3}},
+	}, diffed[string(k5)])
+}
+
+// go test -bench=BenchmarkFlatDiff -count=3 ./pkg/storage | tee ./pkg/storage/benchmark/diff-flat.txt
+
+func BenchmarkFlatDiff(b *testing.B) {
+	ctx := context.Background()
+
+	f, err := os.Open("testdata/profile1.pb.gz")
+	require.NoError(b, err)
+	p1, err := profile.Parse(f)
+	require.NoError(b, err)
+	require.NoError(b, f.Close())
+	f, err = os.Open("testdata/profile2.pb.gz")
+	require.NoError(b, err)
+	p2, err := profile.Parse(f)
+	require.NoError(b, err)
+	require.NoError(b, f.Close())
+
+	l := metastore.NewBadgerMetastore(
+		log.NewNopLogger(),
+		prometheus.NewRegistry(),
+		trace.NewNoopTracerProvider().Tracer(""),
+		metastore.NewRandomUUIDGenerator(),
+	)
+	require.NoError(b, err)
+	b.Cleanup(func() {
+		l.Close()
+	})
+	profile1, err := FlatProfileFromPprof(ctx, log.NewNopLogger(), l, p1, 0)
+	require.NoError(b, err)
+	profile2, err := FlatProfileFromPprof(ctx, log.NewNopLogger(), l, p2, 0)
+	require.NoError(b, err)
+
+	b.Run("simple", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			d, err := NewDiffProfile(profile1, profile2)
+			require.NoError(b, err)
+			CopyInstantFlatProfile(d)
+		}
+	})
+}

--- a/pkg/storage/diff_test.go
+++ b/pkg/storage/diff_test.go
@@ -195,6 +195,8 @@ func TestDiffProfileDeep(t *testing.T) {
 	}, res)
 }
 
+// go test -bench=BenchmarkDiff -count=3 ./pkg/storage | tee ./pkg/storage/benchmark/diff-tree.txt
+
 func BenchmarkDiff(b *testing.B) {
 	ctx := context.Background()
 
@@ -247,6 +249,9 @@ func BenchmarkDiff(b *testing.B) {
 	}
 
 	b.Run("simple", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+
 		for i := 0; i < b.N; i++ {
 			d, err := NewDiffProfile(prof1, prof2)
 			require.NoError(b, err)

--- a/pkg/storage/flamegraph_flat.go
+++ b/pkg/storage/flamegraph_flat.go
@@ -98,6 +98,7 @@ func GenerateFlamegraphFlat(ctx context.Context, tracer trace.Tracer, metaStore 
 						continue
 					}
 					n.Cumulative += s.Value
+					n.Diff += s.DiffValue
 				}
 
 				child = nodes[0]
@@ -110,10 +111,12 @@ func GenerateFlamegraphFlat(ctx context.Context, tracer trace.Tracer, metaStore 
 
 			// Add the value to the cumulative value for each node
 			cur.Cumulative += s.Value
+			cur.Diff += s.DiffValue
 		}
 
 		// Sum up the value to the cumulative value of the root
 		rootNode.Cumulative += s.Value
+		rootNode.Diff += s.DiffValue
 
 		// For next sample start at the root again
 		cur = rootNode

--- a/pkg/storage/profile_normalizer.go
+++ b/pkg/storage/profile_normalizer.go
@@ -38,11 +38,12 @@ type profileNormalizer struct {
 }
 
 type Sample struct {
-	Location []*metastore.Location
-	Value    int64
-	Label    map[string][]string
-	NumLabel map[string][]int64
-	NumUnit  map[string][]string
+	Location  []*metastore.Location
+	Value     int64
+	DiffValue int64
+	Label     map[string][]string
+	NumLabel  map[string][]int64
+	NumUnit   map[string][]string
 }
 
 // Returns the mapped sample and whether it is new or a known sample.


### PR DESCRIPTION
Comparing apples and oranges once more, but diffing for flat profiles is looking good:
```
name            old time/op    new time/op    delta
Diff/simple-24     118µs ± 8%       5µs ±10%  -95.72%  (p=0.000 n=10+10)

name            old alloc/op   new alloc/op   delta
Diff/simple-24     117kB ± 0%       2kB ± 0%  -98.04%  (p=0.000 n=10+10)

name            old allocs/op  new allocs/op  delta
Diff/simple-24     2.43k ± 0%     0.01k ± 0%  -99.79%  (p=0.000 n=10+10)
```