### PR TITLE
[WIP] Add support for multi-arch container builds

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -18,8 +18,17 @@ jobs:
         shell: bash
         run: echo "GITHUB_BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> $GITHUB_ENV
 
+      # To build multi-arch images, see also: https://github.com/redhat-actions/buildah-build#multi-arch-builds
+      - name: Install qemu dependency
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-user-static
+
       - name: Build container
         run: make container
+
+      - name: Check images created
+        run: buildah images | grep 'ghcr.io/parca-dev/parca'
 
       - name: Login to registry
         if: ${{ github.event_name != 'pull_request' }}

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ else
 	COMMIT := $(shell echo $(GITHUB_SHA) | cut -c1-8)
 endif
 VERSION ?= $(if $(RELEASE_TAG),$(RELEASE_TAG),$(shell $(CMD_GIT) describe --tags 2>/dev/null || echo '$(BRANCH)$(COMMIT)'))
+ALL_ARCH ?= amd64 arm arm64
 OUT_DOCKER ?= ghcr.io/parca-dev/parca
 
 .PHONY: build
@@ -74,9 +75,15 @@ proto/vendor:
 	mkdir -p proto/google/pprof
 	curl https://raw.githubusercontent.com/google/pprof/master/proto/profile.proto > proto/google/pprof/profile.proto
 
+.PHONY: container-dev
+container-dev:
+       buildah build-using-dockerfile --timestamp 0 --layers --build-arg VERSION=$(VERSION) --build-arg COMMIT=$(COMMIT) -t $(OUT_DOCKER):$(VERSION) .
+
 .PHONY: container
 container:
-	buildah build-using-dockerfile --timestamp 0 --layers --build-arg VERSION=$(VERSION) --build-arg COMMIT=$(COMMIT) -t $(OUT_DOCKER):$(VERSION) .
+	for arch in $(ALL_ARCH); do \
+	buildah build-using-dockerfile --build-arg VERSION=$(VERSION) --build-arg COMMIT=$(COMMIT) --build-arg ARCH=$$arch --arch $$arch --timestamp 0 --manifest $(OUT_DOCKER):$(VERSION); \
+	done
 
 .PHONY: push-container
 push-container:


### PR DESCRIPTION
At this time, this adds additional support for arm64-based containers.
This can be useful for cloud-based platforms like graviton or to run
parca at home on your SBC cluster.


TODO: Still needs verification that the CI path works and actual testing on an arm64 board.