### PR TITLE
Col2 transactions

### DIFF
--- a/pkg/columnstore/aggregate_test.go
+++ b/pkg/columnstore/aggregate_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestAggregate(t *testing.T) {
+	t.Skip()
 	table := basicTable(t, 2^12)
 
 	err := table.Insert(

--- a/pkg/columnstore/aggregate_test.go
+++ b/pkg/columnstore/aggregate_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestAggregate(t *testing.T) {
-	t.Skip()
 	table := basicTable(t, 2^12)
 
 	err := table.Insert(

--- a/pkg/columnstore/db.go
+++ b/pkg/columnstore/db.go
@@ -2,6 +2,7 @@ package columnstore
 
 import (
 	"sync"
+	"sync/atomic"
 
 	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
@@ -31,6 +32,11 @@ type DB struct {
 	mtx    *sync.RWMutex
 	tables map[string]*Table
 	reg    prometheus.Registerer
+
+	// Databases monotomically increasing transaction id
+	txmtx  *sync.RWMutex
+	tx     uint64
+	active []uint64 // TODO probably not the best choice for active list...
 }
 
 func (s *ColumnStore) DB(name string) *DB {
@@ -83,4 +89,18 @@ func (db *DB) Table(name string, schema Schema, logger log.Logger) *Table {
 	table = newTable(db, name, schema, db.reg, logger)
 	db.tables[name] = table
 	return table
+}
+
+// begin is an internal function that Tables call to start a transaction
+func (db *DB) begin() uint64 {
+	tx := atomic.AddUint64(&db.tx, 1)
+	db.txmtx.Lock()
+	db.active = append(db.active, tx)
+	db.txmtx.Unlock()
+	return tx
+}
+
+// commit this transaction id
+func (db *DB) commit(tx uint64) {
+	// TODO
 }

--- a/pkg/columnstore/db.go
+++ b/pkg/columnstore/db.go
@@ -63,6 +63,9 @@ func (s *ColumnStore) DB(name string) *DB {
 		mtx:    &sync.RWMutex{},
 		tables: map[string]*Table{},
 		reg:    prometheus.WrapRegistererWith(prometheus.Labels{"db": name}, s.reg),
+
+		active: map[uint64]uint64{},
+		txmtx:  &sync.RWMutex{},
 	}
 
 	s.dbs[name] = db

--- a/pkg/columnstore/granule.go
+++ b/pkg/columnstore/granule.go
@@ -127,12 +127,12 @@ func (g *Granule) split(n int) ([]*Granule, error) {
 }
 
 // ArrowRecord merges all parts in a Granule before returning an ArrowRecord over that part
-func (g *Granule) ArrowRecord(tx uint64, pool memory.Allocator) (arrow.Record, error) {
+func (g *Granule) ArrowRecord(tx uint64, db *DB, pool memory.Allocator) (arrow.Record, error) {
 	g.RLock()
 	defer g.RUnlock()
 
 	// Merge the parts
-	p, err := Merge(tx, g.parts...)
+	p, err := Merge(tx, db, g.parts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/columnstore/granule.go
+++ b/pkg/columnstore/granule.go
@@ -127,12 +127,12 @@ func (g *Granule) split(n int) ([]*Granule, error) {
 }
 
 // ArrowRecord merges all parts in a Granule before returning an ArrowRecord over that part
-func (g *Granule) ArrowRecord(tx uint64, db *DB, pool memory.Allocator) (arrow.Record, error) {
+func (g *Granule) ArrowRecord(tx uint64, txCompleted func(uint64) bool, pool memory.Allocator) (arrow.Record, error) {
 	g.RLock()
 	defer g.RUnlock()
 
 	// Merge the parts
-	p, err := Merge(tx, db, g.parts...)
+	p, err := Merge(tx, txCompleted, g.parts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/columnstore/granule.go
+++ b/pkg/columnstore/granule.go
@@ -127,7 +127,7 @@ func (g *Granule) split(n int) ([]*Granule, error) {
 }
 
 // ArrowRecord merges all parts in a Granule before returning an ArrowRecord over that part
-func (g *Granule) ArrowRecord(tx uint64, txCompleted func(uint64) bool, pool memory.Allocator) (arrow.Record, error) {
+func (g *Granule) ArrowRecord(tx uint64, txCompleted func(uint64) uint64, pool memory.Allocator) (arrow.Record, error) {
 	g.RLock()
 	defer g.RUnlock()
 

--- a/pkg/columnstore/granule.go
+++ b/pkg/columnstore/granule.go
@@ -90,6 +90,8 @@ func (g *Granule) split(n int) ([]*Granule, error) {
 		return []*Granule{g}, nil // do nothing
 	}
 
+	tx := uint64(0) // TODO what is the tx during a split?
+
 	// How many granules we'll need to build
 	count := g.parts[0].Cardinality / n
 
@@ -101,7 +103,7 @@ func (g *Granule) split(n int) ([]*Granule, error) {
 	for it.Next() {
 		rows = append(rows, Row{Values: it.Values()})
 		if len(rows) == n && len(granules) != count-1 { // If we have n rows, and aren't on the last granule, create the n-sized granule
-			p, err := NewPart(g.parts[0].schema, rows)
+			p, err := NewPart(tx, g.parts[0].schema, rows)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create new part: %w", err)
 			}
@@ -112,7 +114,7 @@ func (g *Granule) split(n int) ([]*Granule, error) {
 
 	// Save the remaining Granule
 	if len(rows) != 0 {
-		p, err := NewPart(g.parts[0].schema, rows)
+		p, err := NewPart(tx, g.parts[0].schema, rows)
 		if err != nil {
 			if err != nil {
 				return nil, fmt.Errorf("failed to create new part: %w", err)
@@ -125,12 +127,12 @@ func (g *Granule) split(n int) ([]*Granule, error) {
 }
 
 // ArrowRecord merges all parts in a Granule before returning an ArrowRecord over that part
-func (g *Granule) ArrowRecord(pool memory.Allocator) (arrow.Record, error) {
+func (g *Granule) ArrowRecord(tx uint64, pool memory.Allocator) (arrow.Record, error) {
 	g.RLock()
 	defer g.RUnlock()
 
 	// Merge the parts
-	p, err := Merge(g.parts...)
+	p, err := Merge(tx, g.parts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/columnstore/part.go
+++ b/pkg/columnstore/part.go
@@ -94,14 +94,14 @@ func (pi *PartIterator) Err() error {
 }
 
 // Merge merges all parts into a single part
-func Merge(tx uint64, db *DB, parts ...*Part) (*Part, error) {
+func Merge(tx uint64, txCompleted func(uint64) bool, parts ...*Part) (*Part, error) {
 
 	rows := SortableRows{}
 	// Convert all the parts into a set of rows
 	for _, p := range parts {
 
 		// Don't merge parts from an newer tx, or from an uncompleted tx
-		if p.tx > tx || db.txCompleted(p.tx) {
+		if p.tx > tx || !txCompleted(p.tx) {
 			continue
 		}
 

--- a/pkg/columnstore/part.go
+++ b/pkg/columnstore/part.go
@@ -94,11 +94,17 @@ func (pi *PartIterator) Err() error {
 }
 
 // Merge merges all parts into a single part
-func Merge(tx uint64, parts ...*Part) (*Part, error) {
+func Merge(tx uint64, db *DB, parts ...*Part) (*Part, error) {
 
 	rows := SortableRows{}
 	// Convert all the parts into a set of rows
 	for _, p := range parts {
+
+		// Don't merge parts from an newer tx, or from an uncompleted tx
+		if p.tx > tx || db.txCompleted(p.tx) {
+			continue
+		}
+
 		it := p.Iterator()
 		for it.Next() {
 			rows = append(rows, Row{Values: it.Values()})

--- a/pkg/columnstore/part.go
+++ b/pkg/columnstore/part.go
@@ -14,12 +14,17 @@ type Part struct {
 	schema      Schema
 	columns     []Iterable
 	Cardinality int
+
+	// transaction id that this part was indserted under
+	tx uint64
 }
 
-func NewPart(schema Schema, rows []Row) (*Part, error) {
+func NewPart(tx uint64, schema Schema, rows []Row) (*Part, error) {
 	p := &Part{
 		schema:      schema,
 		Cardinality: len(rows),
+
+		tx: tx,
 	}
 	p.columns = make([]Iterable, len(schema.Columns))
 
@@ -89,7 +94,7 @@ func (pi *PartIterator) Err() error {
 }
 
 // Merge merges all parts into a single part
-func Merge(parts ...*Part) (*Part, error) {
+func Merge(tx uint64, parts ...*Part) (*Part, error) {
 
 	rows := SortableRows{}
 	// Convert all the parts into a set of rows
@@ -103,7 +108,7 @@ func Merge(parts ...*Part) (*Part, error) {
 	// Sort the rows
 	sort.Sort(rows)
 
-	return NewPart(parts[0].schema, rows)
+	return NewPart(tx, parts[0].schema, rows)
 }
 
 // SortableRows is a slice of Rows that can be sorted

--- a/pkg/columnstore/part.go
+++ b/pkg/columnstore/part.go
@@ -94,14 +94,14 @@ func (pi *PartIterator) Err() error {
 }
 
 // Merge merges all parts into a single part
-func Merge(tx uint64, txCompleted func(uint64) bool, parts ...*Part) (*Part, error) {
+func Merge(tx uint64, txCompleted func(uint64) uint64, parts ...*Part) (*Part, error) {
 
 	rows := SortableRows{}
 	// Convert all the parts into a set of rows
 	for _, p := range parts {
 
-		// Don't merge parts from an newer tx, or from an uncompleted tx
-		if p.tx > tx || !txCompleted(p.tx) {
+		// Don't merge parts from an newer tx, or from an uncompleted tx, or a completed tx that finished after this tx started
+		if p.tx > tx || txCompleted(p.tx) > tx {
 			continue
 		}
 

--- a/pkg/columnstore/part_test.go
+++ b/pkg/columnstore/part_test.go
@@ -85,7 +85,7 @@ func Test_PartMerge(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	part, err := Merge(0, p, p1, p2, p3)
+	part, err := Merge(0, func(uint64) bool { return true }, p, p1, p2, p3)
 	require.NoError(t, err)
 	require.NotNil(t, part)
 

--- a/pkg/columnstore/part_test.go
+++ b/pkg/columnstore/part_test.go
@@ -85,7 +85,7 @@ func Test_PartMerge(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	part, err := Merge(0, func(uint64) bool { return true }, p, p1, p2, p3)
+	part, err := Merge(0, func(uint64) uint64 { return 0 }, p, p1, p2, p3)
 	require.NoError(t, err)
 	require.NotNil(t, part)
 

--- a/pkg/columnstore/part_test.go
+++ b/pkg/columnstore/part_test.go
@@ -27,7 +27,7 @@ func Test_PartMerge(t *testing.T) {
 		OrderedBy: []string{"labels", "timestamp"},
 	}
 
-	p, err := NewPart(schema, []Row{
+	p, err := NewPart(0, schema, []Row{
 		{
 			Values: []interface{}{
 				[]DynamicColumnValue{
@@ -41,7 +41,7 @@ func Test_PartMerge(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	p1, err := NewPart(schema, []Row{
+	p1, err := NewPart(0, schema, []Row{
 		{
 			Values: []interface{}{
 				[]DynamicColumnValue{
@@ -56,7 +56,7 @@ func Test_PartMerge(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	p2, err := NewPart(schema, []Row{
+	p2, err := NewPart(0, schema, []Row{
 		{
 			Values: []interface{}{
 				[]DynamicColumnValue{
@@ -70,7 +70,7 @@ func Test_PartMerge(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	p3, err := NewPart(schema, []Row{
+	p3, err := NewPart(0, schema, []Row{
 		{
 			Values: []interface{}{
 				[]DynamicColumnValue{
@@ -85,7 +85,7 @@ func Test_PartMerge(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	part, err := Merge(p, p1, p2, p3)
+	part, err := Merge(0, p, p1, p2, p3)
 	require.NoError(t, err)
 	require.NotNil(t, part)
 

--- a/pkg/columnstore/table.go
+++ b/pkg/columnstore/table.go
@@ -143,7 +143,7 @@ func (t *Table) splitGranule(granule *Granule) {
 
 	tx := uint64(0) // TODO what is the tx
 
-	newpart, err := Merge(tx, granule.parts...) // need to merge all parts in a granule before splitting
+	newpart, err := Merge(tx, t.db.txCompleted, granule.parts...) // need to merge all parts in a granule before splitting
 	if err != nil {
 		level.Error(t.logger).Log("msg", "failed to merge parts", "error", err)
 	}
@@ -176,7 +176,7 @@ func (t *Table) Iterator(pool memory.Allocator, iterator func(r arrow.Record) er
 	var err error
 	t.granuleIterator(func(g *Granule) bool {
 		var r arrow.Record
-		r, err = g.ArrowRecord(tx, t.db, pool)
+		r, err = g.ArrowRecord(tx, t.db.txCompleted, pool)
 		if err != nil {
 			return false
 		}


### PR DESCRIPTION
transaction isolation.

Since our concurrency model currently uses a stop the world approach during splits, we don't require the index copying for MVOCC. But it's definitely something we may need in the future for performance