### PR TITLE
Add a reset view button to Icicle graphs

### DIFF
--- a/ui/packages/app/web/src/components/MetricsGraph.tsx
+++ b/ui/packages/app/web/src/components/MetricsGraph.tsx
@@ -149,7 +149,7 @@ export const MetricsTooltip = ({
   const highlightedNameLabel: Label.AsObject = nameLabel !== undefined ? (nameLabel) : ({ name: '', value: '' })
 
   return (
-    <div ref={setPopperElement} style={styles.popper} {...attributes.popper}>
+    <div ref={setPopperElement} style={styles.popper} {...attributes.popper} className="z-10">
       <div className="flex max-w-md">
         <div className="m-auto">
           <div className="border-gray-300 dark:border-gray-500 bg-gray-50 dark:bg-gray-900 rounded-lg p-3 shadow-lg opacity-90" style={{ borderWidth: 1 }}>

--- a/ui/packages/shared/profile/src/ProfileIcicleGraph.tsx
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, forwardRef, useImperativeHandle } from 'react'
 import IcicleGraph from './IcicleGraph'
 import { Flamegraph } from '@parca/client'
 
@@ -16,32 +16,33 @@ function arrayEquals (a, b): boolean {
   )
 }
 
-export default function ProfileIcicleGraph ({
-  width,
-  graph
-}: ProfileIcicleGraphProps) {
-  const [curPath, setCurPath] = useState<string[]>([])
+const ProfileIcicleGraph = forwardRef<{ resetIcicleGraph: () => void }, ProfileIcicleGraphProps>((props, ref) => {
+    const [curPath, setCurPath] = useState<string[]>([])
 
-  useEffect(() => {
-    setCurPath([])
-  }, [graph])
+    const { width, graph } = props
 
-  if (graph === undefined) return <div>no data...</div>
-  const total = graph.total
-  if (total === 0) return <>Profile has no samples</>
+    useEffect(() => {
+      setCurPath([])
+    }, [graph])
 
-  const setNewCurPath = (path: string[]) => {
-    if (!arrayEquals(curPath, path)) {
-      setCurPath(path)
+    useImperativeHandle(ref, () => ({
+      resetIcicleGraph() {
+        setCurPath([])
+      }
+    }))
+
+    if (graph === undefined) return <div>no data...</div>
+    const total = graph.total
+    if (total === 0) return <>Profile has no samples</>
+
+    const setNewCurPath = (path: string[]) => {
+      if (!arrayEquals(curPath, path)) {
+        setCurPath(path)
+      }
     }
-  }
 
-  return (
-        <IcicleGraph
-          width={width}
-          graph={graph}
-          curPath={curPath}
-          setCurPath={setNewCurPath}
-        />
-  )
-}
+    return <IcicleGraph width={width} graph={graph} curPath={curPath} setCurPath={setNewCurPath} />
+  }
+)
+
+export default ProfileIcicleGraph

--- a/ui/packages/shared/profile/src/ProfileIcicleGraph.tsx
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph.tsx
@@ -1,48 +1,24 @@
-import { useState, useEffect, forwardRef, useImperativeHandle } from 'react'
 import IcicleGraph from './IcicleGraph'
 import { Flamegraph } from '@parca/client'
 
 interface ProfileIcicleGraphProps {
   width?: number
   graph: Flamegraph.AsObject | undefined
+  curPath: string[] | []
+  setNewCurPath: (path: string[]) => void
 }
 
-function arrayEquals (a, b): boolean {
-  return (
-    Array.isArray(a) &&
-    Array.isArray(b) &&
-    a.length === b.length &&
-    a.every((val, index) => val === b[index])
-  )
-}
-
-const ProfileIcicleGraph = forwardRef<{ resetIcicleGraph: () => void }, ProfileIcicleGraphProps>((props, ref) => {
-    const [curPath, setCurPath] = useState<string[]>([])
-
-    const { width, graph } = props
-
-    useEffect(() => {
-      setCurPath([])
-    }, [graph])
-
-    useImperativeHandle(ref, () => ({
-      resetIcicleGraph() {
-        setCurPath([])
-      }
-    }))
-
+const ProfileIcicleGraph = ({
+  width,
+  graph,
+  curPath,
+  setNewCurPath
+}: ProfileIcicleGraphProps) => {
     if (graph === undefined) return <div>no data...</div>
     const total = graph.total
     if (total === 0) return <>Profile has no samples</>
 
-    const setNewCurPath = (path: string[]) => {
-      if (!arrayEquals(curPath, path)) {
-        setCurPath(path)
-      }
-    }
-
     return <IcicleGraph width={width} graph={graph} curPath={curPath} setCurPath={setNewCurPath} />
-  }
-)
+}
 
 export default ProfileIcicleGraph

--- a/ui/packages/shared/profile/src/ProfileView.tsx
+++ b/ui/packages/shared/profile/src/ProfileView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState, useRef } from 'react'
 // import ProfileSVG from './ProfileSVG'
 // import ProfileTop from './ProfileTop'
 import { CalcWidth } from '@parca/dynamicsize'
@@ -47,6 +47,7 @@ export const ProfileView = ({
   queryClient,
   profileSource
 }: ProfileViewProps): JSX.Element => {
+  const icicleGraphRef = useRef<{ resetIcicleGraph: () => void }>(null)
   const { response, error } = useQuery(queryClient, profileSource)
 
   if (error != null) {
@@ -94,20 +95,33 @@ export const ProfileView = ({
     })
   }
 
+  const resetIcicleGraph = (e: React.MouseEvent<HTMLElement>) => {
+    if (icicleGraphRef.current) {
+      icicleGraphRef.current.resetIcicleGraph()
+    }
+  }
+
   return (
     <>
-      <div className="py-3">
+      <div className='py-3'>
         <Card>
           <Card.Body>
-            <div className="flex space-x-4 py-3">
+            <div className='flex space-x-4 py-3'>
               {/* TODO: Proper offset */}
-              <div className="w-full"/>
-              <div className="w-full"/>
-              <div className="w-full"/>
-              <Button color="neutral" onClick={downloadPProf}>Download pprof</Button>
+              <div className='w-1/4'>
+                <Button color='neutral' onClick={resetIcicleGraph}>
+                  Reset View
+                </Button>
+              </div>
+
+              <div className='w-full' />
+              <div className='w-full' />
+              <Button color='neutral' onClick={downloadPProf}>
+                Download pprof
+              </Button>
             </div>
             <CalcWidth throttle={300} delay={2000}>
-              <ProfileIcicleGraph graph={response.getFlamegraph()?.toObject()}/>
+              <ProfileIcicleGraph ref={icicleGraphRef} graph={response.getFlamegraph()?.toObject()} />
             </CalcWidth>
           </Card.Body>
         </Card>

--- a/ui/packages/shared/profile/src/ProfileView.tsx
+++ b/ui/packages/shared/profile/src/ProfileView.tsx
@@ -19,6 +19,15 @@ export interface IQueryResult {
   error: ServiceError | null
 }
 
+function arrayEquals(a, b): boolean {
+  return (
+    Array.isArray(a) &&
+    Array.isArray(b) &&
+    a.length === b.length &&
+    a.every((val, index) => val === b[index])
+  )
+}
+
 export const useQuery = (
   client: QueryServiceClient,
   profileSource: ProfileSource
@@ -47,7 +56,7 @@ export const ProfileView = ({
   queryClient,
   profileSource
 }: ProfileViewProps): JSX.Element => {
-  const icicleGraphRef = useRef<{ resetIcicleGraph: () => void }>(null)
+  const [curPath, setCurPath] = useState<string[]>([])
   const { response, error } = useQuery(queryClient, profileSource)
 
   if (error != null) {
@@ -96,8 +105,12 @@ export const ProfileView = ({
   }
 
   const resetIcicleGraph = (e: React.MouseEvent<HTMLElement>) => {
-    if (icicleGraphRef.current) {
-      icicleGraphRef.current.resetIcicleGraph()
+    setCurPath([])
+  }
+
+  const setNewCurPath = (path: string[]) => {
+    if (!arrayEquals(curPath, path)) {
+      setCurPath(path)
     }
   }
 
@@ -107,9 +120,8 @@ export const ProfileView = ({
         <Card>
           <Card.Body>
             <div className='flex space-x-4 py-3'>
-              {/* TODO: Proper offset */}
               <div className='w-1/4'>
-                <Button color='neutral' onClick={resetIcicleGraph}>
+                <Button color='neutral' onClick={resetIcicleGraph} disabled={curPath.length === 0}>
                   Reset View
                 </Button>
               </div>
@@ -121,7 +133,11 @@ export const ProfileView = ({
               </Button>
             </div>
             <CalcWidth throttle={300} delay={2000}>
-              <ProfileIcicleGraph ref={icicleGraphRef} graph={response.getFlamegraph()?.toObject()} />
+              <ProfileIcicleGraph
+                curPath={curPath}
+                setNewCurPath={setNewCurPath}
+                graph={response.getFlamegraph()?.toObject()}
+              />
             </CalcWidth>
           </Card.Body>
         </Card>


### PR DESCRIPTION
This adds a reset view button for the icicle graphs. I opted for "Reset View" as the text but let me know if you have other ideas.

This also fixes the weird behaviour with the download pprof button and the metrics tooltip. The latter would display underneath the button.

This resolves #474

**Screenshot**
![image](https://user-images.githubusercontent.com/9016992/145391277-cde3e4a2-8715-4fb8-9a88-330f705ff3d7.png)
