### PR TITLE
pkg/storage: Use metastore for storing and retreiving stacktraces by UUID

### DIFF
--- a/pkg/storage/benchmark/db-appends.txt
+++ b/pkg/storage/benchmark/db-appends.txt
@@ -2,10 +2,10 @@ goos: linux
 goarch: amd64
 pkg: github.com/parca-dev/parca/pkg/storage
 cpu: AMD Ryzen 9 3900X 12-Core Processor            
-BenchmarkAppends-24    	    2500	  28784154 ns/op	11323444 B/op	  161810 allocs/op
-BenchmarkAppends-24    	    2500	  28038707 ns/op	11320508 B/op	  161799 allocs/op
-BenchmarkAppends-24    	    2500	  28366812 ns/op	11321990 B/op	  161804 allocs/op
-BenchmarkAppends-24    	    2500	  28115180 ns/op	11320783 B/op	  161800 allocs/op
-BenchmarkAppends-24    	    2500	  28379430 ns/op	11321739 B/op	  161804 allocs/op
+BenchmarkAppends-24    	    2500	  27321627 ns/op	11382381 B/op	  164363 allocs/op
+BenchmarkAppends-24    	    2500	  27580439 ns/op	11383229 B/op	  164368 allocs/op
+BenchmarkAppends-24    	    2500	  28115820 ns/op	11385848 B/op	  164377 allocs/op
+BenchmarkAppends-24    	    2500	  27252961 ns/op	11381674 B/op	  164362 allocs/op
+BenchmarkAppends-24    	    2500	  28046181 ns/op	11385242 B/op	  164376 allocs/op
 PASS
-ok  	github.com/parca-dev/parca/pkg/storage	417.895s
+ok  	github.com/parca-dev/parca/pkg/storage	408.648s

--- a/pkg/storage/benchmark/db-iterator.txt
+++ b/pkg/storage/benchmark/db-iterator.txt
@@ -2,10 +2,10 @@ goos: linux
 goarch: amd64
 pkg: github.com/parca-dev/parca/pkg/storage
 cpu: AMD Ryzen 9 3900X 12-Core Processor            
-BenchmarkIterator-24    	    2500	     59652 ns/op	     661 B/op	       4 allocs/op
-BenchmarkIterator-24    	    2500	     63601 ns/op	     674 B/op	       4 allocs/op
-BenchmarkIterator-24    	    2500	     58453 ns/op	     658 B/op	       4 allocs/op
-BenchmarkIterator-24    	    2500	     59437 ns/op	     661 B/op	       4 allocs/op
-BenchmarkIterator-24    	    2500	     70301 ns/op	     705 B/op	       4 allocs/op
+BenchmarkIterator-24    	    2500	     66574 ns/op	     729 B/op	       4 allocs/op
+BenchmarkIterator-24    	    2500	     70821 ns/op	     750 B/op	       4 allocs/op
+BenchmarkIterator-24    	    2500	     84972 ns/op	     815 B/op	       5 allocs/op
+BenchmarkIterator-24    	    2500	     77853 ns/op	     784 B/op	       4 allocs/op
+BenchmarkIterator-24    	    2500	     68876 ns/op	     746 B/op	       4 allocs/op
 PASS
-ok  	github.com/parca-dev/parca/pkg/storage	422.973s
+ok  	github.com/parca-dev/parca/pkg/storage	417.674s

