### PR TITLE
area/ui: Remove Bootstrap step in publish.yml file

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,10 +39,6 @@ jobs:
           git config --global user.name "${{ github.actor }}"
           git config --global user.email "${{ github.actor }}@users.noreply.github.com"
 
-      - name: Bootstrap lerna
-        working-directory: ui
-        run: yarn bootstrap
-
       - name: Bump versions and publish packages
         working-directory: ui
         run: yarn publish:ci


### PR DESCRIPTION
`yarn bootstrap` runs the command `lerna bootstrap` which install all dependencies and links any cross-dependencies which isn't a needed step in the Publish action. It can also lead to errors like [this](https://github.com/parca-dev/parca/runs/5389939995?check_suite_focus=true) so it's best to remove the step entirely.