### PR TITLE
deploy: Remove amd64 node requirement

### DIFF
--- a/deploy/lib/parca/parca.libsonnet
+++ b/deploy/lib/parca/parca.libsonnet
@@ -258,7 +258,6 @@ function(params) {
             }],
             nodeSelector: {
               'kubernetes.io/os': 'linux',
-              'kubernetes.io/arch': 'amd64',
             },
           },
         },


### PR DESCRIPTION
We now have arm64 and further builds for other architectures so this is no longer a requirement.