### PR TITLE
*: Extract profile normalization into separate package

### DIFF
--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -1,0 +1,107 @@
+// Copyright 2022 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profile
+
+import (
+	"time"
+
+	"github.com/google/pprof/profile"
+	"github.com/parca-dev/parca/pkg/storage/metastore"
+)
+
+type InstantProfileMeta struct {
+	PeriodType ValueType
+	SampleType ValueType
+	Timestamp  int64
+	Duration   int64
+	Period     int64
+}
+
+type Sample struct {
+	Location  []*metastore.Location
+	Value     int64
+	DiffValue int64
+	Label     map[string][]string
+	NumLabel  map[string][]int64
+	NumUnit   map[string][]string
+}
+
+type ValueType struct {
+	Type string
+	Unit string
+}
+
+func CopyInstantFlatProfile(p InstantProfile) *FlatProfile {
+	return &FlatProfile{
+		Meta:        p.ProfileMeta(),
+		FlatSamples: p.Samples(),
+	}
+}
+
+type InstantProfile interface {
+	ProfileMeta() InstantProfileMeta
+	Samples() map[string]*Sample
+}
+
+type InstantFlatProfile interface {
+	ProfileMeta() InstantProfileMeta
+	Samples() map[string]*Sample
+}
+
+type FlatProfile struct {
+	Meta        InstantProfileMeta
+	FlatSamples map[string]*Sample
+}
+
+func (fp *FlatProfile) ProfileMeta() InstantProfileMeta {
+	return fp.Meta
+}
+
+func (fp *FlatProfile) Samples() map[string]*Sample {
+	return fp.FlatSamples
+}
+
+func ProfileMetaFromPprof(p *profile.Profile, sampleIndex int) InstantProfileMeta {
+	return InstantProfileMeta{
+		Timestamp:  p.TimeNanos / time.Millisecond.Nanoseconds(),
+		Duration:   p.DurationNanos,
+		Period:     p.Period,
+		PeriodType: ValueType{Type: p.PeriodType.Type, Unit: p.PeriodType.Unit},
+		SampleType: ValueType{Type: p.SampleType[sampleIndex].Type, Unit: p.SampleType[sampleIndex].Unit},
+	}
+}
+
+type ScaledInstantProfile struct {
+	p     InstantProfile
+	ratio float64
+}
+
+func NewScaledInstantProfile(p InstantProfile, ratio float64) InstantProfile {
+	return &ScaledInstantProfile{
+		p:     p,
+		ratio: ratio,
+	}
+}
+
+func (p *ScaledInstantProfile) ProfileMeta() InstantProfileMeta {
+	return p.p.ProfileMeta()
+}
+
+func (p *ScaledInstantProfile) Samples() map[string]*Sample {
+	samples := p.p.Samples()
+	for _, s := range samples {
+		s.Value = int64(p.ratio * float64(s.Value))
+	}
+	return samples
+}

--- a/pkg/profile/profile_flat.go
+++ b/pkg/profile/profile_flat.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package storage
+package profile
 
 import (
 	"context"
@@ -59,8 +59,8 @@ func FlatProfileFromPprof(ctx context.Context, logger log.Logger, metaStore meta
 	}
 
 	return &FlatProfile{
-		Meta:    ProfileMetaFromPprof(p, sampleIndex),
-		samples: pfn.samples,
+		Meta:        ProfileMetaFromPprof(p, sampleIndex),
+		FlatSamples: pfn.samples,
 	}, nil
 }
 
