### PR TITLE
pkg/query: Fix flaky Test_QueryRange_Limited by increasing timeouts and using UTC

### DIFF
--- a/pkg/query/query_test.go
+++ b/pkg/query/query_test.go
@@ -167,7 +167,7 @@ func Test_QueryRange_Limited(t *testing.T) {
 		require.NoError(t, err)
 
 		// Overwrite the profile's timestamp to be within the last 5min.
-		p.TimeNanos = time.Now().UnixNano()
+		p.TimeNanos = time.Now().UTC().UnixNano()
 
 		prof, err := parcaprofile.FlatProfileFromPprof(ctx, log.NewNopLogger(), s, p, 0)
 		require.NoError(t, err)
@@ -175,9 +175,9 @@ func Test_QueryRange_Limited(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	// Query last 5 minutes
-	end := time.Now()
-	start := end.Add(-5 * time.Minute)
+	// Query last 15 minutes
+	end := time.Now().UTC()
+	start := end.Add(-15 * time.Minute)
 
 	limit := rand.Intn(numSeries)
 	resp, err := q.QueryRange(ctx, &pb.QueryRangeRequest{


### PR DESCRIPTION
Hopefully, this will cut the flaky test some slack, and using UTC should make any CI differences negligible.

Fixes #499 