### PR TITLE
Add support for non-root-prefixes for grpc-web

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -93,7 +93,6 @@ func (s *Server) ListenAndServe(ctx context.Context, logger log.Logger, port str
 
 	logOpts := []grpc_logging.Option{
 		grpc_logging.WithDecider(func(_ string, err error) grpc_logging.Decision {
-
 			runtimeLevel := grpc_logging.DefaultServerCodeToLevel(status.Code(err))
 			for _, lvl := range MapAllowedLevels[logLevel] {
 				if string(runtimeLevel) == strings.ToLower(lvl) {
@@ -167,7 +166,6 @@ func (s *Server) ListenAndServe(ctx context.Context, logger log.Logger, port str
 	}
 
 	uiHandler, err := s.uiHandler(uiFS)
-
 	if err != nil {
 		return fmt.Errorf("failed to walk ui filesystem: %w", err)
 	}
@@ -221,15 +219,12 @@ func (s *Server) uiHandler(uiFS fs.FS) (*http.ServeMux, error) {
 		}
 
 		b, err := fs.ReadFile(uiFS, path)
-
 		if err != nil {
 			return fmt.Errorf("failed to read ui file %s: %w", path, err)
 		}
 
 		if strings.HasSuffix(path, ".html") {
-
 			tmpl, err := template.New(path).Parse(string(b))
-
 			if err != nil {
 				return fmt.Errorf("failed to parse ui file %s: %w", path, err)
 			}
@@ -250,7 +245,6 @@ func (s *Server) uiHandler(uiFS fs.FS) (*http.ServeMux, error) {
 		}
 
 		fi, err := d.Info()
-
 		if err != nil {
 			return fmt.Errorf("failed to receive file info %s: %w", path, err)
 		}
@@ -269,7 +263,6 @@ func (s *Server) uiHandler(uiFS fs.FS) (*http.ServeMux, error) {
 
 		return nil
 	})
-
 	if err != nil {
 		return nil, err
 	}
@@ -286,10 +279,12 @@ func grpcHandlerFunc(grpcServer *grpc.Server, otherHandler http.Handler, allowed
 	for _, o := range allowedCORSOrigins {
 		origins[o] = struct{}{}
 	}
-	wrappedGrpc := grpcweb.WrapServer(grpcServer, grpcweb.WithOriginFunc(func(origin string) bool {
-		_, found := origins[origin]
-		return found || allowAll
-	}))
+	wrappedGrpc := grpcweb.WrapServer(grpcServer,
+		grpcweb.WithAllowNonRootResource(true),
+		grpcweb.WithOriginFunc(func(origin string) bool {
+			_, found := origins[origin]
+			return found || allowAll
+		}))
 
 	corsMiddleware := cors.New(cors.Options{
 		AllowOriginFunc: func(r *http.Request, origin string) bool {

--- a/ui/packages/app/web/src/pages/index.tsx
+++ b/ui/packages/app/web/src/pages/index.tsx
@@ -9,7 +9,9 @@ interface ProfilesProps {
 }
 
 const Profiles = (_: ProfilesProps): JSX.Element => {
-  const queryClient = new QueryServiceClient(apiEndpoint === undefined ? '' : apiEndpoint);
+  const queryClient = new QueryServiceClient(
+    apiEndpoint === undefined ? '/api' : `${apiEndpoint}/api`
+  );
   return <ProfileExplorer queryClient={queryClient} />;
 };
 


### PR DESCRIPTION
This allows us to also simply put `/api` in front of API requests and still get the correct resources served. It seems as if [grpcweb.WithAllowNonRootResource](https://github.com/improbable-eng/grpc-web/blob/7dc90821e5bbaae7ff8c2386f72d59653d0fb169/go/grpcweb/options.go#L164-L168) simply truncates any prefix and basically matches the endings. The actual stripping of the prefix happens in [getGRPCEndpoint](https://github.com/improbable-eng/grpc-web/blob/7dc90821e5bbaae7ff8c2386f72d59653d0fb169/go/grpcweb/helpers.go#L43-L50).

For now I added `/api` as prefix in the frontend queryClient but we could also go with `/grpc` instead. Whatever people feel is better.

Closes #614 
Unblocks #598 

