### PR TITLE
fix(config): Fix panic on empty profiling_config

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -190,7 +190,7 @@ func (c *ScrapeConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 
-	if unmarshalled.ProfilingConfig == nil {
+	if unmarshalled.ProfilingConfig == nil || unmarshalled.ProfilingConfig.PprofConfig == nil {
 		unmarshalled.ProfilingConfig = defaults.ProfilingConfig
 	} else {
 		// Merge unmarshalled config with defaults

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -50,58 +50,69 @@ scrape_configs:
         fgprof:
           enabled: true
           path: /debug/fgprof
+  - job_name: 'empty-profiling-config'
+    profiling_config: {}
 `
 
 	expected := &Config{
-		ScrapeConfigs: []*ScrapeConfig{{
-			JobName:        "conprof",
-			ScrapeInterval: model.Duration(10 * time.Second),
-			ScrapeTimeout:  model.Duration(10 * time.Second),
-			Scheme:         "http",
-			ProfilingConfig: &ProfilingConfig{
-				PprofConfig: PprofConfig{
-					"memory_total": &PprofProfilingConfig{
-						Enabled: trueValue(),
-						Path:    "/conprof/debug/pprof/allocs",
-					},
-					"block_total": &PprofProfilingConfig{
-						Enabled: trueValue(),
-						Path:    "/debug/pprof/block",
-					},
-					"goroutine_total": &PprofProfilingConfig{
-						Enabled: trueValue(),
-						Path:    "/debug/pprof/goroutine",
-					},
-					"mutex_total": &PprofProfilingConfig{
-						Enabled: trueValue(),
-						Path:    "/debug/pprof/mutex",
-					},
-					"process_cpu": &PprofProfilingConfig{
-						Enabled: trueValue(),
-						Delta:   true,
-						Path:    "/debug/pprof/profile",
-					},
-					"threadcreate_total": &PprofProfilingConfig{
-						Enabled: trueValue(),
-						Path:    "/debug/pprof/threadcreate",
-					},
-					"fgprof": &PprofProfilingConfig{
-						Enabled: trueValue(),
-						Path:    "/debug/fgprof",
+		ScrapeConfigs: []*ScrapeConfig{
+			{
+				JobName:        "conprof",
+				ScrapeInterval: model.Duration(10 * time.Second),
+				ScrapeTimeout:  model.Duration(10 * time.Second),
+				Scheme:         "http",
+				ProfilingConfig: &ProfilingConfig{
+					PprofConfig: PprofConfig{
+						"memory_total": &PprofProfilingConfig{
+							Enabled: trueValue(),
+							Path:    "/conprof/debug/pprof/allocs",
+						},
+						"block_total": &PprofProfilingConfig{
+							Enabled: trueValue(),
+							Path:    "/debug/pprof/block",
+						},
+						"goroutine_total": &PprofProfilingConfig{
+							Enabled: trueValue(),
+							Path:    "/debug/pprof/goroutine",
+						},
+						"mutex_total": &PprofProfilingConfig{
+							Enabled: trueValue(),
+							Path:    "/debug/pprof/mutex",
+						},
+						"process_cpu": &PprofProfilingConfig{
+							Enabled: trueValue(),
+							Delta:   true,
+							Path:    "/debug/pprof/profile",
+						},
+						"threadcreate_total": &PprofProfilingConfig{
+							Enabled: trueValue(),
+							Path:    "/debug/pprof/threadcreate",
+						},
+						"fgprof": &PprofProfilingConfig{
+							Enabled: trueValue(),
+							Path:    "/debug/fgprof",
+						},
 					},
 				},
+				ServiceDiscoveryConfigs: discovery.Configs{discovery.StaticConfig{{
+					Targets: []model.LabelSet{{"__address__": "localhost:10902"}},
+					Labels:  nil,
+					Source:  "0",
+				}}},
 			},
-			ServiceDiscoveryConfigs: discovery.Configs{discovery.StaticConfig{{
-				Targets: []model.LabelSet{{"__address__": "localhost:10902"}},
-				Labels:  nil,
-				Source:  "0",
-			}}},
-		}},
+			{
+				JobName:        "empty-profiling-config",
+				ScrapeInterval: model.Duration(10 * time.Second),
+				ScrapeTimeout:  model.Duration(10 * time.Second),
+				Scheme:         "http",
+				ProfilingConfig: DefaultScrapeConfig().ProfilingConfig,
+			},
+        },
 	}
 
 	c, err := Load(complexYAML)
 	require.NoError(t, err)
-	require.Len(t, c.ScrapeConfigs, 1)
+	require.Len(t, c.ScrapeConfigs, 2)
 	require.Equal(t, expected, c)
 }
 


### PR DESCRIPTION
Hello there 👋, what an exciting project you have here!

I just started pocking around with Parca, and I hit this little bug on a define `profiling_config`, but empty `{}`, so not `nil`:

<details>
<summary>logs</summary>

```
ooooooooo.
`888   `Y88.
 888   .d88'  .oooo.   oooo d8b  .ooooo.   .oooo.
 888ooo88P'  `P  )88b  `888""8P d88' `"Y8 `P  )88b
 888          .oP"888   888     888        .oP"888
 888         d8(  888   888     888   .o8 d8(  888
o888o        `Y888""8o d888b    `Y8bod8P' `Y888""8o



panic: assignment to entry in nil map [recovered]
        panic: assignment to entry in nil map

goroutine 1 [running]:
gopkg.in/yaml%2ev2.handleErr(0xc002c9fa20)
        gopkg.in/yaml.v2@v2.4.0/yaml.go:249 +0x8d
panic(0x3236b20, 0x3e82970)
        runtime/panic.go:965 +0x1b9
github.com/parca-dev/parca/pkg/config.(*ScrapeConfig).UnmarshalYAML(0xc00033f800, 0xc0004f7920, 0x0, 0x7f999266ccb8)
        github.com/parca-dev/parca/pkg/config/config.go:200 +0x3f8
gopkg.in/yaml%2ev2.(*decoder).callUnmarshaler(0xc0005e1080, 0xc00041fc00, 0x7f999266ccb8, 0xc00033f800, 0xc00033f800)
        gopkg.in/yaml.v2@v2.4.0/decode.go:270 +0xa6
gopkg.in/yaml%2ev2.(*decoder).prepare(0xc0005e1080, 0xc00041fc00, 0x325e5e0, 0xc00034c138, 0x196, 0x2f12060, 0xc000898cc0, 0x2f12060, 0x0)
        gopkg.in/yaml.v2@v2.4.0/decode.go:313 +0x1d0
gopkg.in/yaml%2ev2.(*decoder).unmarshal(0xc0005e1080, 0xc00041fc00, 0x325e5e0, 0xc00034c138, 0x196, 0x196)
        gopkg.in/yaml.v2@v2.4.0/decode.go:364 +0xe9
gopkg.in/yaml%2ev2.(*decoder).sequence(0xc0005e1080, 0xc00041fb90, 0x2f258e0, 0xc0004f7508, 0x197, 0x2f258e0)
        gopkg.in/yaml.v2@v2.4.0/decode.go:609 +0x272
gopkg.in/yaml%2ev2.(*decoder).unmarshal(0xc0005e1080, 0xc00041fb90, 0x2f258e0, 0xc0004f7508, 0x197, 0xc0004f7508)
        gopkg.in/yaml.v2@v2.4.0/decode.go:374 +0x18a
gopkg.in/yaml%2ev2.(*decoder).mappingStruct(0xc0005e1080, 0xc00041f180, 0x33ee2a0, 0xc0004f7500, 0x199, 0x32d5a88)
        gopkg.in/yaml.v2@v2.4.0/decode.go:767 +0xa33
gopkg.in/yaml%2ev2.(*decoder).mapping(0xc0005e1080, 0xc00041f180, 0x33ee2a0, 0xc0004f7500, 0x199, 0x33ee2a0)
        gopkg.in/yaml.v2@v2.4.0/decode.go:626 +0xa67
gopkg.in/yaml%2ev2.(*decoder).unmarshal(0xc0005e1080, 0xc00041f180, 0x33ee2a0, 0xc0004f7500, 0x199, 0x0)
        gopkg.in/yaml.v2@v2.4.0/decode.go:372 +0x1b6
gopkg.in/yaml%2ev2.(*decoder).document(0xc0005e1080, 0xc00041f110, 0x33ee2a0, 0xc0004f7500, 0x199, 0xec9887)
        gopkg.in/yaml.v2@v2.4.0/decode.go:384 +0x7c
gopkg.in/yaml%2ev2.(*decoder).unmarshal(0xc0005e1080, 0xc00041f110, 0x33ee2a0, 0xc0004f7500, 0x199, 0x199)
        gopkg.in/yaml.v2@v2.4.0/decode.go:360 +0x250
gopkg.in/yaml%2ev2.unmarshal(0xc000335000, 0xdd3, 0xdd4, 0x32d5a40, 0xc0004f7500, 0x0, 0x0, 0x0)
        gopkg.in/yaml.v2@v2.4.0/yaml.go:148 +0x33f
gopkg.in/yaml%2ev2.Unmarshal(...)
        gopkg.in/yaml.v2@v2.4.0/yaml.go:81
github.com/parca-dev/parca/pkg/parca.Run(0x3f5d540, 0xc000128000, 0x3eff740, 0xc000b82910, 0xc000b829b0, 0xc0008a0780, 0x3e7d870, 0x6, 0x0, 0x0)
        github.com/parca-dev/parca/pkg/parca/parca.go:97 +0x2d2
main.main()
        github.com/parca-dev/parca/cmd/parca/main.go:56 +0x519
```

</details>