@@ -116,7 +116,7 @@ func (pn *profileFlatNormalizer) mapSample(ctx context.Context, src *profile.Sam
 	// Check memoization table. Must be done on the remapped location to
 	// account for the remapped mapping. Add current values to the
 	// existing sample.
-	k := makeStacktraceKey(s)
+	k := MakeStacktraceKey(s)
 
 	stacktraceUUID, err := pn.metaStore.GetStacktraceByKey(ctx, k)
 	if err != nil && err != metastore.ErrStacktraceNotFound {

--- a/pkg/profile/profile_flat_test.go
+++ b/pkg/profile/profile_flat_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package storage
+package profile
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 )
 
 func TestProfileFlatNormalizer(t *testing.T) {
-	f, err := os.Open("testdata/profile1.pb.gz")
+	f, err := os.Open("../storage/testdata/profile1.pb.gz")
 	require.NoError(t, err)
 	p1, err := profile.Parse(f)
 	require.NoError(t, err)
@@ -38,7 +38,7 @@ func TestProfileFlatNormalizer(t *testing.T) {
 		log.NewNopLogger(),
 		prometheus.NewRegistry(),
 		trace.NewNoopTracerProvider().Tracer(""),
-		NewLinearUUIDGenerator(),
+		metastore.NewLinearUUIDGenerator(),
 	)
 	t.Cleanup(func() {
 		l.Close()

--- a/pkg/profile/profile_normalizer.go
+++ b/pkg/profile/profile_normalizer.go
@@ -11,33 +11,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package storage
+package profile
 
 import (
 	"sort"
 
 	pb "github.com/parca-dev/parca/gen/proto/go/parca/metastore/v1alpha1"
-	"github.com/parca-dev/parca/pkg/storage/metastore"
 )
-
-type Sample struct {
-	Location  []*metastore.Location
-	Value     int64
-	DiffValue int64
-	Label     map[string][]string
-	NumLabel  map[string][]int64
-	NumUnit   map[string][]string
-}
 
 type mapInfo struct {
 	m      *pb.Mapping
 	offset int64
 }
 
-type stacktraceKey []byte
+type StacktraceKey []byte
 
-// key generates stacktraceKey to be used as a key for maps.
-func makeStacktraceKey(sample *Sample) stacktraceKey {
+// MakeStacktraceKey generates stacktraceKey to be used as a key for maps.
+func MakeStacktraceKey(sample *Sample) StacktraceKey {
 	numLocations := len(sample.Location)
 	if numLocations == 0 {
 		return []byte{}

--- a/pkg/profile/profile_normalizer_test.go
+++ b/pkg/profile/profile_normalizer_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package storage
+package profile
 
 import (
 	"testing"
@@ -21,7 +21,7 @@ import (
 )
 
 func TestMakeStacktraceKey(t *testing.T) {
-	g := NewLinearUUIDGenerator()
+	g := metastore.NewLinearUUIDGenerator()
 
 	s := &Sample{
 		Location: []*metastore.Location{{ID: g.New()}, {ID: g.New()}, {ID: g.New()}},
@@ -30,7 +30,7 @@ func TestMakeStacktraceKey(t *testing.T) {
 		NumUnit:  map[string][]string{"foo": {"cpu", "memory"}},
 	}
 
-	k := []byte(makeStacktraceKey(s))
+	k := []byte(MakeStacktraceKey(s))
 
 	require.Len(t, k, 119)
 
@@ -64,7 +64,7 @@ func TestMakeStacktraceKey(t *testing.T) {
 }
 
 func BenchmarkMakeStacktraceKey(b *testing.B) {
-	g := NewLinearUUIDGenerator()
+	g := metastore.NewLinearUUIDGenerator()
 	s := &Sample{
 		Location: []*metastore.Location{{ID: g.New()}, {ID: g.New()}, {ID: g.New()}},
 		Label:    map[string][]string{"foo": {"bar", "baz"}},
@@ -76,6 +76,6 @@ func BenchmarkMakeStacktraceKey(b *testing.B) {
 	b.StartTimer()
 
 	for i := 0; i < b.N; i++ {
-		_ = makeStacktraceKey(s)
+		_ = MakeStacktraceKey(s)
 	}
 }

--- a/pkg/profilestore/profilestore.go
+++ b/pkg/profilestore/profilestore.go
@@ -28,6 +28,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	profilestorepb "github.com/parca-dev/parca/gen/proto/go/parca/profilestore/v1alpha1"
+	parcaprofile "github.com/parca-dev/parca/pkg/profile"
 	"github.com/parca-dev/parca/pkg/storage"
 )
 
@@ -80,7 +81,7 @@ func (s *ProfileStore) WriteRaw(ctx context.Context, r *profilestorepb.WriteRawR
 			}
 
 			convertCtx, convertSpan := s.tracer.Start(ctx, "profile-from-pprof")
-			profiles, err := storage.FlatProfilesFromPprof(convertCtx, s.logger, s.metaStore, p)
+			profiles, err := parcaprofile.FlatProfilesFromPprof(convertCtx, s.logger, s.metaStore, p)
 			if err != nil {
 				return nil, status.Errorf(codes.Internal, "failed to normalize pprof: %v", err)
 			}

--- a/pkg/query/query_test.go
+++ b/pkg/query/query_test.go
@@ -35,6 +35,7 @@ import (
 
 	profilestore "github.com/parca-dev/parca/gen/proto/go/parca/profilestore/v1alpha1"
 	pb "github.com/parca-dev/parca/gen/proto/go/parca/query/v1alpha1"
+	parcaprofile "github.com/parca-dev/parca/pkg/profile"
 	"github.com/parca-dev/parca/pkg/storage"
 )
 
@@ -97,7 +98,7 @@ func Test_QueryRange_Valid(t *testing.T) {
 	// Overwrite the profile's timestamp to be within the last 5min.
 	p.TimeNanos = time.Now().UnixNano()
 
-	prof, err := storage.FlatProfileFromPprof(ctx, log.NewNopLogger(), s, p, 0)
+	prof, err := parcaprofile.FlatProfileFromPprof(ctx, log.NewNopLogger(), s, p, 0)
 	require.NoError(t, err)
 	err = app.AppendFlat(ctx, prof)
 	require.NoError(t, err)
@@ -168,7 +169,7 @@ func Test_QueryRange_Limited(t *testing.T) {
 		// Overwrite the profile's timestamp to be within the last 5min.
 		p.TimeNanos = time.Now().UnixNano()
 
-		prof, err := storage.FlatProfileFromPprof(ctx, log.NewNopLogger(), s, p, 0)
+		prof, err := parcaprofile.FlatProfileFromPprof(ctx, log.NewNopLogger(), s, p, 0)
 		require.NoError(t, err)
 		err = app.AppendFlat(ctx, prof)
 		require.NoError(t, err)
@@ -224,7 +225,7 @@ func Test_QueryRange_Ranged(t *testing.T) {
 
 	for i := 0; i < 500; i++ {
 		p.TimeNanos = start.Add(time.Duration(i) * time.Second).UnixNano()
-		pprof, err := storage.FlatProfileFromPprof(ctx, logger, s, p, 0)
+		pprof, err := parcaprofile.FlatProfileFromPprof(ctx, logger, s, p, 0)
 		require.NoError(t, err)
 		err = app.AppendFlat(ctx, pprof)
 		require.NoError(t, err)
@@ -397,7 +398,7 @@ func Test_Query_Simple(t *testing.T) {
 	t1 := (time.Now().UnixNano() / 1000000) * 1000000
 	p1.TimeNanos = t1
 
-	prof, err := storage.FlatProfileFromPprof(ctx, log.NewNopLogger(), s, p1, 0)
+	prof, err := parcaprofile.FlatProfileFromPprof(ctx, log.NewNopLogger(), s, p1, 0)
 	require.NoError(t, err)
 	err = app.AppendFlat(ctx, prof)
 	require.NoError(t, err)
@@ -462,7 +463,7 @@ func Test_Query_Diff(t *testing.T) {
 	t1 := (time.Now().UnixNano() / 1000000) * 1000000
 	p1.TimeNanos = t1
 
-	prof1, err := storage.FlatProfileFromPprof(ctx, log.NewNopLogger(), s, p1, 0)
+	prof1, err := parcaprofile.FlatProfileFromPprof(ctx, log.NewNopLogger(), s, p1, 0)
 	require.NoError(t, err)
 	err = app.AppendFlat(ctx, prof1)
 	require.NoError(t, err)
@@ -472,7 +473,7 @@ func Test_Query_Diff(t *testing.T) {
 	t2 := (time.Now().UnixNano() / 1000000) * 1000000
 	p2.TimeNanos = t2
 
-	prof2, err := storage.FlatProfileFromPprof(ctx, log.NewNopLogger(), s, p2, 0)
+	prof2, err := parcaprofile.FlatProfileFromPprof(ctx, log.NewNopLogger(), s, p2, 0)
 	require.NoError(t, err)
 	err = app.AppendFlat(ctx, prof2)
 	require.NoError(t, err)
@@ -528,7 +529,7 @@ func Benchmark_Query_Merge(b *testing.B) {
 	require.NoError(b, err)
 	require.NoError(b, f.Close())
 
-	p, err := storage.FlatProfileFromPprof(ctx, log.NewNopLogger(), s, p1, 0)
+	p, err := parcaprofile.FlatProfileFromPprof(ctx, log.NewNopLogger(), s, p1, 0)
 	require.NoError(b, err)
 
 	for k := 0.; k <= 10; k++ {
@@ -596,7 +597,7 @@ func Test_Query_Merge(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	p, err := storage.FlatProfileFromPprof(ctx, log.NewNopLogger(), s, p1, 0)
+	p, err := parcaprofile.FlatProfileFromPprof(ctx, log.NewNopLogger(), s, p1, 0)
 	require.NoError(t, err)
 
 	for k := 0.; k <= 10; k++ {
@@ -704,7 +705,7 @@ func Test_QueryRange_MultipleLabels_NoMatch(t *testing.T) {
 
 		p1.TimeNanos = t1
 
-		prof, err := storage.FlatProfileFromPprof(ctx, log.NewNopLogger(), s, p1, 0)
+		prof, err := parcaprofile.FlatProfileFromPprof(ctx, log.NewNopLogger(), s, p1, 0)
 		require.NoError(t, err)
 		err = app.AppendFlat(ctx, prof)
 		require.NoError(t, err)

--- a/pkg/storage/benchmark_test.go
+++ b/pkg/storage/benchmark_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/google/pprof/profile"
+	parcaprofile "github.com/parca-dev/parca/pkg/profile"
 	"github.com/parca-dev/parca/pkg/storage"
 	"github.com/parca-dev/parca/pkg/storage/metastore"
 	"github.com/prometheus/client_golang/prometheus"
@@ -119,7 +120,7 @@ func BenchmarkAppends(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		p := profiles[i%len(profiles)]
-		pprof, err := storage.FlatProfileFromPprof(ctx, logger, l, p, 0)
+		pprof, err := parcaprofile.FlatProfileFromPprof(ctx, logger, l, p, 0)
 		require.NoError(b, err)
 		err = app.AppendFlat(ctx, pprof)
 		require.NoError(b, err)
@@ -158,7 +159,7 @@ func BenchmarkIterator(b *testing.B) {
 	require.NoError(b, err)
 	for i := 0; i < b.N; i++ {
 		pprof := profiles[i%len(profiles)]
-		p, err := storage.FlatProfileFromPprof(ctx, logger, l, pprof, 0)
+		p, err := parcaprofile.FlatProfileFromPprof(ctx, logger, l, pprof, 0)
 		require.NoError(b, err)
 		err = app.AppendFlat(ctx, p)
 		require.NoError(b, err)

--- a/pkg/storage/db.go
+++ b/pkg/storage/db.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/parca-dev/parca/pkg/profile"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/pkg/timestamp"
@@ -94,7 +95,7 @@ type Labels interface {
 }
 
 type Appender interface {
-	AppendFlat(ctx context.Context, p *FlatProfile) error
+	AppendFlat(ctx context.Context, p *profile.FlatProfile) error
 }
 
 type SliceSeriesSet struct {

--- a/pkg/storage/db_test.go
+++ b/pkg/storage/db_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/google/pprof/profile"
+	parcaprofile "github.com/parca-dev/parca/pkg/profile"
 	"github.com/parca-dev/parca/pkg/storage/metastore"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/pkg/labels"
@@ -51,7 +52,7 @@ func TestDB(t *testing.T) {
 	p, err := profile.Parse(b)
 	require.NoError(t, err)
 
-	prof1, err := FlatProfileFromPprof(ctx, log.NewNopLogger(), l, p, 0)
+	prof1, err := parcaprofile.FlatProfileFromPprof(ctx, log.NewNopLogger(), l, p, 0)
 	require.NoError(t, err)
 	require.NoError(t, app1.AppendFlat(ctx, prof1))
 
@@ -64,7 +65,7 @@ func TestDB(t *testing.T) {
 	p, err = profile.Parse(b)
 	require.NoError(t, err)
 
-	prof2, err := FlatProfileFromPprof(ctx, log.NewNopLogger(), l, p, 0)
+	prof2, err := parcaprofile.FlatProfileFromPprof(ctx, log.NewNopLogger(), l, p, 0)
 	require.NoError(t, err)
 	require.NoError(t, app2.AppendFlat(ctx, prof2))
 

--- a/pkg/storage/diff.go
+++ b/pkg/storage/diff.go
@@ -15,6 +15,8 @@ package storage
 
 import (
 	"errors"
+
+	"github.com/parca-dev/parca/pkg/profile"
 )
 
 var (
@@ -23,13 +25,13 @@ var (
 )
 
 type DiffProfile struct {
-	base    InstantProfile
-	compare InstantProfile
+	base    profile.InstantProfile
+	compare profile.InstantProfile
 
-	meta InstantProfileMeta
+	meta profile.InstantProfileMeta
 }
 
-func NewDiffProfile(base, compare InstantProfile) (*DiffProfile, error) {
+func NewDiffProfile(base, compare profile.InstantProfile) (*DiffProfile, error) {
 	baseMeta := base.ProfileMeta()
 	compareMeta := compare.ProfileMeta()
 
@@ -44,22 +46,22 @@ func NewDiffProfile(base, compare InstantProfile) (*DiffProfile, error) {
 	return &DiffProfile{
 		base:    base,
 		compare: compare,
-		meta: InstantProfileMeta{
+		meta: profile.InstantProfileMeta{
 			PeriodType: baseMeta.PeriodType,
 			SampleType: baseMeta.SampleType,
 		},
 	}, nil
 }
 
-func (d *DiffProfile) ProfileMeta() InstantProfileMeta {
+func (d *DiffProfile) ProfileMeta() profile.InstantProfileMeta {
 	return d.meta
 }
 
-func (d *DiffProfile) Samples() map[string]*Sample {
+func (d *DiffProfile) Samples() map[string]*profile.Sample {
 	bs := d.base.Samples()
 	cs := d.compare.Samples()
 
-	ss := make(map[string]*Sample, len(bs))
+	ss := make(map[string]*profile.Sample, len(bs))
 
 	for k, s := range cs {
 		if sb, ok := bs[k]; ok {

--- a/pkg/storage/diff_flat_test.go
+++ b/pkg/storage/diff_flat_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/google/pprof/profile"
 	"github.com/google/uuid"
+	parcaprofile "github.com/parca-dev/parca/pkg/profile"
 	"github.com/parca-dev/parca/pkg/storage/metastore"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
@@ -36,15 +37,15 @@ func TestDiffFlatProfileSimple(t *testing.T) {
 	s1 := makeSample(3, []uuid.UUID{uuid2, uuid1})
 	k1 := uuid.MustParse("00000000-0000-0000-0000-0000000000e1")
 
-	p1 := &FlatProfile{
-		Meta: InstantProfileMeta{
-			PeriodType: ValueType{Type: "cpu", Unit: "cycles"},
-			SampleType: ValueType{Type: "numSamples", Unit: "count"},
+	p1 := &parcaprofile.FlatProfile{
+		Meta: parcaprofile.InstantProfileMeta{
+			PeriodType: parcaprofile.ValueType{Type: "cpu", Unit: "cycles"},
+			SampleType: parcaprofile.ValueType{Type: "numSamples", Unit: "count"},
 			Timestamp:  1,
 			Duration:   int64(time.Second * 10),
 			Period:     100,
 		},
-		samples: map[string]*Sample{
+		FlatSamples: map[string]*parcaprofile.Sample{
 			string(k1[:]): s1,
 		},
 	}
@@ -52,30 +53,30 @@ func TestDiffFlatProfileSimple(t *testing.T) {
 	s2 := makeSample(1, []uuid.UUID{uuid3, uuid1})
 	k2 := uuid.MustParse("00000000-0000-0000-0000-0000000000e2")
 
-	p2 := &FlatProfile{
-		Meta: InstantProfileMeta{
-			PeriodType: ValueType{Type: "cpu", Unit: "cycles"},
-			SampleType: ValueType{Type: "numSamples", Unit: "count"},
+	p2 := &parcaprofile.FlatProfile{
+		Meta: parcaprofile.InstantProfileMeta{
+			PeriodType: parcaprofile.ValueType{Type: "cpu", Unit: "cycles"},
+			SampleType: parcaprofile.ValueType{Type: "numSamples", Unit: "count"},
 			Timestamp:  1,
 			Duration:   int64(time.Second * 10),
 			Period:     100,
 		},
-		samples: map[string]*Sample{
+		FlatSamples: map[string]*parcaprofile.Sample{
 			string(k2[:]): s2,
 		},
 	}
 
 	dp, err := NewDiffProfile(p1, p2)
 	require.NoError(t, err)
-	require.Equal(t, InstantProfileMeta{
-		PeriodType: ValueType{Type: "cpu", Unit: "cycles"},
-		SampleType: ValueType{Type: "numSamples", Unit: "count"},
+	require.Equal(t, parcaprofile.InstantProfileMeta{
+		PeriodType: parcaprofile.ValueType{Type: "cpu", Unit: "cycles"},
+		SampleType: parcaprofile.ValueType{Type: "numSamples", Unit: "count"},
 	}, dp.ProfileMeta())
 
 	diffed := dp.Samples()
 	require.Len(t, diffed, 1)
 
-	require.Equal(t, &Sample{
+	require.Equal(t, &parcaprofile.Sample{
 		Value:     1,
 		DiffValue: 0,
 		Location:  []*metastore.Location{{ID: uuid3}, {ID: uuid1}},
@@ -98,15 +99,15 @@ func TestDiffFlatProfileDeep(t *testing.T) {
 	k2 := uuid.MustParse("00000000-0000-0000-0000-0000000000e2")
 	k3 := uuid.MustParse("00000000-0000-0000-0000-0000000000e3")
 
-	p1 := &FlatProfile{
-		Meta: InstantProfileMeta{
-			PeriodType: ValueType{Type: "cpu", Unit: "cycles"},
-			SampleType: ValueType{Type: "numSamples", Unit: "count"},
+	p1 := &parcaprofile.FlatProfile{
+		Meta: parcaprofile.InstantProfileMeta{
+			PeriodType: parcaprofile.ValueType{Type: "cpu", Unit: "cycles"},
+			SampleType: parcaprofile.ValueType{Type: "numSamples", Unit: "count"},
 			Timestamp:  1,
 			Duration:   int64(time.Second * 10),
 			Period:     100,
 		},
-		samples: map[string]*Sample{
+		FlatSamples: map[string]*parcaprofile.Sample{
 			string(k0[:]): s0,
 			string(k1[:]): s1,
 			string(k2[:]): s2,
@@ -119,15 +120,15 @@ func TestDiffFlatProfileDeep(t *testing.T) {
 
 	k4 := uuid.MustParse("00000000-0000-0000-0000-0000000000e4")
 
-	p2 := &FlatProfile{
-		Meta: InstantProfileMeta{
-			PeriodType: ValueType{Type: "cpu", Unit: "cycles"},
-			SampleType: ValueType{Type: "numSamples", Unit: "count"},
+	p2 := &parcaprofile.FlatProfile{
+		Meta: parcaprofile.InstantProfileMeta{
+			PeriodType: parcaprofile.ValueType{Type: "cpu", Unit: "cycles"},
+			SampleType: parcaprofile.ValueType{Type: "numSamples", Unit: "count"},
 			Timestamp:  1,
 			Duration:   int64(time.Second * 10),
 			Period:     100,
 		},
-		samples: map[string]*Sample{
+		FlatSamples: map[string]*parcaprofile.Sample{
 			string(k4[:]): s4,
 			string(k2[:]): s5,
 		},
@@ -135,20 +136,20 @@ func TestDiffFlatProfileDeep(t *testing.T) {
 
 	dp, err := NewDiffProfile(p1, p2)
 	require.NoError(t, err)
-	require.Equal(t, InstantProfileMeta{
-		PeriodType: ValueType{Type: "cpu", Unit: "cycles"},
-		SampleType: ValueType{Type: "numSamples", Unit: "count"},
+	require.Equal(t, parcaprofile.InstantProfileMeta{
+		PeriodType: parcaprofile.ValueType{Type: "cpu", Unit: "cycles"},
+		SampleType: parcaprofile.ValueType{Type: "numSamples", Unit: "count"},
 	}, dp.ProfileMeta())
 
 	diffed := dp.Samples()
 	require.Len(t, diffed, 2)
 
-	require.Equal(t, &Sample{
+	require.Equal(t, &parcaprofile.Sample{
 		Value:     3,
 		DiffValue: 0,
 		Location:  []*metastore.Location{{ID: uuid3}, {ID: uuid2}, {ID: uuid2}},
 	}, diffed[string(k4[:])])
-	require.Equal(t, &Sample{
+	require.Equal(t, &parcaprofile.Sample{
 		Value:     5,
 		DiffValue: 2,
 		Location:  []*metastore.Location{{ID: uuid2}, {ID: uuid3}},
@@ -181,9 +182,9 @@ func BenchmarkFlatDiff(b *testing.B) {
 	b.Cleanup(func() {
 		l.Close()
 	})
-	profile1, err := FlatProfileFromPprof(ctx, log.NewNopLogger(), l, p1, 0)
+	profile1, err := parcaprofile.FlatProfileFromPprof(ctx, log.NewNopLogger(), l, p1, 0)
 	require.NoError(b, err)
-	profile2, err := FlatProfileFromPprof(ctx, log.NewNopLogger(), l, p2, 0)
+	profile2, err := parcaprofile.FlatProfileFromPprof(ctx, log.NewNopLogger(), l, p2, 0)
 	require.NoError(b, err)
 
 	b.Run("simple", func(b *testing.B) {
@@ -193,7 +194,7 @@ func BenchmarkFlatDiff(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			d, err := NewDiffProfile(profile1, profile2)
 			require.NoError(b, err)
-			CopyInstantFlatProfile(d)
+			parcaprofile.CopyInstantFlatProfile(d)
 		}
 	})
 }

--- a/pkg/storage/flamegraph_flat.go
+++ b/pkg/storage/flamegraph_flat.go
@@ -20,29 +20,12 @@ import (
 	"sort"
 
 	pb "github.com/parca-dev/parca/gen/proto/go/parca/query/v1alpha1"
+	"github.com/parca-dev/parca/pkg/profile"
 	"github.com/parca-dev/parca/pkg/storage/metastore"
 	"go.opentelemetry.io/otel/trace"
 )
 
-type InstantFlatProfile interface {
-	ProfileMeta() InstantProfileMeta
-	Samples() map[string]*Sample
-}
-
-type FlatProfile struct {
-	Meta    InstantProfileMeta
-	samples map[string]*Sample
-}
-
-func (fp *FlatProfile) ProfileMeta() InstantProfileMeta {
-	return fp.Meta
-}
-
-func (fp *FlatProfile) Samples() map[string]*Sample {
-	return fp.samples
-}
-
-func GenerateFlamegraphFlat(ctx context.Context, tracer trace.Tracer, metaStore metastore.ProfileMetaStore, p InstantFlatProfile) (*pb.Flamegraph, error) {
+func GenerateFlamegraphFlat(ctx context.Context, tracer trace.Tracer, metaStore metastore.ProfileMetaStore, p profile.InstantFlatProfile) (*pb.Flamegraph, error) {
 	rootNode := &pb.FlamegraphNode{}
 	current := rootNode
 

--- a/pkg/storage/head.go
+++ b/pkg/storage/head.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/parca-dev/parca/pkg/profile"
 	"github.com/parca-dev/parca/pkg/storage/chunkenc"
 	"github.com/parca-dev/parca/pkg/storage/index"
 	"github.com/prometheus/client_golang/prometheus"
@@ -239,7 +240,7 @@ type initAppender struct {
 	head *Head
 }
 
-func (a *initAppender) AppendFlat(ctx context.Context, p *FlatProfile) error {
+func (a *initAppender) AppendFlat(ctx context.Context, p *profile.FlatProfile) error {
 	if a.app != nil {
 		return a.app.AppendFlat(ctx, p)
 	}

--- a/pkg/storage/head_read_test.go
+++ b/pkg/storage/head_read_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/parca-dev/parca/pkg/profile"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/stretchr/testify/require"
@@ -49,8 +50,8 @@ func TestHeadIndexReader_LabelValues(t *testing.T) {
 			{Name: "tens", Value: fmt.Sprintf("value%d", i/10)},
 		})
 		require.NoError(t, err)
-		err = app.AppendFlat(ctx, &FlatProfile{
-			Meta: InstantProfileMeta{
+		err = app.AppendFlat(ctx, &profile.FlatProfile{
+			Meta: profile.InstantProfileMeta{
 				Timestamp: int64(100 + i),
 			},
 		})

--- a/pkg/storage/head_test.go
+++ b/pkg/storage/head_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/parca-dev/parca/pkg/profile"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/stretchr/testify/require"
@@ -36,12 +37,12 @@ func TestHead_MaxTime(t *testing.T) {
 		uuid.MustParse("00000000-0000-0000-0000-000000000002"),
 		uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 	})
-	k := makeStacktraceKey(s)
+	k := profile.MakeStacktraceKey(s)
 
 	for i := int64(1); i < 500; i++ {
-		require.NoError(t, app.AppendFlat(ctx, &FlatProfile{
-			Meta:    InstantProfileMeta{Timestamp: i},
-			samples: map[string]*Sample{string(k): s},
+		require.NoError(t, app.AppendFlat(ctx, &profile.FlatProfile{
+			Meta:        profile.InstantProfileMeta{Timestamp: i},
+			FlatSamples: map[string]*profile.Sample{string(k): s},
 		}))
 		require.Equal(t, i, h.MaxTime())
 	}
@@ -131,7 +132,7 @@ func TestHead_Truncate(t *testing.T) {
 		uuid.MustParse("00000000-0000-0000-0000-000000000002"),
 		uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 	})
-	k := makeStacktraceKey(s)
+	k := profile.MakeStacktraceKey(s)
 
 	ctx := context.Background()
 	{
@@ -139,9 +140,9 @@ func TestHead_Truncate(t *testing.T) {
 		require.NoError(t, err)
 
 		for i := int64(1); i <= 500; i++ {
-			require.NoError(t, app.AppendFlat(ctx, &FlatProfile{
-				Meta:    InstantProfileMeta{Timestamp: i},
-				samples: map[string]*Sample{string(k): s},
+			require.NoError(t, app.AppendFlat(ctx, &profile.FlatProfile{
+				Meta:        profile.InstantProfileMeta{Timestamp: i},
+				FlatSamples: map[string]*profile.Sample{string(k): s},
 			}))
 		}
 	}
@@ -150,9 +151,9 @@ func TestHead_Truncate(t *testing.T) {
 		require.NoError(t, err)
 
 		for i := int64(100); i < 768; i++ {
-			require.NoError(t, app.AppendFlat(ctx, &FlatProfile{
-				Meta:    InstantProfileMeta{Timestamp: i},
-				samples: map[string]*Sample{string(k): s},
+			require.NoError(t, app.AppendFlat(ctx, &profile.FlatProfile{
+				Meta:        profile.InstantProfileMeta{Timestamp: i},
+				FlatSamples: map[string]*profile.Sample{string(k): s},
 			}))
 		}
 	}

--- a/pkg/storage/interface_test.go
+++ b/pkg/storage/interface_test.go
@@ -17,12 +17,13 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/parca-dev/parca/pkg/profile"
 	"github.com/parca-dev/parca/pkg/storage/metastore"
 	"github.com/stretchr/testify/require"
 )
 
-func makeSample(value int64, locationIds []uuid.UUID) *Sample {
-	s := &Sample{
+func makeSample(value int64, locationIds []uuid.UUID) *profile.Sample {
+	s := &profile.Sample{
 		Value: value,
 	}
 
@@ -50,19 +51,19 @@ func TestScaledInstantProfile(t *testing.T) {
 		uuid.MustParse("00000000-0000-0000-0000-000000000002"),
 		uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 	})
-	k1 := makeStacktraceKey(s1)
-	k2 := makeStacktraceKey(s2)
-	k3 := makeStacktraceKey(s3)
+	k1 := profile.MakeStacktraceKey(s1)
+	k2 := profile.MakeStacktraceKey(s2)
+	k3 := profile.MakeStacktraceKey(s3)
 
-	p := &FlatProfile{
-		samples: map[string]*Sample{
+	p := &profile.FlatProfile{
+		FlatSamples: map[string]*profile.Sample{
 			string(k1): s1,
 			string(k2): s2,
 			string(k3): s3,
 		},
 	}
 
-	sp := NewScaledInstantProfile(p, -1)
+	sp := profile.NewScaledInstantProfile(p, -1)
 
 	expected := map[string]int64{
 		string(k1): -2,
@@ -77,7 +78,7 @@ func TestScaledInstantProfile(t *testing.T) {
 func TestSliceProfileSeriesIterator(t *testing.T) {
 	it := &SliceProfileSeriesIterator{
 		i:       -1,
-		samples: []InstantProfile{&FlatProfile{}},
+		samples: []profile.InstantProfile{&profile.FlatProfile{}},
 	}
 
 	require.True(t, it.Next())

--- a/pkg/storage/merge_flat_test.go
+++ b/pkg/storage/merge_flat_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/google/pprof/profile"
 	"github.com/google/uuid"
+	parcaprofile "github.com/parca-dev/parca/pkg/profile"
 	"github.com/parca-dev/parca/pkg/storage/metastore"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
@@ -38,15 +39,15 @@ func TestMergeFlatProfileSimple(t *testing.T) {
 	s1 := makeSample(2, []uuid.UUID{uuid2, uuid1})
 	k1 := uuid.MustParse("00000000-0000-0000-0000-0000000000e1")
 
-	p1 := &FlatProfile{
-		Meta: InstantProfileMeta{
-			PeriodType: ValueType{Type: "cpu", Unit: "cycles"},
-			SampleType: ValueType{Type: "numSamples", Unit: "count"},
+	p1 := &parcaprofile.FlatProfile{
+		Meta: parcaprofile.InstantProfileMeta{
+			PeriodType: parcaprofile.ValueType{Type: "cpu", Unit: "cycles"},
+			SampleType: parcaprofile.ValueType{Type: "numSamples", Unit: "count"},
 			Timestamp:  1,
 			Duration:   int64(time.Second * 10),
 			Period:     100,
 		},
-		samples: map[string]*Sample{
+		FlatSamples: map[string]*parcaprofile.Sample{
 			string(k1[:]): s1,
 		},
 	}
@@ -54,24 +55,24 @@ func TestMergeFlatProfileSimple(t *testing.T) {
 	s2 := makeSample(1, []uuid.UUID{uuid3, uuid1})
 	k2 := uuid.MustParse("00000000-0000-0000-0000-0000000000e2")
 
-	p2 := &FlatProfile{
-		Meta: InstantProfileMeta{
-			PeriodType: ValueType{Type: "cpu", Unit: "cycles"},
-			SampleType: ValueType{Type: "numSamples", Unit: "count"},
+	p2 := &parcaprofile.FlatProfile{
+		Meta: parcaprofile.InstantProfileMeta{
+			PeriodType: parcaprofile.ValueType{Type: "cpu", Unit: "cycles"},
+			SampleType: parcaprofile.ValueType{Type: "numSamples", Unit: "count"},
 			Timestamp:  1,
 			Duration:   int64(time.Second * 10),
 			Period:     100,
 		},
-		samples: map[string]*Sample{
+		FlatSamples: map[string]*parcaprofile.Sample{
 			string(k2[:]): s2,
 		},
 	}
 
 	mp, err := MergeProfiles(p1, p2)
 	require.NoError(t, err)
-	require.Equal(t, InstantProfileMeta{
-		PeriodType: ValueType{Type: "cpu", Unit: "cycles"},
-		SampleType: ValueType{Type: "numSamples", Unit: "count"},
+	require.Equal(t, parcaprofile.InstantProfileMeta{
+		PeriodType: parcaprofile.ValueType{Type: "cpu", Unit: "cycles"},
+		SampleType: parcaprofile.ValueType{Type: "numSamples", Unit: "count"},
 		Timestamp:  1,
 		Duration:   int64(time.Second * 20),
 		Period:     100,
@@ -80,11 +81,11 @@ func TestMergeFlatProfileSimple(t *testing.T) {
 	merged := mp.Samples()
 	require.Len(t, merged, 2)
 
-	require.Equal(t, &Sample{
+	require.Equal(t, &parcaprofile.Sample{
 		Value:    2,
 		Location: []*metastore.Location{{ID: uuid2}, {ID: uuid1}},
 	}, merged[string(k1[:])])
-	require.Equal(t, &Sample{
+	require.Equal(t, &parcaprofile.Sample{
 		Value:    1,
 		Location: []*metastore.Location{{ID: uuid3}, {ID: uuid1}},
 	}, merged[string(k2[:])])
@@ -106,15 +107,15 @@ func TestMergeFlatProfileDeep(t *testing.T) {
 	k3 := uuid.MustParse("00000000-0000-0000-0000-0000000000e3")
 	k4 := uuid.MustParse("00000000-0000-0000-0000-0000000000e4")
 
-	p1 := &FlatProfile{
-		Meta: InstantProfileMeta{
-			PeriodType: ValueType{Type: "cpu", Unit: "cycles"},
-			SampleType: ValueType{Type: "numSamples", Unit: "count"},
+	p1 := &parcaprofile.FlatProfile{
+		Meta: parcaprofile.InstantProfileMeta{
+			PeriodType: parcaprofile.ValueType{Type: "cpu", Unit: "cycles"},
+			SampleType: parcaprofile.ValueType{Type: "numSamples", Unit: "count"},
 			Timestamp:  1,
 			Duration:   int64(time.Second * 10),
 			Period:     100,
 		},
-		samples: map[string]*Sample{
+		FlatSamples: map[string]*parcaprofile.Sample{
 			string(k1[:]): s1,
 			string(k2[:]): s2,
 			string(k3[:]): s3,
@@ -125,24 +126,24 @@ func TestMergeFlatProfileDeep(t *testing.T) {
 	s5 := makeSample(3, []uuid.UUID{uuid3, uuid2, uuid2})
 	k5 := uuid.MustParse("00000000-0000-0000-0000-0000000000e5")
 
-	p2 := &FlatProfile{
-		Meta: InstantProfileMeta{
-			PeriodType: ValueType{Type: "cpu", Unit: "cycles"},
-			SampleType: ValueType{Type: "numSamples", Unit: "count"},
+	p2 := &parcaprofile.FlatProfile{
+		Meta: parcaprofile.InstantProfileMeta{
+			PeriodType: parcaprofile.ValueType{Type: "cpu", Unit: "cycles"},
+			SampleType: parcaprofile.ValueType{Type: "numSamples", Unit: "count"},
 			Timestamp:  1,
 			Duration:   int64(time.Second * 10),
 			Period:     100,
 		},
-		samples: map[string]*Sample{
+		FlatSamples: map[string]*parcaprofile.Sample{
 			string(k5[:]): s5,
 		},
 	}
 
 	mp, err := MergeProfiles(p1, p2)
 	require.NoError(t, err)
-	require.Equal(t, InstantProfileMeta{
-		PeriodType: ValueType{Type: "cpu", Unit: "cycles"},
-		SampleType: ValueType{Type: "numSamples", Unit: "count"},
+	require.Equal(t, parcaprofile.InstantProfileMeta{
+		PeriodType: parcaprofile.ValueType{Type: "cpu", Unit: "cycles"},
+		SampleType: parcaprofile.ValueType{Type: "numSamples", Unit: "count"},
 		Timestamp:  1,
 		Duration:   int64(time.Second * 20),
 		Period:     100,
@@ -152,23 +153,23 @@ func TestMergeFlatProfileDeep(t *testing.T) {
 
 	require.Len(t, merged, 5)
 
-	require.Equal(t, &Sample{
+	require.Equal(t, &parcaprofile.Sample{
 		Value:    3,
 		Location: []*metastore.Location{{ID: uuid1}, {ID: uuid3}},
 	}, merged[string(k1[:])])
-	require.Equal(t, &Sample{
+	require.Equal(t, &parcaprofile.Sample{
 		Value:    3,
 		Location: []*metastore.Location{{ID: uuid2}, {ID: uuid3}},
 	}, merged[string(k2[:])])
-	require.Equal(t, &Sample{
+	require.Equal(t, &parcaprofile.Sample{
 		Value:    3,
 		Location: []*metastore.Location{{ID: uuid3}, {ID: uuid3}, {ID: uuid2}},
 	}, merged[string(k3[:])])
-	require.Equal(t, &Sample{
+	require.Equal(t, &parcaprofile.Sample{
 		Value:    3,
 		Location: []*metastore.Location{{ID: uuid6}, {ID: uuid2}},
 	}, merged[string(k4[:])])
-	require.Equal(t, &Sample{
+	require.Equal(t, &parcaprofile.Sample{
 		Value:    3,
 		Location: []*metastore.Location{{ID: uuid3}, {ID: uuid2}, {ID: uuid2}},
 	}, merged[string(k5[:])])
@@ -194,15 +195,15 @@ func TestMergeFlatProfile(t *testing.T) {
 	k4 := uuid.MustParse("00000000-0000-0000-0000-0000000000e4")
 	k5 := uuid.MustParse("00000000-0000-0000-0000-0000000000e5")
 
-	p1 := &FlatProfile{
-		Meta: InstantProfileMeta{
-			PeriodType: ValueType{Type: "cpu", Unit: "cycles"},
-			SampleType: ValueType{Type: "numSamples", Unit: "count"},
+	p1 := &parcaprofile.FlatProfile{
+		Meta: parcaprofile.InstantProfileMeta{
+			PeriodType: parcaprofile.ValueType{Type: "cpu", Unit: "cycles"},
+			SampleType: parcaprofile.ValueType{Type: "numSamples", Unit: "count"},
 			Timestamp:  1,
 			Duration:   int64(time.Second * 10),
 			Period:     100,
 		},
-		samples: map[string]*Sample{
+		FlatSamples: map[string]*parcaprofile.Sample{
 			string(k1[:]): s1,
 			string(k2[:]): s2,
 			string(k3[:]): s3,
@@ -217,15 +218,15 @@ func TestMergeFlatProfile(t *testing.T) {
 	k6 := uuid.MustParse("00000000-0000-0000-0000-0000000000e6")
 	k7 := uuid.MustParse("00000000-0000-0000-0000-0000000000e7")
 
-	p2 := &FlatProfile{
-		Meta: InstantProfileMeta{
-			PeriodType: ValueType{Type: "cpu", Unit: "cycles"},
-			SampleType: ValueType{Type: "numSamples", Unit: "count"},
+	p2 := &parcaprofile.FlatProfile{
+		Meta: parcaprofile.InstantProfileMeta{
+			PeriodType: parcaprofile.ValueType{Type: "cpu", Unit: "cycles"},
+			SampleType: parcaprofile.ValueType{Type: "numSamples", Unit: "count"},
 			Timestamp:  1,
 			Duration:   int64(time.Second * 10),
 			Period:     100,
 		},
-		samples: map[string]*Sample{
+		FlatSamples: map[string]*parcaprofile.Sample{
 			string(k1[:]): s1,
 			string(k3[:]): s3,
 			string(k6[:]): s6,
@@ -235,9 +236,9 @@ func TestMergeFlatProfile(t *testing.T) {
 
 	mp, err := MergeProfiles(p1, p2)
 	require.NoError(t, err)
-	require.Equal(t, InstantProfileMeta{
-		PeriodType: ValueType{Type: "cpu", Unit: "cycles"},
-		SampleType: ValueType{Type: "numSamples", Unit: "count"},
+	require.Equal(t, parcaprofile.InstantProfileMeta{
+		PeriodType: parcaprofile.ValueType{Type: "cpu", Unit: "cycles"},
+		SampleType: parcaprofile.ValueType{Type: "numSamples", Unit: "count"},
 		Timestamp:  1,
 		Duration:   int64(time.Second * 20),
 		Period:     100,
@@ -246,31 +247,31 @@ func TestMergeFlatProfile(t *testing.T) {
 	merged := mp.Samples()
 	require.Len(t, merged, 7)
 
-	require.Equal(t, &Sample{
+	require.Equal(t, &parcaprofile.Sample{
 		Value:    4, // 2 + 2
 		Location: []*metastore.Location{{ID: uuid2}, {ID: uuid1}},
 	}, merged[string(k1[:])])
-	require.Equal(t, &Sample{
+	require.Equal(t, &parcaprofile.Sample{
 		Value:    1,
 		Location: []*metastore.Location{{ID: uuid6}, {ID: uuid3}, {ID: uuid2}, {ID: uuid1}},
 	}, merged[string(k2[:])])
-	require.Equal(t, &Sample{
+	require.Equal(t, &parcaprofile.Sample{
 		Value:    6, // 3 + 3
 		Location: []*metastore.Location{{ID: uuid4}, {ID: uuid3}, {ID: uuid2}, {ID: uuid1}},
 	}, merged[string(k3[:])])
-	require.Equal(t, &Sample{
+	require.Equal(t, &parcaprofile.Sample{
 		Value:    3,
 		Location: []*metastore.Location{{ID: uuid3}, {ID: uuid3}, {ID: uuid2}},
 	}, merged[string(k4[:])])
-	require.Equal(t, &Sample{
+	require.Equal(t, &parcaprofile.Sample{
 		Value:    3,
 		Location: []*metastore.Location{{ID: uuid6}, {ID: uuid2}},
 	}, merged[string(k5[:])])
-	require.Equal(t, &Sample{
+	require.Equal(t, &parcaprofile.Sample{
 		Value:    1,
 		Location: []*metastore.Location{{ID: uuid5}, {ID: uuid3}, {ID: uuid2}, {ID: uuid1}},
 	}, merged[string(k6[:])])
-	require.Equal(t, &Sample{
+	require.Equal(t, &parcaprofile.Sample{
 		Value:    3,
 		Location: []*metastore.Location{{ID: uuid3}, {ID: uuid2}, {ID: uuid2}},
 	}, merged[string(k7[:])])
@@ -295,7 +296,7 @@ func TestMergeSingleFlat(t *testing.T) {
 		l.Close()
 	})
 	require.NoError(t, err)
-	prof, err := FlatProfileFromPprof(ctx, log.NewNopLogger(), l, p, 0)
+	prof, err := parcaprofile.FlatProfileFromPprof(ctx, log.NewNopLogger(), l, p, 0)
 	require.NoError(t, err)
 
 	m, err := MergeProfiles(prof)
@@ -322,18 +323,18 @@ func TestMergeManyFlat(t *testing.T) {
 		l.Close()
 	})
 	require.NoError(t, err)
-	prof, err := FlatProfileFromPprof(ctx, log.NewNopLogger(), l, p, 0)
+	prof, err := parcaprofile.FlatProfileFromPprof(ctx, log.NewNopLogger(), l, p, 0)
 	require.NoError(t, err)
 
 	num := 1000
-	profiles := make([]InstantProfile, 0, 1000)
+	profiles := make([]parcaprofile.InstantProfile, 0, 1000)
 	for i := 0; i < num; i++ {
 		profiles = append(profiles, prof)
 	}
 
 	m, err := MergeProfiles(profiles...)
 	require.NoError(t, err)
-	CopyInstantFlatProfile(m)
+	parcaprofile.CopyInstantFlatProfile(m)
 }
 
 func BenchmarkFlatMerge(b *testing.B) {
@@ -359,16 +360,16 @@ func BenchmarkFlatMerge(b *testing.B) {
 		l.Close()
 	})
 	require.NoError(b, err)
-	profile1, err := FlatProfileFromPprof(ctx, log.NewNopLogger(), l, p1, 0)
+	profile1, err := parcaprofile.FlatProfileFromPprof(ctx, log.NewNopLogger(), l, p1, 0)
 	require.NoError(b, err)
-	profile2, err := FlatProfileFromPprof(ctx, log.NewNopLogger(), l, p2, 0)
+	profile2, err := parcaprofile.FlatProfileFromPprof(ctx, log.NewNopLogger(), l, p2, 0)
 	require.NoError(b, err)
 
 	b.ReportAllocs()
 	b.ResetTimer()
 	m, err := MergeProfiles(profile1, profile2)
 	require.NoError(b, err)
-	CopyInstantFlatProfile(m)
+	parcaprofile.CopyInstantFlatProfile(m)
 }
 
 func BenchmarkMergeFlatMany(b *testing.B) {
@@ -396,10 +397,10 @@ func BenchmarkMergeFlatMany(b *testing.B) {
 				l.Close()
 			}()
 
-			prof, err := FlatProfileFromPprof(ctx, logger, l, p, 0)
+			prof, err := parcaprofile.FlatProfileFromPprof(ctx, logger, l, p, 0)
 			require.NoError(b, err)
 
-			profiles := make([]InstantProfile, 0, n)
+			profiles := make([]parcaprofile.InstantProfile, 0, n)
 			for i := 0; i < n; i++ {
 				profiles = append(profiles, prof)
 			}
@@ -409,7 +410,7 @@ func BenchmarkMergeFlatMany(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				m, err := MergeProfiles(profiles...)
 				require.NoError(b, err)
-				CopyInstantFlatProfile(m)
+				parcaprofile.CopyInstantFlatProfile(m)
 			}
 		})
 	}

--- a/pkg/storage/pprof.go
+++ b/pkg/storage/pprof.go
@@ -17,6 +17,7 @@ import (
 	"context"
 
 	"github.com/google/pprof/profile"
+	parcaprofile "github.com/parca-dev/parca/pkg/profile"
 	"github.com/parca-dev/parca/pkg/storage/metastore"
 )
 
@@ -61,7 +62,7 @@ func (s *LocationStack) ToLocationStacktrace() []*profile.Location {
 	return a
 }
 
-func GenerateFlatPprof(ctx context.Context, metaStore metastore.ProfileMetaStore, ip InstantProfile) (*profile.Profile, error) {
+func GenerateFlatPprof(ctx context.Context, metaStore metastore.ProfileMetaStore, ip parcaprofile.InstantProfile) (*profile.Profile, error) {
 	meta := ip.ProfileMeta()
 
 	mappingByID := map[string]*profile.Mapping{}

--- a/pkg/storage/pprof_test.go
+++ b/pkg/storage/pprof_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/pprof/profile"
 	"github.com/google/uuid"
 	pb "github.com/parca-dev/parca/gen/proto/go/parca/metastore/v1alpha1"
+	parcaprofile "github.com/parca-dev/parca/pkg/profile"
 	"github.com/parca-dev/parca/pkg/storage/metastore"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
@@ -49,7 +50,7 @@ func TestGenerateFlatPprof(t *testing.T) {
 	t.Cleanup(func() {
 		l.Close()
 	})
-	p, err := FlatProfileFromPprof(ctx, log.NewNopLogger(), l, p1, 0)
+	p, err := parcaprofile.FlatProfileFromPprof(ctx, log.NewNopLogger(), l, p1, 0)
 	require.NoError(t, err)
 	res, err := GenerateFlatPprof(ctx, l, p)
 	require.NoError(t, err)
@@ -150,10 +151,10 @@ func TestGeneratePprofNilMapping(t *testing.T) {
 		l2.ID,
 		l1.ID,
 	})
-	key := makeStacktraceKey(sample)
+	key := parcaprofile.MakeStacktraceKey(sample)
 
-	res, err := GenerateFlatPprof(ctx, l, &FlatProfile{
-		samples: map[string]*Sample{
+	res, err := GenerateFlatPprof(ctx, l, &parcaprofile.FlatProfile{
+		FlatSamples: map[string]*parcaprofile.Sample{
 			string(key): sample,
 		},
 	})

--- a/pkg/storage/querier_bench_test.go
+++ b/pkg/storage/querier_bench_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"testing"
 
+	parcaprofile "github.com/parca-dev/parca/pkg/profile"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/trace"
@@ -39,8 +40,8 @@ func BenchmarkHeadQuerier_Select(b *testing.B) {
 	for i := 1; i <= numSeries; i++ {
 		app, err := h.Appender(ctx, labels.FromStrings("foo", "bar", "s", fmt.Sprintf("%d%s", i, postingsBenchSuffix)))
 		require.NoError(b, err)
-		err = app.AppendFlat(ctx, &FlatProfile{
-			Meta: InstantProfileMeta{
+		err = app.AppendFlat(ctx, &parcaprofile.FlatProfile{
+			Meta: parcaprofile.InstantProfileMeta{
 				Timestamp: int64(i),
 			},
 		})

--- a/pkg/storage/series.go
+++ b/pkg/storage/series.go
@@ -20,6 +20,7 @@ import (
 	"math"
 	"sync"
 
+	"github.com/parca-dev/parca/pkg/profile"
 	"github.com/parca-dev/parca/pkg/storage/chunkenc"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/pkg/labels"
@@ -34,8 +35,8 @@ type MemSeries struct {
 	id   uint64
 	lset labels.Labels
 
-	periodType ValueType
-	sampleType ValueType
+	periodType profile.ValueType
+	sampleType profile.ValueType
 
 	minTime, maxTime int64
 	timestamps       timestampChunks
@@ -135,7 +136,7 @@ type MemSeriesAppender struct {
 
 const samplesPerChunk = 120
 
-func (a *MemSeriesAppender) AppendFlat(ctx context.Context, p *FlatProfile) error {
+func (a *MemSeriesAppender) AppendFlat(ctx context.Context, p *profile.FlatProfile) error {
 	ctx, span := a.s.tracer.Start(ctx, "AppendFlat")
 	defer span.End()
 

--- a/pkg/storage/series_iterator_range.go
+++ b/pkg/storage/series_iterator_range.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/parca-dev/parca/pkg/profile"
 	"github.com/parca-dev/parca/pkg/storage/chunkenc"
 	"github.com/prometheus/prometheus/pkg/labels"
 )
@@ -214,7 +215,7 @@ func (it *MemRangeSeriesIterator) Next() bool {
 	return true
 }
 
-func (it *MemRangeSeriesIterator) At() InstantProfile {
+func (it *MemRangeSeriesIterator) At() profile.InstantProfile {
 	return &MemSeriesInstantFlatProfile{
 		PeriodType: it.s.periodType,
 		SampleType: it.s.sampleType,
@@ -231,8 +232,8 @@ func (it *MemRangeSeriesIterator) Err() error {
 }
 
 type MemSeriesInstantFlatProfile struct {
-	PeriodType ValueType
-	SampleType ValueType
+	PeriodType profile.ValueType
+	SampleType profile.ValueType
 
 	timestampsIterator MemSeriesValuesIterator
 	durationsIterator  MemSeriesValuesIterator
@@ -241,8 +242,8 @@ type MemSeriesInstantFlatProfile struct {
 	sampleIterators map[string]*MultiChunksIterator
 }
 
-func (m MemSeriesInstantFlatProfile) ProfileMeta() InstantProfileMeta {
-	return InstantProfileMeta{
+func (m MemSeriesInstantFlatProfile) ProfileMeta() profile.InstantProfileMeta {
+	return profile.InstantProfileMeta{
 		PeriodType: m.PeriodType,
 		SampleType: m.SampleType,
 		Timestamp:  m.timestampsIterator.At(),
@@ -251,10 +252,10 @@ func (m MemSeriesInstantFlatProfile) ProfileMeta() InstantProfileMeta {
 	}
 }
 
-func (m MemSeriesInstantFlatProfile) Samples() map[string]*Sample {
-	samples := make(map[string]*Sample, len(m.sampleIterators))
+func (m MemSeriesInstantFlatProfile) Samples() map[string]*profile.Sample {
+	samples := make(map[string]*profile.Sample, len(m.sampleIterators))
 	for k, it := range m.sampleIterators {
-		samples[k] = &Sample{
+		samples[k] = &profile.Sample{
 			Value: it.At(),
 		}
 	}

--- a/pkg/storage/series_iterator_range_test.go
+++ b/pkg/storage/series_iterator_range_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/parca-dev/parca/pkg/profile"
 	"github.com/parca-dev/parca/pkg/storage/chunkenc"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/stretchr/testify/require"
@@ -34,17 +35,17 @@ func TestMemRangeSeries_Iterator(t *testing.T) {
 		uuid.MustParse("00000000-0000-0000-0000-000000000002"),
 		uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 	})
-	k1 := makeStacktraceKey(s1)
+	k1 := profile.MakeStacktraceKey(s1)
 
 	for i := 1; i <= 500; i++ {
 		s1.Value = int64(i)
-		p := &FlatProfile{
-			Meta: InstantProfileMeta{
+		p := &profile.FlatProfile{
+			Meta: profile.InstantProfileMeta{
 				Timestamp: int64(i),
 				Duration:  time.Second.Nanoseconds(),
 				Period:    time.Second.Nanoseconds(),
 			},
-			samples: map[string]*Sample{
+			FlatSamples: map[string]*profile.Sample{
 				string(k1): s1,
 			},
 		}

--- a/pkg/storage/series_iterator_root.go
+++ b/pkg/storage/series_iterator_root.go
@@ -16,6 +16,7 @@ package storage
 import (
 	"fmt"
 
+	"github.com/parca-dev/parca/pkg/profile"
 	"github.com/parca-dev/parca/pkg/storage/chunkenc"
 	"github.com/prometheus/prometheus/pkg/labels"
 )
@@ -129,14 +130,14 @@ func (it *MemRootSeriesIterator) Next() bool {
 	return true
 }
 
-func (it *MemRootSeriesIterator) At() InstantProfile {
-	return &FlatProfile{
-		Meta: InstantProfileMeta{
+func (it *MemRootSeriesIterator) At() profile.InstantProfile {
+	return &profile.FlatProfile{
+		Meta: profile.InstantProfileMeta{
 			Timestamp:  it.timestampsIterator.At(),
 			PeriodType: it.s.periodType,
 			SampleType: it.s.sampleType,
 		},
-		samples: map[string]*Sample{
+		FlatSamples: map[string]*profile.Sample{
 			"": {Value: it.rootIterator.At()},
 		},
 	}

--- a/pkg/storage/series_iterator_root_test.go
+++ b/pkg/storage/series_iterator_root_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/parca-dev/parca/pkg/profile"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/stretchr/testify/require"
 )
@@ -31,13 +32,13 @@ func TestMemRootSeries_Iterator(t *testing.T) {
 
 	var i int64
 	for i = 1; i < 500; i++ {
-		p := &FlatProfile{
-			Meta: InstantProfileMeta{
+		p := &profile.FlatProfile{
+			Meta: profile.InstantProfileMeta{
 				Timestamp: i,
 				Duration:  time.Second.Nanoseconds(),
 				Period:    time.Second.Nanoseconds(),
 			},
-			samples: map[string]*Sample{
+			FlatSamples: map[string]*profile.Sample{
 				"": {Value: i},
 			},
 		}

--- a/pkg/storage/series_test.go
+++ b/pkg/storage/series_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/parca-dev/parca/pkg/profile"
 	"github.com/parca-dev/parca/pkg/storage/chunkenc"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/stretchr/testify/require"
@@ -55,15 +56,15 @@ func TestMemSeries(t *testing.T) {
 	k11 := uuid.MustParse("00000000-0000-0000-0000-000000000e11")
 	k12 := uuid.MustParse("00000000-0000-0000-0000-000000000e12")
 
-	fp1 := &FlatProfile{
-		Meta: InstantProfileMeta{
-			PeriodType: ValueType{},
-			SampleType: ValueType{},
+	fp1 := &profile.FlatProfile{
+		Meta: profile.InstantProfileMeta{
+			PeriodType: profile.ValueType{},
+			SampleType: profile.ValueType{},
 			Timestamp:  1000,
 			Duration:   time.Second.Nanoseconds(),
 			Period:     time.Second.Nanoseconds(),
 		},
-		samples: map[string]*Sample{
+		FlatSamples: map[string]*profile.Sample{
 			string(k11[:]): s11,
 			string(k12[:]): s12,
 		},
@@ -77,15 +78,15 @@ func TestMemSeries(t *testing.T) {
 	require.Equal(t, chunkenc.FromValuesXOR(2), s.samples[string(k12[:])][0])
 
 	s2 := makeSample(3, []uuid.UUID{uuid2, uuid1})
-	fp2 := &FlatProfile{
-		Meta: InstantProfileMeta{
-			PeriodType: ValueType{},
-			SampleType: ValueType{},
+	fp2 := &profile.FlatProfile{
+		Meta: profile.InstantProfileMeta{
+			PeriodType: profile.ValueType{},
+			SampleType: profile.ValueType{},
 			Timestamp:  2000,
 			Duration:   time.Second.Nanoseconds(),
 			Period:     time.Second.Nanoseconds(),
 		},
-		samples: map[string]*Sample{
+		FlatSamples: map[string]*profile.Sample{
 			string(k11[:]): s2,
 		},
 	}
@@ -101,15 +102,15 @@ func TestMemSeries(t *testing.T) {
 	s3 := makeSample(4, []uuid.UUID{uuid3, uuid1})
 	k3 := uuid.MustParse("00000000-0000-0000-0000-0000000000e3")
 
-	fp3 := &FlatProfile{
-		Meta: InstantProfileMeta{
-			PeriodType: ValueType{},
-			SampleType: ValueType{},
+	fp3 := &profile.FlatProfile{
+		Meta: profile.InstantProfileMeta{
+			PeriodType: profile.ValueType{},
+			SampleType: profile.ValueType{},
 			Timestamp:  3000,
 			Duration:   time.Second.Nanoseconds(),
 			Period:     time.Second.Nanoseconds(),
 		},
-		samples: map[string]*Sample{
+		FlatSamples: map[string]*profile.Sample{
 			string(k3[:]): s3,
 		},
 	}
@@ -126,15 +127,15 @@ func TestMemSeries(t *testing.T) {
 	s4 := makeSample(6, []uuid.UUID{uuid5, uuid2, uuid1})
 	k4 := uuid.MustParse("00000000-0000-0000-0000-0000000000e4")
 
-	fp4 := &FlatProfile{
-		Meta: InstantProfileMeta{
-			PeriodType: ValueType{},
-			SampleType: ValueType{},
+	fp4 := &profile.FlatProfile{
+		Meta: profile.InstantProfileMeta{
+			PeriodType: profile.ValueType{},
+			SampleType: profile.ValueType{},
 			Timestamp:  4000,
 			Duration:   time.Second.Nanoseconds(),
 			Period:     time.Second.Nanoseconds(),
 		},
-		samples: map[string]*Sample{
+		FlatSamples: map[string]*profile.Sample{
 			string(k4[:]): s4,
 		},
 	}
@@ -150,15 +151,15 @@ func TestMemSeries(t *testing.T) {
 
 	// Merging another profileTree onto the existing one with one new Location
 	s5 := makeSample(7, []uuid.UUID{uuid2, uuid1})
-	fp5 := &FlatProfile{
-		Meta: InstantProfileMeta{
-			PeriodType: ValueType{},
-			SampleType: ValueType{},
+	fp5 := &profile.FlatProfile{
+		Meta: profile.InstantProfileMeta{
+			PeriodType: profile.ValueType{},
+			SampleType: profile.ValueType{},
 			Timestamp:  5000,
 			Duration:   time.Second.Nanoseconds(),
 			Period:     time.Second.Nanoseconds(),
 		},
-		samples: map[string]*Sample{
+		FlatSamples: map[string]*profile.Sample{
 			string(k11[:]): s5,
 		},
 	}
@@ -200,13 +201,13 @@ func TestMemSeriesMany(t *testing.T) {
 		s1.Value = int64(i)
 		s2.Value = int64(2 * i)
 
-		err = app.AppendFlat(ctx, &FlatProfile{
-			Meta: InstantProfileMeta{
+		err = app.AppendFlat(ctx, &profile.FlatProfile{
+			Meta: profile.InstantProfileMeta{
 				Timestamp: int64(i),
 				Duration:  snano,
 				Period:    snano,
 			},
-			samples: map[string]*Sample{
+			FlatSamples: map[string]*profile.Sample{
 				string(k1[:]): s1,
 				string(k2[:]): s2,
 			},
@@ -263,8 +264,8 @@ func TestMemSeries_truncateChunksBefore(t *testing.T) {
 			require.NoError(t, err)
 
 			for i := int64(1); i <= 500; i++ {
-				require.NoError(t, app.AppendFlat(ctx, &FlatProfile{
-					Meta: InstantProfileMeta{Timestamp: i},
+				require.NoError(t, app.AppendFlat(ctx, &profile.FlatProfile{
+					Meta: profile.InstantProfileMeta{Timestamp: i},
 				}))
 			}
 
@@ -296,12 +297,12 @@ func TestMemSeries_truncateFlatChunksBeforeConcurrent(t *testing.T) {
 		uuid.MustParse("00000000-0000-0000-0000-000000000002"),
 		uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 	})
-	k1 := makeStacktraceKey(s1)
+	k1 := profile.MakeStacktraceKey(s1)
 
 	for i := int64(1); i < 500; i++ {
-		require.NoError(t, app.AppendFlat(ctx, &FlatProfile{
-			Meta: InstantProfileMeta{Timestamp: i},
-			samples: map[string]*Sample{
+		require.NoError(t, app.AppendFlat(ctx, &profile.FlatProfile{
+			Meta: profile.InstantProfileMeta{Timestamp: i},
+			FlatSamples: map[string]*profile.Sample{
 				string(k1): s1,
 			},
 		}))
@@ -320,9 +321,9 @@ func TestMemSeries_truncateFlatChunksBeforeConcurrent(t *testing.T) {
 
 	// Test for appending working correctly after truncating.
 	for i := int64(500); i < 1_000; i++ {
-		require.NoError(t, app.AppendFlat(ctx, &FlatProfile{
-			Meta: InstantProfileMeta{Timestamp: i},
-			samples: map[string]*Sample{
+		require.NoError(t, app.AppendFlat(ctx, &profile.FlatProfile{
+			Meta: profile.InstantProfileMeta{Timestamp: i},
+			FlatSamples: map[string]*profile.Sample{
 				string(k1): s1,
 			},
 		}))
@@ -338,9 +339,9 @@ func TestMemSeries_truncateFlatChunksBeforeConcurrent(t *testing.T) {
 
 	// Append more profiles after truncating all chunks.
 	for i := int64(1_100); i < 1_234; i++ {
-		require.NoError(t, app.AppendFlat(ctx, &FlatProfile{
-			Meta: InstantProfileMeta{Timestamp: i},
-			samples: map[string]*Sample{
+		require.NoError(t, app.AppendFlat(ctx, &profile.FlatProfile{
+			Meta: profile.InstantProfileMeta{Timestamp: i},
+			FlatSamples: map[string]*profile.Sample{
 				string(k1): s1,
 			},
 		}))
@@ -362,11 +363,11 @@ func BenchmarkMemSeries_truncateChunksBefore(b *testing.B) {
 		uuid.MustParse("00000000-0000-0000-0000-000000000002"),
 		uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 	})
-	sampleKey := makeStacktraceKey(sample)
+	sampleKey := profile.MakeStacktraceKey(sample)
 
-	p := &FlatProfile{
-		Meta: InstantProfileMeta{},
-		samples: map[string]*Sample{
+	p := &profile.FlatProfile{
+		Meta: profile.InstantProfileMeta{},
+		FlatSamples: map[string]*profile.Sample{
 			string(sampleKey): sample,
 		},
 	}


### PR DESCRIPTION
This code really has nothing to do with the storage, so it should be
separate from it.

@metalmatze @thorfour 