### PR TITLE
debuginfo: Fix several issues with debuginfod client

### DIFF
--- a/deploy/dev.jsonnet
+++ b/deploy/dev.jsonnet
@@ -16,6 +16,8 @@ function(agentVersion='v0.4.1')
     logLevel: 'debug',
     configPath: '/parca.yaml',
     corsAllowedOrigins: '*',
+    debugInfodUpstreamServers: ['https://debuginfod.systemtap.org'],
+    // debugInfodHTTPRequestTimeout: '5m',
   });
 
   local parcaAgent = (import 'parca-agent/parca-agent.libsonnet')({

--- a/deploy/lib/parca/parca.libsonnet
+++ b/deploy/lib/parca/parca.libsonnet
@@ -32,6 +32,9 @@ local defaults = {
   serviceMonitor: false,
   storageRetentionTime: '',
 
+  debugInfodUpstreamServers: ['https://debuginfod.systemtap.org'],
+  debugInfodHTTPRequestTimeout: '5m',
+
   commonLabels:: {
     'app.kubernetes.io/name': 'parca',
     'app.kubernetes.io/instance': defaults.name,
@@ -210,7 +213,11 @@ function(params) {
         (if prc.config.corsAllowedOrigins == '' then []
          else ['--cors-allowed-origins=' + prc.config.corsAllowedOrigins]) +
         (if prc.config.storageRetentionTime == '' then []
-         else ['--storage-tsdb-retention-time=' + prc.config.storageRetentionTime]),
+         else ['--storage-tsdb-retention-time=' + prc.config.storageRetentionTime]) +
+        (if std.length(prc.config.debugInfodUpstreamServers) == 0 then []
+         else ['--debug-infod-upstream-servers=' + std.join(',', prc.config.debugInfodUpstreamServers)]) +
+        (if prc.config.debugInfodHTTPRequestTimeout == '' then []
+         else ['--debug-infod-http-request-timeout=' + prc.config.debugInfodHTTPRequestTimeout]),
       ports: [
         { name: port.name, containerPort: port.port }
         for port in prc.service.spec.ports

--- a/pkg/debuginfo/store_test.go
+++ b/pkg/debuginfo/store_test.go
@@ -22,7 +22,6 @@ import (
 	"net"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/go-kit/log"
 	"github.com/stretchr/testify/require"
@@ -48,7 +47,6 @@ func TestStore(t *testing.T) {
 	sym, err := symbol.NewSymbolizer(logger)
 	require.NoError(t, err)
 
-	// cfg := config.Config{}
 	cfg := &Config{
 		Bucket: &client.BucketConfig{
 			Type: client.FILESYSTEM,
@@ -64,17 +62,11 @@ func TestStore(t *testing.T) {
 		},
 	}
 
-	httpDebugInfodClient, err := NewHTTPDebugInfodClient(logger, "https://debuginfod.systemtap.org", 4*time.Millisecond)
-	require.NoError(t, err)
-
-	debuginfodClientCache, err := NewDebugInfodClientWithObjectStorageCache(logger, cfg, httpDebugInfodClient)
-	require.NoError(t, err)
-
 	s, err := NewStore(
 		logger,
 		sym,
 		cfg,
-		debuginfodClientCache,
+		NopDebugInfodClient{},
 	)
 	require.NoError(t, err)
 

--- a/pkg/parca/parca.go
+++ b/pkg/parca/parca.go
@@ -73,7 +73,7 @@ type Flags struct {
 
 	Metastore string `default:"badgerinmemory" help:"Which metastore implementation to use" enum:"sqliteinmemory,badgerinmemory"`
 
-	UpstreamDebuginfodServer     string        `default:"https://debuginfod.systemtap.org" help:"Upstream private/public server for debuginfod files. Defaults to https://debuginfod.systemtap.org."`
+	DebugInfodUpstreamServers    []string      `default:"https://debuginfod.systemtap.org" help:"Upstream private/public servers for debuginfod files. Defaults to https://debuginfod.systemtap.org. It is an ordered list of servers to try."`
 	DebugInfodHTTPRequestTimeout time.Duration `default:"5m" help:"Timeout duration for HTTP request to upstream debuginfod server. Defaults to 5m"`
 }
 
@@ -179,19 +179,22 @@ func Run(ctx context.Context, logger log.Logger, reg *prometheus.Registry, flags
 		return err
 	}
 
-	httpDebugInfoClient, err := debuginfo.NewHTTPDebugInfodClient(logger, flags.UpstreamDebuginfodServer, flags.DebugInfodHTTPRequestTimeout)
-	if err != nil {
-		level.Error(logger).Log("msg", "failed to initialize debuginfod http client", "err", err)
-		return err
+	var debugInfodClient debuginfo.DebugInfodClient = debuginfo.NopDebugInfodClient{}
+	if len(flags.DebugInfodUpstreamServers) > 0 {
+		httpDebugInfoClient, err := debuginfo.NewHTTPDebugInfodClient(logger, flags.DebugInfodUpstreamServers, flags.DebugInfodHTTPRequestTimeout)
+		if err != nil {
+			level.Error(logger).Log("msg", "failed to initialize debuginfod http client", "err", err)
+			return err
+		}
+
+		debugInfodClient, err = debuginfo.NewDebugInfodClientWithObjectStorageCache(logger, cfg.DebugInfo, httpDebugInfoClient)
+		if err != nil {
+			level.Error(logger).Log("msg", "failed to initialize debuginfod client cache", "err", err)
+			return err
+		}
 	}
 
-	debugInfodClientCache, err := debuginfo.NewDebugInfodClientWithObjectStorageCache(logger, cfg.DebugInfo, httpDebugInfoClient)
-	if err != nil {
-		level.Error(logger).Log("msg", "failed to initialize debuginfod client cache", "err", err)
-		return err
-	}
-
-	dbgInfo, err := debuginfo.NewStore(logger, sym, cfg.DebugInfo, debugInfodClientCache)
+	dbgInfo, err := debuginfo.NewStore(logger, sym, cfg.DebugInfo, debugInfodClient)
 	if err != nil {
 		level.Error(logger).Log("msg", "failed to initialize debug info store", "err", err)
 		return err

--- a/pkg/symbolizer/symbolizer_test.go
+++ b/pkg/symbolizer/symbolizer_test.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"sort"
 	"testing"
-	"time"
 
 	"github.com/go-kit/log"
 	"github.com/google/pprof/profile"
@@ -427,17 +426,11 @@ func setup(t *testing.T) (*grpc.ClientConn, *debuginfo.Store, metastore.ProfileM
 		},
 	}
 
-	httpDebugInfodClient, err := debuginfo.NewHTTPDebugInfodClient(logger, "https://debuginfod.systemtap.org", 5*time.Minute)
-	require.NoError(t, err)
-
-	debuginfodClientCache, err := debuginfo.NewDebugInfodClientWithObjectStorageCache(logger, cfg, httpDebugInfodClient)
-	require.NoError(t, err)
-
 	dbgStr, err := debuginfo.NewStore(
 		logger,
 		sym,
 		cfg,
-		debuginfodClientCache)
+		debuginfo.NopDebugInfodClient{})
 	require.NoError(t, err)
 
 	mStr := metastore.NewBadgerMetastore(


### PR DESCRIPTION
- Optimize fetching objects from debuginfod server
  - Previously it was downloading from public server and uploading to object store then downloading again to utilize the object file.
  - Right now it caches the downloaded file to local filesystem and asynchronously uploads it to object store.
- Add the ability to specify multiple servers
- Add jsonnet config generators for debuginfod configurations
- Prevents actual requests to debuginfod servers while testing

Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>