### PR TITLE
Adds lower level locking to the column store.

### DIFF
--- a/pkg/columnstore/part.go
+++ b/pkg/columnstore/part.go
@@ -161,6 +161,9 @@ func compare(a, b interface{}) int {
 
 // Less returns true if the row is Less than the given row
 func (r Row) Less(than Row) bool {
+	if than.Values == nil { // in the 0 case always return true
+		return true
+	}
 	for k := 0; k < len(r.Values); k++ {
 		vi := r.Values[k]
 		vj := than.Values[k]

--- a/pkg/columnstore/table_test.go
+++ b/pkg/columnstore/table_test.go
@@ -2,7 +2,10 @@ package columnstore
 
 import (
 	"fmt"
+	"math/rand"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/apache/arrow/go/v7/arrow"
 	"github.com/apache/arrow/go/v7/arrow/memory"
@@ -205,16 +208,11 @@ func Test_Table_GranuleSplit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	table.granuleIterator(func(g *Granule) bool {
-		ar, err := g.ArrowRecord(memory.NewGoAllocator())
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer ar.Release()
-		fmt.Println("-----------------Granule----------------")
-		fmt.Println(ar)
-		fmt.Println("----------------------------------------")
+	time.Sleep(time.Second)
 
+	table.Iterator(memory.NewGoAllocator(), func(r arrow.Record) bool {
+		defer r.Release()
+		fmt.Println(r)
 		return true
 	})
 
@@ -301,6 +299,8 @@ func Test_Table_InsertLowest(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	time.Sleep(time.Second)
+
 	require.Equal(t, 2, table.index.Len())
 	require.Equal(t, 2, table.index.Min().(*Granule).Cardinality()) // [10,11]
 	require.Equal(t, 3, table.index.Max().(*Granule).Cardinality()) // [12,13,14]
@@ -324,4 +324,116 @@ func Test_Table_InsertLowest(t *testing.T) {
 	require.Equal(t, 2, table.index.Len())
 	require.Equal(t, 3, table.index.Min().(*Granule).Cardinality()) // [1,10,11]
 	require.Equal(t, 3, table.index.Max().(*Granule).Cardinality()) // [12,13,14]
+}
+
+// This test issues concurrent writes to the database, and expects all of them to be recorded successfully.
+func Test_Table_Concurrency(t *testing.T) {
+	table := basicTable(t, 1<<13)
+
+	generateRows := func(n int) []Row {
+		rows := make([]Row, 0, n)
+		for i := 0; i < n; i++ {
+			rows = append(rows, Row{
+				Values: []interface{}{
+					[]DynamicColumnValue{ // TODO would be nice to not have all the same column
+						{Name: "label1", Value: "value1"},
+						{Name: "label2", Value: "value2"},
+					},
+					rand.Int63(),
+					rand.Int63(),
+				},
+			})
+		}
+		return rows
+	}
+
+	// Spawn n workers that will insert values into the table
+	n := 8
+	inserts := 100
+	rows := 10
+	wg := &sync.WaitGroup{}
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < inserts; i++ {
+				if err := table.Insert(generateRows(rows)); err != nil {
+					fmt.Println("Received error on insert: ", err)
+				}
+			}
+		}()
+	}
+
+	// TODO probably have them generate until a stop event
+	wg.Wait()
+
+	totalrows := int64(0)
+	err := table.Iterator(memory.NewGoAllocator(), func(ar arrow.Record) bool {
+		totalrows += ar.NumRows()
+		defer ar.Release()
+
+		return true
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(n*inserts*rows), totalrows)
+}
+
+func Benchmark_Table_Insert_10Rows_10Writers(b *testing.B) {
+	schema := Schema{
+		Columns: []ColumnDefinition{{
+			Name:     "labels",
+			Type:     StringType,
+			Encoding: PlainEncoding,
+			Dynamic:  true,
+		}, {
+			Name:     "timestamp",
+			Type:     Int64Type,
+			Encoding: PlainEncoding,
+		}, {
+			Name:     "value",
+			Type:     Int64Type,
+			Encoding: PlainEncoding,
+		}},
+		OrderedBy:   []string{"labels", "timestamp"},
+		GranuleSize: 2 << 13,
+	}
+
+	c := New(nil)
+	db := c.DB("test")
+	table := db.Table("test", schema)
+	generateRows := func(n int) []Row {
+		rows := make([]Row, 0, n)
+		for i := 0; i < n; i++ {
+			rows = append(rows, Row{
+				Values: []interface{}{
+					[]DynamicColumnValue{ // TODO would be nice to not have all the same column
+						{Name: "label1", Value: "value1"},
+						{Name: "label2", Value: "value2"},
+					},
+					rand.Int63(),
+					rand.Int63(),
+				},
+			})
+		}
+		return rows
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		// Spawn n workers that will insert values into the table
+		n := 10
+		wg := &sync.WaitGroup{}
+		for i := 0; i < n; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				r := generateRows(10)
+				if err := table.Insert(r); err != nil {
+					fmt.Println("Received error on insert: ", err)
+				}
+			}()
+		}
+		wg.Wait()
+	}
 }


### PR DESCRIPTION
Read locks on the index on insert and then writer locks on the granules themselves.

Write locks on the index when during splits. 