### PR TITLE
pkg/storage: Fix bug so samples seek to correct index

### DIFF
--- a/pkg/storage/series_iterator.go
+++ b/pkg/storage/series_iterator.go
@@ -376,7 +376,7 @@ type MemSeriesInstantFlatProfile struct {
 	durationsIterator  MemSeriesValuesIterator
 	periodsIterator    MemSeriesValuesIterator
 
-	sampleIterators map[string]MemSeriesValuesIterator
+	sampleIterators map[string]*MultiChunksIterator
 	locations       map[string][]*metastore.Location
 }
 


### PR DESCRIPTION
We currently don't seek the correct index for samples in chunks. 
This has the effect that we basically every only read the first sample of each chunk - resulting in not updating icicle graphs until a timestamp in another chunk is selected.

I was already wondering why this was happening in the UI... :man_shrugging: :smile: 