### PR TITLE
fix(grafana): Fix datasource template

### DIFF
--- a/deploy/grafana/parca.json
+++ b/deploy/grafana/parca.json
@@ -1,40 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_LOCALHOST",
-      "label": "localhost",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
-  "__requires": [
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "8.1.5"
-    },
-    {
-      "type": "datasource",
-      "id": "prometheus",
-      "name": "Prometheus",
-      "version": "1.0.0"
-    },
-    {
-      "type": "panel",
-      "id": "stat",
-      "name": "Stat",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "timeseries",
-      "name": "Time series",
-      "version": ""
-    }
-  ],
   "annotations": {
     "list": [
       {
@@ -62,7 +26,7 @@
   "links": [],
   "panels": [
     {
-      "datasource": "${DS_LOCALHOST}",
+      "datasource": "$datasource",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -146,7 +110,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": null,
+      "datasource": "$datasource",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -158,7 +122,7 @@
       "type": "row"
     },
     {
-      "datasource": "${DS_LOCALHOST}",
+      "datasource": "$datasource",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -241,7 +205,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": "${DS_LOCALHOST}",
+      "datasource": "$datasource",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -320,7 +284,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": "${DS_LOCALHOST}",
+      "datasource": "$datasource",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -420,7 +384,7 @@
     },
     {
       "collapsed": false,
-      "datasource": null,
+      "datasource": "$datasource",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -433,7 +397,7 @@
       "type": "row"
     },
     {
-      "datasource": "${DS_LOCALHOST}",
+      "datasource": "$datasource",
       "description": "These are the requests that query the overview metrics for profiles over a given time range.",
       "fieldConfig": {
         "defaults": {
@@ -516,7 +480,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": "${DS_LOCALHOST}",
+      "datasource": "$datasource",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -595,7 +559,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": "${DS_LOCALHOST}",
+      "datasource": "$datasource",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -694,7 +658,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": "${DS_LOCALHOST}",
+      "datasource": "$datasource",
       "description": "These are requests that show the actual profiles.",
       "fieldConfig": {
         "defaults": {
@@ -777,7 +741,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": "${DS_LOCALHOST}",
+      "datasource": "$datasource",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -856,7 +820,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": "${DS_LOCALHOST}",
+      "datasource": "$datasource",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -955,7 +919,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": "${DS_LOCALHOST}",
+      "datasource": "$datasource",
       "description": "These are the requests that return label names and values, usually used in UIs for label suggestions.",
       "fieldConfig": {
         "defaults": {
@@ -1038,7 +1002,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": "${DS_LOCALHOST}",
+      "datasource": "$datasource",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -1117,7 +1081,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": "${DS_LOCALHOST}",
+      "datasource": "$datasource",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -1216,7 +1180,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": null,
+      "datasource": "$datasource",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1228,7 +1192,7 @@
       "type": "row"
     },
     {
-      "datasource": "${DS_LOCALHOST}",
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1309,7 +1273,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": "${DS_LOCALHOST}",
+      "datasource": "$datasource",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -1368,7 +1332,7 @@
       "type": "stat"
     },
     {
-      "datasource": "${DS_LOCALHOST}",
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1434,14 +1398,14 @@
       {
         "current": {
           "selected": false,
-          "text": "localhost",
-          "value": "localhost"
+          "text": "Prometheus",
+          "value": "Prometheus"
         },
         "description": null,
         "error": null,
         "hide": 0,
         "includeAll": false,
-        "label": null,
+        "label": "Data Source",
         "multi": false,
         "name": "datasource",
         "options": [],


### PR DESCRIPTION
The template name had likely been overwritten by the Grafana export.

I have done that so many times, I have written scripts a couple years ago, now in a Gist if that helps anyone:
https://gist.github.com/maxbrunet/e96dee35f7e5fcd73a98929f4bc9c2bb