### PR TITLE
*: Fix env.sh when installing minikube

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
 chmod +x ./minikube-linux-amd64
-sudo minikube-linux-amd64 /usr/local/bin/minikube
+sudo mv minikube-linux-amd64 /usr/local/bin/minikube
 
 curl -fsSL https://raw.githubusercontent.com/tilt-dev/tilt/master/scripts/install.sh | bash
 


### PR DESCRIPTION
There was a `mv` command omitted in the script which caused it to try
running the `minikube-linux-amd64` binary instead of moving it into
$PATH. This caused an error because the binary would not be found.

Add `mv` command to fix this.