### PR TITLE
pkg/query: Fix adding a unit to the flamegraph

### DIFF
--- a/pkg/query/flamegraph_flat.go
+++ b/pkg/query/flamegraph_flat.go
@@ -20,8 +20,8 @@ import (
 	"sort"
 
 	pb "github.com/parca-dev/parca/gen/proto/go/parca/query/v1alpha1"
-	"github.com/parca-dev/parca/pkg/profile"
 	"github.com/parca-dev/parca/pkg/metastore"
+	"github.com/parca-dev/parca/pkg/profile"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -116,12 +116,16 @@ func GenerateFlamegraphFlat(ctx context.Context, tracer trace.Tracer, metaStore 
 		current = rootNode
 	}
 
-	flamegraph := &pb.Flamegraph{Root: &pb.FlamegraphRootNode{}}
-	flamegraph.Total = rootNode.Cumulative
-	flamegraph.Height = height + 1 // add one for the root
-	flamegraph.Root.Cumulative = rootNode.Cumulative
-	flamegraph.Root.Diff = rootNode.Diff
-	flamegraph.Root.Children = rootNode.Children
+	flamegraph := &pb.Flamegraph{
+		Root: &pb.FlamegraphRootNode{
+			Cumulative: rootNode.Cumulative,
+			Diff:       rootNode.Diff,
+			Children:   rootNode.Children,
+		},
+		Total:  rootNode.Cumulative,
+		Unit:   p.ProfileMeta().SampleType.Unit,
+		Height: height + 1, // add one for the root
+	}
 
 	return aggregateByFunction(flamegraph), nil
 }

--- a/pkg/query/flamegraph_flat_test.go
+++ b/pkg/query/flamegraph_flat_test.go
@@ -23,8 +23,8 @@ import (
 	"github.com/google/uuid"
 	metapb "github.com/parca-dev/parca/gen/proto/go/parca/metastore/v1alpha1"
 	pb "github.com/parca-dev/parca/gen/proto/go/parca/query/v1alpha1"
-	parcaprofile "github.com/parca-dev/parca/pkg/profile"
 	"github.com/parca-dev/parca/pkg/metastore"
+	parcaprofile "github.com/parca-dev/parca/pkg/profile"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/trace"
@@ -295,8 +295,8 @@ func TestGenerateFlamegraphWithInlined(t *testing.T) {
 		},
 	}
 	p := &profile.Profile{
-		SampleType: []*profile.ValueType{{Type: "", Unit: ""}},
-		PeriodType: &profile.ValueType{Type: "", Unit: ""},
+		SampleType: []*profile.ValueType{{Type: "alloc_space", Unit: "bytes"}},
+		PeriodType: &profile.ValueType{Type: "space", Unit: "bytes"},
 		Sample:     samples,
 		Location:   locations,
 		Function:   functions,
@@ -311,6 +311,7 @@ func TestGenerateFlamegraphWithInlined(t *testing.T) {
 	require.Equal(t, &pb.Flamegraph{
 		Total:  1,
 		Height: 4,
+		Unit:   "bytes",
 		Root: &pb.FlamegraphRootNode{
 			Cumulative: 1,
 			Children: []*pb.FlamegraphNode{{


### PR DESCRIPTION
Fixes #578

For some reason, we didn't set the unit field anymore. :man_shrugging: 
It might be easier to construct the struct in the workflow I chose now and similar mistakes could be easier to catch. Either way, I added updated a unit test too to catch it in the future.