### PR TITLE
Log error if no err channel provided

### DIFF
--- a/pkg/scrape/scrape.go
+++ b/pkg/scrape/scrape.go
@@ -477,9 +477,13 @@ mainLoop:
 					},
 				},
 			})
-			if err != nil && errc != nil {
-				level.Debug(sl.l).Log("err", err)
-				errc <- err
+			if err != nil {
+				switch errc {
+				case nil:
+					level.Error(sl.l).Log("msg", "WriteRaw failed for scraped profile", "err", err)
+				default:
+					errc <- err
+				}
 			}
 
 			sl.target.health = HealthGood


### PR DESCRIPTION
Logs are being swallowed currently because no errc is provided by the
scrape loop.

We should log the errors if not errc is provided.