### PR TITLE
ui/datePicker: Date Range Picker uses UTC as the timezone

### DIFF
--- a/ui/packages/app/web/src/components/ui/DateTimePicker/index.tsx
+++ b/ui/packages/app/web/src/components/ui/DateTimePicker/index.tsx
@@ -1,0 +1,24 @@
+import {convertLocalToUTCDate, convertUTCToLocalDate} from '@parca/functions';
+import ReactDatePicker from 'react-datepicker';
+
+const DateTimePicker = ({selected, onChange}) => (
+  <ReactDatePicker
+    selected={selected}
+    onChange={onChange}
+    showTimeInput
+    dateFormat="MMMM d, yyyy h:mm aa"
+    className="text-sm w-52 p-2 rounded-md  bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-600"
+  />
+);
+
+export const UTCDateTimePicker = ({selected, onChange}) => (
+  <ReactDatePicker
+    selected={convertUTCToLocalDate(selected)}
+    onChange={date => onChange(convertLocalToUTCDate(date))}
+    showTimeInput
+    dateFormat="MMMM d, yyyy h:mm aa"
+    className="text-sm w-52 p-2 rounded-md  bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-600"
+  />
+);
+
+export default DateTimePicker;

--- a/ui/packages/app/web/src/components/ui/DateTimeRangePicker/DateTimeRangePickerPanel/AbsoluteDatePicker/index.tsx
+++ b/ui/packages/app/web/src/components/ui/DateTimeRangePicker/DateTimeRangePickerPanel/AbsoluteDatePicker/index.tsx
@@ -1,8 +1,8 @@
 import {useState} from 'react';
-import DatePicker from 'react-datepicker';
 
 import {AbsoluteDate, DateTimeRange, getDateHoursAgo} from '../../utils';
 import Button from '../../../Button';
+import {UTCDateTimePicker} from '../../../DateTimePicker';
 
 import 'react-datepicker/dist/react-datepicker.css';
 
@@ -10,16 +10,6 @@ interface AbsoluteDatePickerProps {
   range: DateTimeRange;
   onChange?: (from: AbsoluteDate, to: AbsoluteDate) => void;
 }
-
-const ReactDateTimePicker = ({selected, onChange}) => (
-  <DatePicker
-    selected={selected}
-    onChange={onChange}
-    showTimeInput
-    dateFormat="MMMM d, yyyy h:mm aa"
-    className="text-sm w-48 p-2 rounded-md  bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-600"
-  />
-);
 
 const AbsoluteDatePicker = ({range, onChange = () => null}: AbsoluteDatePickerProps) => {
   const [from, setFrom] = useState<Date>(
@@ -38,13 +28,13 @@ const AbsoluteDatePicker = ({range, onChange = () => null}: AbsoluteDatePickerPr
           <div className="mb-2">
             <span className="uppercase text-xs">From:</span>
           </div>
-          <ReactDateTimePicker selected={from} onChange={date => setFrom(date)} />
+          <UTCDateTimePicker selected={from} onChange={date => setFrom(date)} />
         </div>
         <div className="mb-1">
           <div className="mb-2">
             <span className="uppercase text-xs">To:</span>
           </div>
-          <ReactDateTimePicker selected={to} onChange={date => setTo(date)} />
+          <UTCDateTimePicker selected={to} onChange={date => setTo(date)} />
         </div>
       </div>
       <div className="w-32 mx-auto mt-4">
@@ -56,6 +46,9 @@ const AbsoluteDatePicker = ({range, onChange = () => null}: AbsoluteDatePickerPr
           Apply
         </Button>
       </div>
+      <p className="text-gray-500 text-xs italic text-center m-4">
+        Note: All date and time values are in UTC.
+      </p>
     </div>
   );
 };

--- a/ui/packages/app/web/src/components/ui/DateTimeRangePicker/utils.ts
+++ b/ui/packages/app/web/src/components/ui/DateTimeRangePicker/utils.ts
@@ -1,3 +1,5 @@
+import {convertLocalToUTCDate} from '@parca/functions';
+
 export const UNITS = {
   MINUTE: 'minute',
   HOUR: 'hour',
@@ -149,7 +151,7 @@ export const formatDateStringForUI: (dateString: DateUnion) => string = dateStri
     }
     return `${value} ${unit}${value > 1 ? 's' : ''} ago`;
   }
-  return (dateString.value as Date).toLocaleDateString('en-GB', {
+  return convertLocalToUTCDate(dateString.value as Date).toLocaleDateString('en-GB', {
     year: 'numeric',
     month: 'short',
     day: 'numeric',

--- a/ui/packages/shared/functions/src/index.ts
+++ b/ui/packages/shared/functions/src/index.ts
@@ -179,3 +179,33 @@ export const convertToQueryParams = params =>
   Object.keys(params)
     .map(key => key + '=' + params[key])
     .join('&');
+
+export function convertUTCToLocalDate(date: Date) {
+  if (!date) {
+    return date;
+  }
+  return new Date(
+    date.getUTCFullYear(),
+    date.getUTCMonth(),
+    date.getUTCDate(),
+    date.getUTCHours(),
+    date.getUTCMinutes(),
+    date.getUTCSeconds()
+  );
+}
+
+export function convertLocalToUTCDate(date: Date) {
+  if (!date) {
+    return date;
+  }
+  return new Date(
+    Date.UTC(
+      date.getFullYear(),
+      date.getMonth(),
+      date.getDate(),
+      date.getHours(),
+      date.getMinutes(),
+      date.getSeconds()
+    )
+  );
+}


### PR DESCRIPTION
Fixes #663.

Added a small note as well to indicate it is in UTC:
<img width="324" alt="Screenshot 2022-02-28 at 10 48 35 AM" src="https://user-images.githubusercontent.com/1283424/155928231-5ebf3cb5-f4ee-4f11-9452-6b8e8e0a3ce3.png">
