### PR TITLE
pkg/storage: Truncate flat profile chunks

### DIFF
--- a/pkg/storage/series.go
+++ b/pkg/storage/series.go
@@ -542,6 +542,9 @@ func (s *MemSeries) truncateChunksBefore(mint int64) (removed int) {
 	for key, chunks := range s.flatValues {
 		s.flatValues[key] = chunks[start:]
 	}
+	for key, chunks := range s.samples {
+		s.samples[key] = chunks[start:]
+	}
 
 	s.minTime = s.timestamps[0].minTime
 


### PR DESCRIPTION
We should truncate these to support proper retention for flat profiles too.