### PR TITLE
*: Specify shell in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 CMD_DOCKER ?= docker
 CMD_GIT ?= git
+SHELL := /bin/bash
 ifeq ($(GITHUB_BRANCH_NAME),)
 	BRANCH := $(shell git rev-parse --abbrev-ref HEAD)-
 else


### PR DESCRIPTION
The default shell Make will try to use in /bin/sh which does not
implement the `source` command, causing make targets such as `dev/up` to
fail.