### PR TITLE
Close profile card in compare view

### DIFF
--- a/ui/packages/app/web/src/components/ProfileExplorer.tsx
+++ b/ui/packages/app/web/src/components/ProfileExplorer.tsx
@@ -41,6 +41,17 @@ const ProfileExplorer = ({router, queryClient}: ProfileExplorerProps): JSX.Eleme
   ): {[key: string]: string | string[] | undefined} =>
     Object.fromEntries(Object.entries(o).filter(([key]) => !key.endsWith(suffix)));
 
+  const swapQueryParameters = (o: {
+    [key: string]: string | string[] | undefined;
+  }): {[key: string]: string | string[] | undefined} => {
+    Object.entries(o).forEach(([key, value]) => {
+      if (key.endsWith('_b')) {
+        o[key.slice(0, -2) + '_a'] = value;
+      }
+    });
+    return o;
+  };
+
   const selectProfileA = async (p: ProfileSelection): Promise<boolean> => {
     return await router.push({
       pathname: '/',
@@ -208,6 +219,23 @@ const ProfileExplorer = ({router, queryClient}: ProfileExplorerProps): JSX.Eleme
     });
   };
 
+  const closeProfile = async (card: string): Promise<boolean> => {
+    let newQueryParameters = queryParams;
+    if (card === 'A') {
+      newQueryParameters = swapQueryParameters(queryParams);
+    }
+
+    return await router.push({
+      pathname: '/',
+      query: {
+        ...filterSuffix(newQueryParameters, '_b'),
+        ...{
+          compare_a: 'false',
+        },
+      },
+    });
+  };
+
   return (
     <ProfileExplorerCompare
       queryClient={queryClient}
@@ -219,6 +247,7 @@ const ProfileExplorer = ({router, queryClient}: ProfileExplorerProps): JSX.Eleme
       selectQueryB={selectQueryB}
       selectProfileA={selectProfileA}
       selectProfileB={selectProfileB}
+      closeProfile={closeProfile}
     />
   );
 };

--- a/ui/packages/app/web/src/components/ProfileExplorerCompare.tsx
+++ b/ui/packages/app/web/src/components/ProfileExplorerCompare.tsx
@@ -14,6 +14,7 @@ interface ProfileExplorerCompareProps {
   selectQueryB: (query: QuerySelection) => void;
   selectProfileA: (source: ProfileSelection) => void;
   selectProfileB: (source: ProfileSelection) => void;
+  closeProfile: (card: string) => void;
 }
 
 const ProfileExplorerCompare = ({
@@ -26,7 +27,16 @@ const ProfileExplorerCompare = ({
   selectQueryB,
   selectProfileA,
   selectProfileB,
+  closeProfile,
 }: ProfileExplorerCompareProps): JSX.Element => {
+  const closeProfileA = () => {
+    closeProfile('A');
+  };
+
+  const closeProfileB = () => {
+    closeProfile('B');
+  };
+
   return (
     <>
       <div className="grid grid-cols-2">
@@ -37,6 +47,7 @@ const ProfileExplorerCompare = ({
             profileSelection={profileA}
             selectProfile={selectProfileA}
             selectQuery={selectQueryA}
+            closeProfile={closeProfileA}
             enforcedProfileName={''}
             comparing={true}
             onCompareProfile={() => {}}
@@ -49,6 +60,7 @@ const ProfileExplorerCompare = ({
             profileSelection={profileB}
             selectProfile={selectProfileB}
             selectQuery={selectQueryB}
+            closeProfile={closeProfileB}
             enforcedProfileName={Query.parse(queryA.expression).profileName()}
             comparing={true}
             onCompareProfile={() => {}}

--- a/ui/packages/app/web/src/components/ProfileExplorerSingle.tsx
+++ b/ui/packages/app/web/src/components/ProfileExplorerSingle.tsx
@@ -28,6 +28,7 @@ const ProfileExplorerSingle = ({
             querySelection={query}
             selectQuery={selectQuery}
             selectProfile={selectProfile}
+            closeProfile={() => {}}
             profileSelection={profile}
             comparing={false}
             onCompareProfile={compareProfile}

--- a/ui/packages/app/web/src/components/ProfileSelector.tsx
+++ b/ui/packages/app/web/src/components/ProfileSelector.tsx
@@ -10,6 +10,7 @@ import CompareButton from './CompareButton';
 import Button from './ui/Button';
 import ButtonGroup from './ui/ButtonGroup';
 import Card from './ui/Card';
+import CloseIcon from './ui/CloseIcon';
 import Select, {SelectElement} from './ui/Select';
 
 interface TimeSelection {
@@ -30,6 +31,7 @@ interface ProfileSelectorProps {
   querySelection: QuerySelection;
   selectProfile: (source: ProfileSelection) => void;
   selectQuery: (query: QuerySelection) => void;
+  closeProfile: () => void;
   enforcedProfileName: string;
   profileSelection: ProfileSelection | null;
   comparing: boolean;
@@ -152,6 +154,7 @@ const ProfileSelector = ({
   querySelection,
   selectProfile,
   selectQuery,
+  closeProfile,
   enforcedProfileName,
   profileSelection,
   comparing,
@@ -351,6 +354,11 @@ const ProfileSelector = ({
       <Card>
         <Card.Header>
           <div className="flex space-x-4">
+            {comparing && (
+              <button type="button" onClick={() => closeProfile()}>
+                <CloseIcon />
+              </button>
+            )}
             <Select
               items={profileLabels}
               selectedKey={selectedProfileName}

--- a/ui/packages/app/web/src/components/ui/CloseIcon.tsx
+++ b/ui/packages/app/web/src/components/ui/CloseIcon.tsx
@@ -1,0 +1,23 @@
+const CloseIcon = () => {
+  return (
+    <>
+      <svg
+        className="h-5 w-5 text-white-400"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        stroke-width="2"
+        stroke="currentColor"
+        fill="none"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <path stroke="none" d="M0 0h24v24H0z" />
+        <line x1="18" y1="6" x2="6" y2="18" />
+        <line x1="6" y1="6" x2="18" y2="18" />
+      </svg>
+    </>
+  );
+};
+
+export default CloseIcon;


### PR DESCRIPTION
Closes #211 

https://user-images.githubusercontent.com/52544819/151407091-d6f30235-060a-4ad7-8a91-e279b75a43ab.mp4

The `compare_a` parameter continues to exist in the single profile view. If necessary, I can write another function that will filter the params based on the prefix(`compare_` in this case).