### PR TITLE
Add version and commit to Parca build in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,8 @@ RUN yarn workspace @parca/web build
 FROM docker.io/golang@sha256:7e31a85c5b182e446c9e0e6fba57c522902f281a6a5a6cbd25afa17ac48a6b85 as builder
 RUN mkdir /.cache && chown nobody:nogroup /.cache && touch -t 202101010000.00 /.cache
 
+ARG VERSION
+ARG COMMIT
 ENV CGO_ENABLED=0
 ENV GOOS=linux
 ENV GOARCH=amd64
@@ -42,7 +44,7 @@ COPY --chown=nobody:nogroup ./gen ./gen
 COPY --chown=nobody:nogroup ./proto ./proto
 COPY --chown=nobody:nogroup ./ui/ui.go ./ui/ui.go
 COPY --chown=nobody:nogroup --from=ui-builder /app/packages/app/web/dist ./ui/packages/app/web/dist
-RUN go build -trimpath -o parca ./cmd/parca
+RUN go build -ldflags "-X main.version=${VERSION} -X main.commit=${COMMIT}" -trimpath -o parca ./cmd/parca
 RUN go install github.com/grpc-ecosystem/grpc-health-probe@latest
 
 # this image is what docker.io/alpine:3.14.1 on August 13 2021

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ proto/vendor:
 
 .PHONY: container
 container:
-	buildah build-using-dockerfile --timestamp 0 --layers -t $(OUT_DOCKER):$(VERSION)
+	buildah build-using-dockerfile --timestamp 0 --layers --build-arg VERSION=$(VERSION) --build-arg COMMIT=$(COMMIT) -t $(OUT_DOCKER):$(VERSION) .
 
 .PHONY: push-container
 push-container:


### PR DESCRIPTION
We added the version to binaries compiled outside containers but were still missing the version and commit for the container binaries.
This PR add VERSION and COMMIT to Parca so that it shows up in the UI too.