### PR TITLE
Makefile: Push manifest instead of image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,11 +87,11 @@ container:
 
 .PHONY: push-container
 push-container:
-	buildah push $(OUT_DOCKER):$(VERSION)
+	buildah manifest push --all $(OUT_DOCKER):$(VERSION)
 
 .PHONY: push-quay-container
 push-quay-container:
-	buildah push $(OUT_DOCKER):$(VERSION) quay.io/parca/parca:$(VERSION)
+	buildah manifest push --all $(OUT_DOCKER):$(VERSION) quay.io/parca/parca:$(VERSION)
 
 .PHONY: deploy/manifests
 deploy/manifests:


### PR DESCRIPTION
@brancz  This should allow to push all architectures.

currently it only pushed one image.