### PR TITLE
area/ui: Fix selecting multiple labels breaking the UI

### DIFF
--- a/ui/packages/app/web/src/components/ProfileExplorer.tsx
+++ b/ui/packages/app/web/src/components/ProfileExplorer.tsx
@@ -17,10 +17,7 @@ const ProfileExplorer = ({
   queryParams,
   navigateTo,
 }: ProfileExplorerProps): JSX.Element => {
-  /* eslint-disable */
-  // Disable eslint due to params being snake case
   const {
-    expression_a,
     from_a,
     to_a,
     merge_a,
@@ -28,7 +25,6 @@ const ProfileExplorer = ({
     time_a,
     time_selection_a,
     compare_a,
-    expression_b,
     from_b,
     to_b,
     merge_b,
@@ -37,7 +33,14 @@ const ProfileExplorer = ({
     time_selection_b,
     compare_b,
   } = queryParams;
-  /* eslint-enable */
+
+  const expression_a: string = Array.isArray(queryParams.expression_a)
+    ? queryParams.expression_a.join()
+    : queryParams.expression_a;
+
+  const expression_b = Array.isArray(queryParams.expression_b)
+    ? queryParams.expression_b.join()
+    : queryParams.expression_b;
 
   const filterSuffix = (
     o: {[key: string]: string | string[] | undefined},
@@ -97,7 +100,7 @@ const ProfileExplorer = ({
         {
           ...filterSuffix(queryParams, '_a'),
           ...{
-            expression_a: q.expression,
+            expression_a: encodeURIComponent(q.expression),
             from_a: q.from.toString(),
             to_a: q.to.toString(),
             merge_a: q.merge,
@@ -118,14 +121,14 @@ const ProfileExplorer = ({
     const compareProfile = (): void => {
       let compareQuery = {
         compare_a: 'true',
-        expression_a: query.expression,
+        expression_a: encodeURIComponent(query.expression),
         from_a: query.from.toString(),
         to_a: query.to.toString(),
         merge_a: query.merge,
         time_selection_a: query.timeSelection,
 
         compare_b: 'true',
-        expression_b: query.expression,
+        expression_b: encodeURIComponent(query.expression),
         from_b: query.from.toString(),
         to_b: query.to.toString(),
         merge_b: query.merge,
@@ -203,7 +206,7 @@ const ProfileExplorer = ({
         ...filterSuffix(queryParams, '_a'),
         ...{
           compare_a: 'true',
-          expression_a: q.expression,
+          expression_a: encodeURIComponent(q.expression),
           from_a: q.from.toString(),
           to_a: q.to.toString(),
           merge_a: q.merge,
@@ -222,7 +225,7 @@ const ProfileExplorer = ({
         ...filterSuffix(queryParams, '_b'),
         ...{
           compare_b: 'true',
-          expression_b: q.expression,
+          expression_b: encodeURIComponent(q.expression),
           from_b: q.from.toString(),
           to_b: q.to.toString(),
           merge_b: q.merge,

--- a/ui/packages/app/web/src/components/ProfileExplorer.tsx
+++ b/ui/packages/app/web/src/components/ProfileExplorer.tsx
@@ -12,6 +12,11 @@ interface ProfileExplorerProps {
   navigateTo: NavigateFunction;
 }
 
+const getExpressionAsAString = (expression: string | []) => {
+  const x = Array.isArray(expression) ? expression.join() : expression;
+  return x;
+};
+
 const ProfileExplorer = ({
   queryClient,
   queryParams,
@@ -34,13 +39,12 @@ const ProfileExplorer = ({
     compare_b,
   } = queryParams;
 
-  const expression_a: string = Array.isArray(queryParams.expression_a)
-    ? queryParams.expression_a.join()
-    : queryParams.expression_a;
+  const expression_a = getExpressionAsAString(queryParams.expression_a);
 
-  const expression_b = Array.isArray(queryParams.expression_b)
-    ? queryParams.expression_b.join()
-    : queryParams.expression_b;
+  const expression_b = getExpressionAsAString(queryParams.expression_b);
+
+  if (queryParams && queryParams.expression_a) queryParams.expression_a = expression_a;
+  if (queryParams && queryParams.expression_b) queryParams.expression_b = expression_b;
 
   const filterSuffix = (
     o: {[key: string]: string | string[] | undefined},
@@ -60,6 +64,8 @@ const ProfileExplorer = ({
   };
 
   const selectProfileA = (p: ProfileSelection) => {
+    queryParams.expression_a = encodeURIComponent(queryParams.expression_a);
+    queryParams.expression_b = encodeURIComponent(queryParams.expression_b);
     return navigateTo('/', {
       ...queryParams,
       ...SuffixParams(p.HistoryParams(), '_a'),
@@ -67,6 +73,8 @@ const ProfileExplorer = ({
   };
 
   const selectProfileB = (p: ProfileSelection) => {
+    queryParams.expression_a = encodeURIComponent(queryParams.expression_a);
+    queryParams.expression_b = encodeURIComponent(queryParams.expression_b);
     return navigateTo('/', {
       ...queryParams,
       ...SuffixParams(p.HistoryParams(), '_b'),
@@ -112,6 +120,7 @@ const ProfileExplorer = ({
     };
 
     const selectProfile = (p: ProfileSelection) => {
+      queryParams.expression_a = encodeURIComponent(queryParams.expression_a);
       return navigateTo('/', {
         ...queryParams,
         ...SuffixParams(p.HistoryParams(), '_a'),
@@ -207,6 +216,7 @@ const ProfileExplorer = ({
         ...{
           compare_a: 'true',
           expression_a: encodeURIComponent(q.expression),
+          expression_b: encodeURIComponent(expression_b),
           from_a: q.from.toString(),
           to_a: q.to.toString(),
           merge_a: q.merge,
@@ -226,6 +236,7 @@ const ProfileExplorer = ({
         ...{
           compare_b: 'true',
           expression_b: encodeURIComponent(q.expression),
+          expression_a: encodeURIComponent(expression_a),
           from_b: q.from.toString(),
           to_b: q.to.toString(),
           merge_b: q.merge,


### PR DESCRIPTION
Fixes #662

Two things were responsible for the bug here. The query parameter  `expression_a` was being interpreted as an array whenever there are multiple labels and it was not being encoded. This PR checks if the query param is an array, if it is, it converts it to a string and then encodes them in the fns for selecting profiles and queries.