--- a/pkg/storage/flamegraph_flat_test.go
+++ b/pkg/storage/flamegraph_flat_test.go
@@ -185,12 +185,19 @@ func TestGenerateFlamegraphFlat(t *testing.T) {
 	k1 := makeStacktraceKey(s1)
 	k2 := makeStacktraceKey(s2)
 
+	stacktraceID0, err := l.CreateStacktrace(ctx, k0, &metapb.Sample{LocationIds: [][]byte{l2.ID[:], l1.ID[:]}})
+	require.NoError(t, err)
+	stacktraceID1, err := l.CreateStacktrace(ctx, k1, &metapb.Sample{LocationIds: [][]byte{l5.ID[:], l3.ID[:], l2.ID[:], l1.ID[:]}})
+	require.NoError(t, err)
+	stacktraceID2, err := l.CreateStacktrace(ctx, k2, &metapb.Sample{LocationIds: [][]byte{l4.ID[:], l3.ID[:], l2.ID[:], l1.ID[:]}})
+	require.NoError(t, err)
+
 	fp := &FlatProfile{
 		Meta: InstantProfileMeta{},
 		samples: map[string]*Sample{
-			string(k0): s0,
-			string(k1): s1,
-			string(k2): s2,
+			string(stacktraceID0[:]): s0,
+			string(stacktraceID1[:]): s1,
+			string(stacktraceID2[:]): s2,
 		},
 	}
 

--- a/pkg/storage/metastore/inmemory_sqlite.go
+++ b/pkg/storage/metastore/inmemory_sqlite.go
@@ -62,6 +62,10 @@ func (i InMemorySQLiteMetaStore) GetStacktraceByKey(ctx context.Context, key []b
 	panic("implement me")
 }
 
+func (i InMemorySQLiteMetaStore) GetStacktraceByIDs(ctx context.Context, ids ...[]byte) (map[string]*pb.Sample, error) {
+	panic("implement me")
+}
+
 func (i InMemorySQLiteMetaStore) CreateStacktrace(ctx context.Context, key []byte, sample *pb.Sample) (uuid.UUID, error) {
 	panic("implement me")
 }

--- a/pkg/storage/metastore/metastore.go
+++ b/pkg/storage/metastore/metastore.go
@@ -44,6 +44,7 @@ type ProfileMetaStore interface {
 
 type StacktraceStore interface {
 	GetStacktraceByKey(ctx context.Context, key []byte) (uuid.UUID, error)
+	GetStacktraceByIDs(ctx context.Context, ids ...[]byte) (map[string]*pb.Sample, error)
 	CreateStacktrace(ctx context.Context, key []byte, sample *pb.Sample) (uuid.UUID, error)
 }
 

--- a/pkg/storage/metastore/ondisk_sqlite.go
+++ b/pkg/storage/metastore/ondisk_sqlite.go
@@ -62,6 +62,10 @@ func (o OnDiskSQLiteMetaStore) GetStacktraceByKey(ctx context.Context, key []byt
 	panic("implement me")
 }
 
+func (o OnDiskSQLiteMetaStore) GetStacktraceByIDs(ctx context.Context, ids ...[]byte) (map[string]*pb.Sample, error) {
+	panic("implement me")
+}
+
 func (o OnDiskSQLiteMetaStore) CreateStacktrace(ctx context.Context, key []byte, sample *pb.Sample) (uuid.UUID, error) {
 	panic("implement me")
 }

--- a/pkg/storage/metastore/remote.go
+++ b/pkg/storage/metastore/remote.go
@@ -34,6 +34,10 @@ func (r RemoteMetaStore) GetStacktraceByKey(ctx context.Context, key []byte) (uu
 	panic("implement me")
 }
 
+func (r RemoteMetaStore) GetStacktraceByIDs(ctx context.Context, ids ...[]byte) (map[string]*pb.Sample, error) {
+	panic("implement me")
+}
+
 func (r RemoteMetaStore) CreateStacktrace(ctx context.Context, key []byte, sample *pb.Sample) (uuid.UUID, error) {
 	panic("implement me")
 }

--- a/pkg/storage/series_iterator.go
+++ b/pkg/storage/series_iterator.go
@@ -394,11 +394,7 @@ func (m MemSeriesInstantFlatProfile) Samples() map[string]*Sample {
 	samples := make(map[string]*Sample, len(m.sampleIterators))
 	for k, it := range m.sampleIterators {
 		samples[k] = &Sample{
-			Value:    it.At(),
-			Location: m.locations[k],
-			Label:    nil, // TODO
-			NumLabel: nil, // TODO
-			NumUnit:  nil, // TODO
+			Value: it.At(),
 		}
 	}
 	return samples


### PR DESCRIPTION
This should allow us to remove the labels from the storage entirely going forward, where they don't really belong anyway.
In the end we don't even use the labels in the flame graph, maybe we should start doing something with them? https://github.com/parca-dev/parca/issues/488

Appends:
```
name        old time/op    new time/op    delta
Appends-24    28.3ms ± 2%    27.7ms ± 2%    ~     (p=0.056 n=5+5)

name        old alloc/op   new alloc/op   delta
Appends-24    11.3MB ± 0%    11.4MB ± 0%  +0.55%  (p=0.008 n=5+5)

name        old allocs/op  new allocs/op  delta
Appends-24      162k ± 0%      164k ± 0%  +1.59%  (p=0.008 n=5+5)
```
Iterator:
```
name         old time/op    new time/op    delta
Iterator-24    62.3µs ±13%    73.8µs ±15%  +18.51%  (p=0.032 n=5+5)

name         old alloc/op   new alloc/op   delta
Iterator-24      672B ± 5%      765B ± 7%  +13.84%  (p=0.008 n=5+5)

name         old allocs/op  new allocs/op  delta
Iterator-24      4.00 ± 0%      4.00 ± 0%     ~     (all equal)
```