### PR TITLE
Only run GitHub Actions when related files changed

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,8 +3,16 @@ name: Go
 on:
   push:
     branches: [ main ]
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
   pull_request:
     branches: [ main ]
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
 
 jobs:
   goreleaser:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -6,6 +6,8 @@ on:
     branches:
       - master
       - main
+    paths:
+      - '**.go'
   pull_request:
 jobs:
   golangci:

--- a/.github/workflows/jsonnet.yml
+++ b/.github/workflows/jsonnet.yml
@@ -3,8 +3,11 @@ name: Jsonnet
 on:
   push:
     branches: [ main ]
+    paths:
+      - jsonnet/**
   pull_request:
     branches: [ main ]
+      - jsonnet/**
 
 jobs:
   build:

--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -3,8 +3,12 @@ name: Protobuf
 on:
   push:
     branches: [ main ]
+    paths:
+      - proto/**
   pull_request:
     branches: [ main ]
+    paths:
+      - proto/**
 
 jobs:
   build:

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -3,8 +3,12 @@ name: UI
 on:
   push:
     branches: [ main ]
+    paths:
+      - ui/**
   pull_request:
     branches: [ main ]
+    paths:
+      - ui/**
 
 jobs:
   test:


### PR DESCRIPTION
Especially for golangci-lint, proto and jsonnet we don't need to run these actions, if none of the related files changed.
As for the UI and Go itself I'm not 100% sure but willing to try. Maybe doing a change to the README would be super fast then? Not sure if those are worth it in the end. WDYT?