### PR TITLE
pkg/parca: Don't use profileTrees by default anymore

### DIFF
--- a/pkg/parca/parca.go
+++ b/pkg/parca/parca.go
@@ -66,7 +66,7 @@ type Flags struct {
 
 	StorageTSDBRetentionTime    time.Duration `default:"6h" help:"How long to retain samples in storage."`
 	StorageTSDBExpensiveMetrics bool          `default:"false" help:"Enable really heavy metrics. Only do this for debugging as the metrics are slowing Parca down by a lot." hidden:"true"`
-	StorageTSDBProfileTrees     bool          `default:"true" help:"Enable profile tree storage in the TSDB" hidden:"true"`
+	StorageTSDBProfileTrees     bool          `default:"false" help:"Enable profile tree storage in the TSDB" hidden:"true"`
 
 	SymbolizerDemangleMode  string `default:"simple" help:"Mode to demangle C++ symbols. Default mode is simplified: no parameters, no templates, no return type" enum:"simple,full,none,templates"`
 	SymbolizerNumberOfTries int    `default:"3" help:"Number of tries to attempt to symbolize an unsybolized location"`


### PR DESCRIPTION
Time to use the slimmer version of the storage that doesn't use profile trees anymore. 
I still want to keep the hidden flag, just in case we encounter problems, and can point people to turning profile trees on again. 
