### PR TITLE
area/ui: Add additional Next.js pages to the binary pkg

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -252,6 +252,10 @@ func (s *Server) uiHandler(uiFS fs.FS) (*http.ServeMux, error) {
 			paths = append(paths, "/")
 		}
 
+		if paths[0] == "/table/index.html" {
+			paths = append(paths, "/table")
+		}
+
 		for _, path := range paths {
 			uiHandler.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
 				http.ServeContent(w, r, d.Name(), fi.ModTime(), bytes.NewReader(outputBytes))

--- a/ui/packages/app/web/src/pages/table.tsx
+++ b/ui/packages/app/web/src/pages/table.tsx
@@ -1,0 +1,5 @@
+import { withRouter } from 'next/router'
+
+const Table = () => <p>A table shows up here</p>
+
+export default withRouter(Table)

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -16,6 +16,7 @@ package ui
 import "embed"
 
 //go:embed packages/app/web/dist
+//go:embed packages/app/web/dist/table
 //go:embed packages/app/web/dist/_next
 //go:embed packages/app/web/dist/_next/static/chunks/pages/*.js
 //go:embed packages/app/web/dist/_next/static/*/*.js


### PR DESCRIPTION
This is a proof of concept for how we can we can create additional Next.js pages and embed them in the built binary package.

After the page has been created in the Next.js app and exported using `make ui`, there should be a directory created for the page with a corresponding `index.html` file.

Finally, the path to the page's directory is added to the embed directive in `ui.go` and the `pkg/server/server.go` file.