### PR TITLE
pkg: Rename FlatProfile to Profile

### DIFF
--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -44,8 +44,8 @@ type ValueType struct {
 	Unit string
 }
 
-func CopyInstantFlatProfile(p InstantProfile) *FlatProfile {
-	return &FlatProfile{
+func CopyInstantFlatProfile(p InstantProfile) *Profile {
+	return &Profile{
 		Meta:        p.ProfileMeta(),
 		FlatSamples: p.Samples(),
 	}
@@ -61,16 +61,16 @@ type InstantFlatProfile interface {
 	Samples() map[string]*Sample
 }
 
-type FlatProfile struct {
+type Profile struct {
 	Meta        InstantProfileMeta
 	FlatSamples map[string]*Sample
 }
 
-func (fp *FlatProfile) ProfileMeta() InstantProfileMeta {
+func (fp *Profile) ProfileMeta() InstantProfileMeta {
 	return fp.Meta
 }
 
-func (fp *FlatProfile) Samples() map[string]*Sample {
+func (fp *Profile) Samples() map[string]*Sample {
 	return fp.FlatSamples
 }
 

--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -44,7 +44,7 @@ type ValueType struct {
 	Unit string
 }
 
-func CopyInstantFlatProfile(p InstantProfile) *Profile {
+func CopyInstantProfile(p InstantProfile) *Profile {
 	return &Profile{
 		Meta:        p.ProfileMeta(),
 		FlatSamples: p.Samples(),
@@ -52,11 +52,6 @@ func CopyInstantFlatProfile(p InstantProfile) *Profile {
 }
 
 type InstantProfile interface {
-	ProfileMeta() InstantProfileMeta
-	Samples() map[string]*Sample
-}
-
-type InstantFlatProfile interface {
 	ProfileMeta() InstantProfileMeta
 	Samples() map[string]*Sample
 }

--- a/pkg/profile/profile_flat.go
+++ b/pkg/profile/profile_flat.go
@@ -24,23 +24,23 @@ import (
 	"github.com/parca-dev/parca/pkg/metastore"
 )
 
-// FlatProfilesFromPprof extracts a Profile from each sample index included in the pprof profile.
-func FlatProfilesFromPprof(ctx context.Context, l log.Logger, s metastore.ProfileMetaStore, p *profile.Profile) ([]*Profile, error) {
-	fps := make([]*Profile, 0, len(p.SampleType))
+// ProfilesFromPprof extracts a Profile from each sample index included in the pprof profile.
+func ProfilesFromPprof(ctx context.Context, l log.Logger, s metastore.ProfileMetaStore, p *profile.Profile) ([]*Profile, error) {
+	ps := make([]*Profile, 0, len(p.SampleType))
 
 	for i := range p.SampleType {
-		fp, err := FlatProfileFromPprof(ctx, l, s, p, i)
+		p, err := ProfileFromPprof(ctx, l, s, p, i)
 		if err != nil {
 			return nil, err
 		}
-		if fp != nil {
-			fps = append(fps, fp)
+		if p != nil {
+			ps = append(ps, p)
 		}
 	}
-	return fps, nil
+	return ps, nil
 }
 
-func FlatProfileFromPprof(ctx context.Context, logger log.Logger, metaStore metastore.ProfileMetaStore, p *profile.Profile, sampleIndex int) (*Profile, error) {
+func ProfileFromPprof(ctx context.Context, logger log.Logger, metaStore metastore.ProfileMetaStore, p *profile.Profile, sampleIndex int) (*Profile, error) {
 	pfn := &profileFlatNormalizer{
 		logger:    logger,
 		metaStore: metaStore,

--- a/pkg/profile/profile_flat.go
+++ b/pkg/profile/profile_flat.go
@@ -29,7 +29,7 @@ func ProfilesFromPprof(ctx context.Context, l log.Logger, s metastore.ProfileMet
 	ps := make([]*Profile, 0, len(p.SampleType))
 
 	for i := range p.SampleType {
-		p, err := ProfileFromPprof(ctx, l, s, p, i)
+		p, err := FromPprof(ctx, l, s, p, i)
 		if err != nil {
 			return nil, err
 		}
@@ -40,7 +40,7 @@ func ProfilesFromPprof(ctx context.Context, l log.Logger, s metastore.ProfileMet
 	return ps, nil
 }
 
-func ProfileFromPprof(ctx context.Context, logger log.Logger, metaStore metastore.ProfileMetaStore, p *profile.Profile, sampleIndex int) (*Profile, error) {
+func FromPprof(ctx context.Context, logger log.Logger, metaStore metastore.ProfileMetaStore, p *profile.Profile, sampleIndex int) (*Profile, error) {
 	pfn := &profileFlatNormalizer{
 		logger:    logger,
 		metaStore: metaStore,

--- a/pkg/profile/profile_flat.go
+++ b/pkg/profile/profile_flat.go
@@ -25,8 +25,8 @@ import (
 )
 
 // FlatProfilesFromPprof extracts a Profile from each sample index included in the pprof profile.
-func FlatProfilesFromPprof(ctx context.Context, l log.Logger, s metastore.ProfileMetaStore, p *profile.Profile) ([]*FlatProfile, error) {
-	fps := make([]*FlatProfile, 0, len(p.SampleType))
+func FlatProfilesFromPprof(ctx context.Context, l log.Logger, s metastore.ProfileMetaStore, p *profile.Profile) ([]*Profile, error) {
+	fps := make([]*Profile, 0, len(p.SampleType))
 
 	for i := range p.SampleType {
 		fp, err := FlatProfileFromPprof(ctx, l, s, p, i)
@@ -40,7 +40,7 @@ func FlatProfilesFromPprof(ctx context.Context, l log.Logger, s metastore.Profil
 	return fps, nil
 }
 
-func FlatProfileFromPprof(ctx context.Context, logger log.Logger, metaStore metastore.ProfileMetaStore, p *profile.Profile, sampleIndex int) (*FlatProfile, error) {
+func FlatProfileFromPprof(ctx context.Context, logger log.Logger, metaStore metastore.ProfileMetaStore, p *profile.Profile, sampleIndex int) (*Profile, error) {
 	pfn := &profileFlatNormalizer{
 		logger:    logger,
 		metaStore: metaStore,
@@ -74,7 +74,7 @@ func FlatProfileFromPprof(ctx context.Context, logger log.Logger, metaStore meta
 		return nil, nil
 	}
 
-	return &FlatProfile{
+	return &Profile{
 		Meta:        MetaFromPprof(p, sampleIndex),
 		FlatSamples: pfn.samples,
 	}, nil

--- a/pkg/profile/profile_flat_test.go
+++ b/pkg/profile/profile_flat_test.go
@@ -45,7 +45,7 @@ func TestProfileFlatNormalizer(t *testing.T) {
 		l.Close()
 	})
 
-	p, err := ProfileFromPprof(context.Background(), log.NewNopLogger(), l, p1, 0)
+	p, err := FromPprof(context.Background(), log.NewNopLogger(), l, p1, 0)
 	require.NoError(t, err)
 
 	require.Equal(t, InstantProfileMeta{

--- a/pkg/profile/profile_flat_test.go
+++ b/pkg/profile/profile_flat_test.go
@@ -45,7 +45,7 @@ func TestProfileFlatNormalizer(t *testing.T) {
 		l.Close()
 	})
 
-	p, err := FlatProfileFromPprof(context.Background(), log.NewNopLogger(), l, p1, 0)
+	p, err := ProfileFromPprof(context.Background(), log.NewNopLogger(), l, p1, 0)
 	require.NoError(t, err)
 
 	require.Equal(t, InstantProfileMeta{

--- a/pkg/profilestore/profilestore.go
+++ b/pkg/profilestore/profilestore.go
@@ -82,7 +82,7 @@ func (s *ProfileStore) WriteRaw(ctx context.Context, r *profilestorepb.WriteRawR
 			}
 
 			convertCtx, convertSpan := s.tracer.Start(ctx, "profile-from-pprof")
-			profiles, err := parcaprofile.FlatProfilesFromPprof(convertCtx, s.logger, s.metaStore, p)
+			profiles, err := parcaprofile.ProfilesFromPprof(convertCtx, s.logger, s.metaStore, p)
 			if err != nil {
 				return nil, status.Errorf(codes.Internal, "failed to normalize pprof: %v", err)
 			}

--- a/pkg/query/flamegraph_flat.go
+++ b/pkg/query/flamegraph_flat.go
@@ -26,7 +26,7 @@ import (
 	"github.com/parca-dev/parca/pkg/profile"
 )
 
-func GenerateFlamegraphFlat(ctx context.Context, tracer trace.Tracer, metaStore metastore.ProfileMetaStore, p profile.InstantFlatProfile) (*pb.Flamegraph, error) {
+func GenerateFlamegraphFlat(ctx context.Context, tracer trace.Tracer, metaStore metastore.ProfileMetaStore, p profile.InstantProfile) (*pb.Flamegraph, error) {
 	rootNode := &pb.FlamegraphNode{}
 	current := rootNode
 

--- a/pkg/query/flamegraph_flat_test.go
+++ b/pkg/query/flamegraph_flat_test.go
@@ -169,7 +169,7 @@ func TestGenerateFlamegraphFlat(t *testing.T) {
 	stacktraceID2, err := l.CreateStacktrace(ctx, k2, &metapb.Sample{LocationIds: [][]byte{l4.ID[:], l3.ID[:], l2.ID[:], l1.ID[:]}})
 	require.NoError(t, err)
 
-	fp := &parcaprofile.FlatProfile{
+	fp := &parcaprofile.Profile{
 		Meta: parcaprofile.InstantProfileMeta{},
 		FlatSamples: map[string]*parcaprofile.Sample{
 			string(stacktraceID0[:]): s0,

--- a/pkg/query/flamegraph_flat_test.go
+++ b/pkg/query/flamegraph_flat_test.go
@@ -258,7 +258,7 @@ func testGenerateFlamegraphFromProfile(t *testing.T, l metastore.ProfileMetaStor
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	profile, err := parcaprofile.ProfileFromPprof(ctx, log.NewNopLogger(), l, p1, 0)
+	profile, err := parcaprofile.FromPprof(ctx, log.NewNopLogger(), l, p1, 0)
 	require.NoError(t, err)
 
 	fg, err := GenerateFlamegraphFlat(ctx, trace.NewNoopTracerProvider().Tracer(""), l, profile)
@@ -303,7 +303,7 @@ func TestGenerateFlamegraphWithInlined(t *testing.T) {
 		Function:   functions,
 	}
 
-	fp, err := parcaprofile.ProfileFromPprof(ctx, logger, store, p, 0)
+	fp, err := parcaprofile.FromPprof(ctx, logger, store, p, 0)
 	require.NoError(t, err)
 
 	fg, err := GenerateFlamegraphFlat(ctx, tracer, store, fp)
@@ -438,7 +438,7 @@ func TestGenerateFlamegraphWithInlinedExisting(t *testing.T) {
 		Function:   functions,
 	}
 
-	fp, err := parcaprofile.ProfileFromPprof(ctx, logger, store, p, 0)
+	fp, err := parcaprofile.FromPprof(ctx, logger, store, p, 0)
 	require.NoError(t, err)
 
 	fg, err := GenerateFlamegraphFlat(ctx, tracer, store, fp)

--- a/pkg/query/flamegraph_flat_test.go
+++ b/pkg/query/flamegraph_flat_test.go
@@ -232,7 +232,7 @@ func TestGenerateFlamegraphFlat(t *testing.T) {
 	}}, fg))
 }
 
-func TestGenerateFlamegraphFromFlatProfile(t *testing.T) {
+func TestGenerateFlamegraphFromProfile(t *testing.T) {
 	tracer := trace.NewNoopTracerProvider().Tracer("")
 	reg := prometheus.NewRegistry()
 
@@ -246,10 +246,10 @@ func TestGenerateFlamegraphFromFlatProfile(t *testing.T) {
 		l.Close()
 	})
 
-	testGenerateFlamegraphFromFlatProfile(t, l)
+	testGenerateFlamegraphFromProfile(t, l)
 }
 
-func testGenerateFlamegraphFromFlatProfile(t *testing.T, l metastore.ProfileMetaStore) *pb.Flamegraph {
+func testGenerateFlamegraphFromProfile(t *testing.T, l metastore.ProfileMetaStore) *pb.Flamegraph {
 	ctx := context.Background()
 
 	f, err := os.Open("../storage/testdata/profile1.pb.gz")
@@ -258,10 +258,10 @@ func testGenerateFlamegraphFromFlatProfile(t *testing.T, l metastore.ProfileMeta
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	flatProfile, err := parcaprofile.FlatProfileFromPprof(ctx, log.NewNopLogger(), l, p1, 0)
+	profile, err := parcaprofile.ProfileFromPprof(ctx, log.NewNopLogger(), l, p1, 0)
 	require.NoError(t, err)
 
-	fg, err := GenerateFlamegraphFlat(ctx, trace.NewNoopTracerProvider().Tracer(""), l, flatProfile)
+	fg, err := GenerateFlamegraphFlat(ctx, trace.NewNoopTracerProvider().Tracer(""), l, profile)
 	require.NoError(t, err)
 
 	return fg
@@ -303,7 +303,7 @@ func TestGenerateFlamegraphWithInlined(t *testing.T) {
 		Function:   functions,
 	}
 
-	fp, err := parcaprofile.FlatProfileFromPprof(ctx, logger, store, p, 0)
+	fp, err := parcaprofile.ProfileFromPprof(ctx, logger, store, p, 0)
 	require.NoError(t, err)
 
 	fg, err := GenerateFlamegraphFlat(ctx, tracer, store, fp)
@@ -438,7 +438,7 @@ func TestGenerateFlamegraphWithInlinedExisting(t *testing.T) {
 		Function:   functions,
 	}
 
-	fp, err := parcaprofile.FlatProfileFromPprof(ctx, logger, store, p, 0)
+	fp, err := parcaprofile.ProfileFromPprof(ctx, logger, store, p, 0)
 	require.NoError(t, err)
 
 	fg, err := GenerateFlamegraphFlat(ctx, tracer, store, fp)

--- a/pkg/query/pprof_test.go
+++ b/pkg/query/pprof_test.go
@@ -51,7 +51,7 @@ func TestGenerateFlatPprof(t *testing.T) {
 	t.Cleanup(func() {
 		l.Close()
 	})
-	p, err := parcaprofile.FlatProfileFromPprof(ctx, log.NewNopLogger(), l, p1, 0)
+	p, err := parcaprofile.ProfileFromPprof(ctx, log.NewNopLogger(), l, p1, 0)
 	require.NoError(t, err)
 	res, err := GenerateFlatPprof(ctx, l, p)
 	require.NoError(t, err)

--- a/pkg/query/pprof_test.go
+++ b/pkg/query/pprof_test.go
@@ -154,7 +154,7 @@ func TestGeneratePprofNilMapping(t *testing.T) {
 	})
 	key := parcaprofile.MakeStacktraceKey(sample)
 
-	res, err := GenerateFlatPprof(ctx, l, &parcaprofile.FlatProfile{
+	res, err := GenerateFlatPprof(ctx, l, &parcaprofile.Profile{
 		FlatSamples: map[string]*parcaprofile.Sample{
 			string(key): sample,
 		},

--- a/pkg/query/pprof_test.go
+++ b/pkg/query/pprof_test.go
@@ -51,7 +51,7 @@ func TestGenerateFlatPprof(t *testing.T) {
 	t.Cleanup(func() {
 		l.Close()
 	})
-	p, err := parcaprofile.ProfileFromPprof(ctx, log.NewNopLogger(), l, p1, 0)
+	p, err := parcaprofile.FromPprof(ctx, log.NewNopLogger(), l, p1, 0)
 	require.NoError(t, err)
 	res, err := GenerateFlatPprof(ctx, l, p)
 	require.NoError(t, err)

--- a/pkg/query/query_test.go
+++ b/pkg/query/query_test.go
@@ -98,7 +98,7 @@ func Test_QueryRange_Valid(t *testing.T) {
 	// Overwrite the profile's timestamp to be within the last 5min.
 	p.TimeNanos = time.Now().UnixNano()
 
-	prof, err := parcaprofile.FlatProfileFromPprof(ctx, log.NewNopLogger(), s, p, 0)
+	prof, err := parcaprofile.ProfileFromPprof(ctx, log.NewNopLogger(), s, p, 0)
 	require.NoError(t, err)
 	err = app.AppendFlat(ctx, prof)
 	require.NoError(t, err)
@@ -169,7 +169,7 @@ func Test_QueryRange_Limited(t *testing.T) {
 		// Overwrite the profile's timestamp to be within the last 5min.
 		p.TimeNanos = time.Now().UTC().UnixNano()
 
-		prof, err := parcaprofile.FlatProfileFromPprof(ctx, log.NewNopLogger(), s, p, 0)
+		prof, err := parcaprofile.ProfileFromPprof(ctx, log.NewNopLogger(), s, p, 0)
 		require.NoError(t, err)
 		err = app.AppendFlat(ctx, prof)
 		require.NoError(t, err)
@@ -225,7 +225,7 @@ func Test_QueryRange_Ranged(t *testing.T) {
 
 	for i := 0; i < 500; i++ {
 		p.TimeNanos = start.Add(time.Duration(i) * time.Second).UnixNano()
-		pprof, err := parcaprofile.FlatProfileFromPprof(ctx, logger, s, p, 0)
+		pprof, err := parcaprofile.ProfileFromPprof(ctx, logger, s, p, 0)
 		require.NoError(t, err)
 		err = app.AppendFlat(ctx, pprof)
 		require.NoError(t, err)
@@ -398,7 +398,7 @@ func Test_Query_Simple(t *testing.T) {
 	t1 := (time.Now().UnixNano() / 1000000) * 1000000
 	p1.TimeNanos = t1
 
-	prof, err := parcaprofile.FlatProfileFromPprof(ctx, log.NewNopLogger(), s, p1, 0)
+	prof, err := parcaprofile.ProfileFromPprof(ctx, log.NewNopLogger(), s, p1, 0)
 	require.NoError(t, err)
 	err = app.AppendFlat(ctx, prof)
 	require.NoError(t, err)
@@ -463,7 +463,7 @@ func Test_Query_Diff(t *testing.T) {
 	t1 := (time.Now().UnixNano() / 1000000) * 1000000
 	p1.TimeNanos = t1
 
-	prof1, err := parcaprofile.FlatProfileFromPprof(ctx, log.NewNopLogger(), s, p1, 0)
+	prof1, err := parcaprofile.ProfileFromPprof(ctx, log.NewNopLogger(), s, p1, 0)
 	require.NoError(t, err)
 	err = app.AppendFlat(ctx, prof1)
 	require.NoError(t, err)
@@ -473,7 +473,7 @@ func Test_Query_Diff(t *testing.T) {
 	t2 := (time.Now().UnixNano() / 1000000) * 1000000
 	p2.TimeNanos = t2
 
-	prof2, err := parcaprofile.FlatProfileFromPprof(ctx, log.NewNopLogger(), s, p2, 0)
+	prof2, err := parcaprofile.ProfileFromPprof(ctx, log.NewNopLogger(), s, p2, 0)
 	require.NoError(t, err)
 	err = app.AppendFlat(ctx, prof2)
 	require.NoError(t, err)
@@ -529,7 +529,7 @@ func Benchmark_Query_Merge(b *testing.B) {
 	require.NoError(b, err)
 	require.NoError(b, f.Close())
 
-	p, err := parcaprofile.FlatProfileFromPprof(ctx, log.NewNopLogger(), s, p1, 0)
+	p, err := parcaprofile.ProfileFromPprof(ctx, log.NewNopLogger(), s, p1, 0)
 	require.NoError(b, err)
 
 	for k := 0.; k <= 10; k++ {
@@ -597,7 +597,7 @@ func Test_Query_Merge(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	p, err := parcaprofile.FlatProfileFromPprof(ctx, log.NewNopLogger(), s, p1, 0)
+	p, err := parcaprofile.ProfileFromPprof(ctx, log.NewNopLogger(), s, p1, 0)
 	require.NoError(t, err)
 
 	for k := 0.; k <= 10; k++ {
@@ -705,7 +705,7 @@ func Test_QueryRange_MultipleLabels_NoMatch(t *testing.T) {
 
 		p1.TimeNanos = t1
 
-		prof, err := parcaprofile.FlatProfileFromPprof(ctx, log.NewNopLogger(), s, p1, 0)
+		prof, err := parcaprofile.ProfileFromPprof(ctx, log.NewNopLogger(), s, p1, 0)
 		require.NoError(t, err)
 		err = app.AppendFlat(ctx, prof)
 		require.NoError(t, err)

--- a/pkg/query/query_test.go
+++ b/pkg/query/query_test.go
@@ -98,7 +98,7 @@ func Test_QueryRange_Valid(t *testing.T) {
 	// Overwrite the profile's timestamp to be within the last 5min.
 	p.TimeNanos = time.Now().UnixNano()
 
-	prof, err := parcaprofile.ProfileFromPprof(ctx, log.NewNopLogger(), s, p, 0)
+	prof, err := parcaprofile.FromPprof(ctx, log.NewNopLogger(), s, p, 0)
 	require.NoError(t, err)
 	err = app.AppendFlat(ctx, prof)
 	require.NoError(t, err)
@@ -169,7 +169,7 @@ func Test_QueryRange_Limited(t *testing.T) {
 		// Overwrite the profile's timestamp to be within the last 5min.
 		p.TimeNanos = time.Now().UTC().UnixNano()
 
-		prof, err := parcaprofile.ProfileFromPprof(ctx, log.NewNopLogger(), s, p, 0)
+		prof, err := parcaprofile.FromPprof(ctx, log.NewNopLogger(), s, p, 0)
 		require.NoError(t, err)
 		err = app.AppendFlat(ctx, prof)
 		require.NoError(t, err)
@@ -225,7 +225,7 @@ func Test_QueryRange_Ranged(t *testing.T) {
 
 	for i := 0; i < 500; i++ {
 		p.TimeNanos = start.Add(time.Duration(i) * time.Second).UnixNano()
-		pprof, err := parcaprofile.ProfileFromPprof(ctx, logger, s, p, 0)
+		pprof, err := parcaprofile.FromPprof(ctx, logger, s, p, 0)
 		require.NoError(t, err)
 		err = app.AppendFlat(ctx, pprof)
 		require.NoError(t, err)
@@ -398,7 +398,7 @@ func Test_Query_Simple(t *testing.T) {
 	t1 := (time.Now().UnixNano() / 1000000) * 1000000
 	p1.TimeNanos = t1
 
-	prof, err := parcaprofile.ProfileFromPprof(ctx, log.NewNopLogger(), s, p1, 0)
+	prof, err := parcaprofile.FromPprof(ctx, log.NewNopLogger(), s, p1, 0)
 	require.NoError(t, err)
 	err = app.AppendFlat(ctx, prof)
 	require.NoError(t, err)
@@ -463,7 +463,7 @@ func Test_Query_Diff(t *testing.T) {
 	t1 := (time.Now().UnixNano() / 1000000) * 1000000
 	p1.TimeNanos = t1
 
-	prof1, err := parcaprofile.ProfileFromPprof(ctx, log.NewNopLogger(), s, p1, 0)
+	prof1, err := parcaprofile.FromPprof(ctx, log.NewNopLogger(), s, p1, 0)
 	require.NoError(t, err)
 	err = app.AppendFlat(ctx, prof1)
 	require.NoError(t, err)
@@ -473,7 +473,7 @@ func Test_Query_Diff(t *testing.T) {
 	t2 := (time.Now().UnixNano() / 1000000) * 1000000
 	p2.TimeNanos = t2
 
-	prof2, err := parcaprofile.ProfileFromPprof(ctx, log.NewNopLogger(), s, p2, 0)
+	prof2, err := parcaprofile.FromPprof(ctx, log.NewNopLogger(), s, p2, 0)
 	require.NoError(t, err)
 	err = app.AppendFlat(ctx, prof2)
 	require.NoError(t, err)
@@ -529,7 +529,7 @@ func Benchmark_Query_Merge(b *testing.B) {
 	require.NoError(b, err)
 	require.NoError(b, f.Close())
 
-	p, err := parcaprofile.ProfileFromPprof(ctx, log.NewNopLogger(), s, p1, 0)
+	p, err := parcaprofile.FromPprof(ctx, log.NewNopLogger(), s, p1, 0)
 	require.NoError(b, err)
 
 	for k := 0.; k <= 10; k++ {
@@ -597,7 +597,7 @@ func Test_Query_Merge(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	p, err := parcaprofile.ProfileFromPprof(ctx, log.NewNopLogger(), s, p1, 0)
+	p, err := parcaprofile.FromPprof(ctx, log.NewNopLogger(), s, p1, 0)
 	require.NoError(t, err)
 
 	for k := 0.; k <= 10; k++ {
@@ -705,7 +705,7 @@ func Test_QueryRange_MultipleLabels_NoMatch(t *testing.T) {
 
 		p1.TimeNanos = t1
 
-		prof, err := parcaprofile.ProfileFromPprof(ctx, log.NewNopLogger(), s, p1, 0)
+		prof, err := parcaprofile.FromPprof(ctx, log.NewNopLogger(), s, p1, 0)
 		require.NoError(t, err)
 		err = app.AppendFlat(ctx, prof)
 		require.NoError(t, err)

--- a/pkg/query/top_test.go
+++ b/pkg/query/top_test.go
@@ -48,7 +48,7 @@ func TestGenerateTopTable(t *testing.T) {
 	t.Cleanup(func() {
 		l.Close()
 	})
-	p, err := parcaprofile.FlatProfileFromPprof(ctx, log.NewNopLogger(), l, p1, 0)
+	p, err := parcaprofile.ProfileFromPprof(ctx, log.NewNopLogger(), l, p1, 0)
 	require.NoError(t, err)
 
 	res, err := GenerateTopTable(ctx, l, p)

--- a/pkg/query/top_test.go
+++ b/pkg/query/top_test.go
@@ -48,7 +48,7 @@ func TestGenerateTopTable(t *testing.T) {
 	t.Cleanup(func() {
 		l.Close()
 	})
-	p, err := parcaprofile.ProfileFromPprof(ctx, log.NewNopLogger(), l, p1, 0)
+	p, err := parcaprofile.FromPprof(ctx, log.NewNopLogger(), l, p1, 0)
 	require.NoError(t, err)
 
 	res, err := GenerateTopTable(ctx, l, p)

--- a/pkg/storage/benchmark_test.go
+++ b/pkg/storage/benchmark_test.go
@@ -113,7 +113,7 @@ func BenchmarkAppends(b *testing.B) {
 
 	//for i := 0; i < b.N; i++ {
 	//	p := profiles[i%len(profiles)]
-	//	pprof, err := storage.ProfileFromPprof(ctx, logger, l, p, 0)
+	//	pprof, err := storage.FromPprof(ctx, logger, l, p, 0)
 	//	require.NoError(b, err)
 	//	err = app.Append(ctx, pprof)
 	//	require.NoError(b, err)
@@ -121,7 +121,7 @@ func BenchmarkAppends(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		p := profiles[i%len(profiles)]
-		pprof, err := parcaprofile.ProfileFromPprof(ctx, logger, l, p, 0)
+		pprof, err := parcaprofile.FromPprof(ctx, logger, l, p, 0)
 		require.NoError(b, err)
 		err = app.AppendFlat(ctx, pprof)
 		require.NoError(b, err)
@@ -160,7 +160,7 @@ func BenchmarkIterator(b *testing.B) {
 	require.NoError(b, err)
 	for i := 0; i < b.N; i++ {
 		pprof := profiles[i%len(profiles)]
-		p, err := parcaprofile.ProfileFromPprof(ctx, logger, l, pprof, 0)
+		p, err := parcaprofile.FromPprof(ctx, logger, l, pprof, 0)
 		require.NoError(b, err)
 		err = app.AppendFlat(ctx, p)
 		require.NoError(b, err)

--- a/pkg/storage/benchmark_test.go
+++ b/pkg/storage/benchmark_test.go
@@ -121,7 +121,7 @@ func BenchmarkAppends(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		p := profiles[i%len(profiles)]
-		pprof, err := parcaprofile.FlatProfileFromPprof(ctx, logger, l, p, 0)
+		pprof, err := parcaprofile.ProfileFromPprof(ctx, logger, l, p, 0)
 		require.NoError(b, err)
 		err = app.AppendFlat(ctx, pprof)
 		require.NoError(b, err)
@@ -160,7 +160,7 @@ func BenchmarkIterator(b *testing.B) {
 	require.NoError(b, err)
 	for i := 0; i < b.N; i++ {
 		pprof := profiles[i%len(profiles)]
-		p, err := parcaprofile.FlatProfileFromPprof(ctx, logger, l, pprof, 0)
+		p, err := parcaprofile.ProfileFromPprof(ctx, logger, l, pprof, 0)
 		require.NoError(b, err)
 		err = app.AppendFlat(ctx, p)
 		require.NoError(b, err)

--- a/pkg/storage/db.go
+++ b/pkg/storage/db.go
@@ -96,7 +96,7 @@ type Labels interface {
 }
 
 type Appender interface {
-	AppendFlat(ctx context.Context, p *profile.FlatProfile) error
+	AppendFlat(ctx context.Context, p *profile.Profile) error
 }
 
 type SliceSeriesSet struct {

--- a/pkg/storage/db_test.go
+++ b/pkg/storage/db_test.go
@@ -53,7 +53,7 @@ func TestDB(t *testing.T) {
 	p, err := profile.Parse(b)
 	require.NoError(t, err)
 
-	prof1, err := parcaprofile.FlatProfileFromPprof(ctx, log.NewNopLogger(), l, p, 0)
+	prof1, err := parcaprofile.ProfileFromPprof(ctx, log.NewNopLogger(), l, p, 0)
 	require.NoError(t, err)
 	require.NoError(t, app1.AppendFlat(ctx, prof1))
 
@@ -66,7 +66,7 @@ func TestDB(t *testing.T) {
 	p, err = profile.Parse(b)
 	require.NoError(t, err)
 
-	prof2, err := parcaprofile.FlatProfileFromPprof(ctx, log.NewNopLogger(), l, p, 0)
+	prof2, err := parcaprofile.ProfileFromPprof(ctx, log.NewNopLogger(), l, p, 0)
 	require.NoError(t, err)
 	require.NoError(t, app2.AppendFlat(ctx, prof2))
 

--- a/pkg/storage/db_test.go
+++ b/pkg/storage/db_test.go
@@ -53,7 +53,7 @@ func TestDB(t *testing.T) {
 	p, err := profile.Parse(b)
 	require.NoError(t, err)
 
-	prof1, err := parcaprofile.ProfileFromPprof(ctx, log.NewNopLogger(), l, p, 0)
+	prof1, err := parcaprofile.FromPprof(ctx, log.NewNopLogger(), l, p, 0)
 	require.NoError(t, err)
 	require.NoError(t, app1.AppendFlat(ctx, prof1))
 
@@ -66,7 +66,7 @@ func TestDB(t *testing.T) {
 	p, err = profile.Parse(b)
 	require.NoError(t, err)
 
-	prof2, err := parcaprofile.ProfileFromPprof(ctx, log.NewNopLogger(), l, p, 0)
+	prof2, err := parcaprofile.FromPprof(ctx, log.NewNopLogger(), l, p, 0)
 	require.NoError(t, err)
 	require.NoError(t, app2.AppendFlat(ctx, prof2))
 

--- a/pkg/storage/diff_flat_test.go
+++ b/pkg/storage/diff_flat_test.go
@@ -30,7 +30,7 @@ import (
 	parcaprofile "github.com/parca-dev/parca/pkg/profile"
 )
 
-func TestDiffFlatProfileSimple(t *testing.T) {
+func TestDiffProfileSimple(t *testing.T) {
 	uuid1 := uuid.MustParse("00000000-0000-0000-0000-000000000001")
 	uuid2 := uuid.MustParse("00000000-0000-0000-0000-000000000002")
 	uuid3 := uuid.MustParse("00000000-0000-0000-0000-000000000003")
@@ -84,7 +84,7 @@ func TestDiffFlatProfileSimple(t *testing.T) {
 	}, diffed[string(k2[:])])
 }
 
-func TestDiffFlatProfileDeep(t *testing.T) {
+func TestDiffProfileDeep(t *testing.T) {
 	uuid1 := uuid.MustParse("00000000-0000-0000-0000-000000000001")
 	uuid2 := uuid.MustParse("00000000-0000-0000-0000-000000000002")
 	uuid3 := uuid.MustParse("00000000-0000-0000-0000-000000000003")
@@ -183,9 +183,9 @@ func BenchmarkFlatDiff(b *testing.B) {
 	b.Cleanup(func() {
 		l.Close()
 	})
-	profile1, err := parcaprofile.FlatProfileFromPprof(ctx, log.NewNopLogger(), l, p1, 0)
+	profile1, err := parcaprofile.ProfileFromPprof(ctx, log.NewNopLogger(), l, p1, 0)
 	require.NoError(b, err)
-	profile2, err := parcaprofile.FlatProfileFromPprof(ctx, log.NewNopLogger(), l, p2, 0)
+	profile2, err := parcaprofile.ProfileFromPprof(ctx, log.NewNopLogger(), l, p2, 0)
 	require.NoError(b, err)
 
 	b.Run("simple", func(b *testing.B) {
@@ -195,7 +195,7 @@ func BenchmarkFlatDiff(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			d, err := NewDiffProfile(profile1, profile2)
 			require.NoError(b, err)
-			parcaprofile.CopyInstantFlatProfile(d)
+			parcaprofile.CopyInstantProfile(d)
 		}
 	})
 }

--- a/pkg/storage/diff_flat_test.go
+++ b/pkg/storage/diff_flat_test.go
@@ -183,9 +183,9 @@ func BenchmarkFlatDiff(b *testing.B) {
 	b.Cleanup(func() {
 		l.Close()
 	})
-	profile1, err := parcaprofile.ProfileFromPprof(ctx, log.NewNopLogger(), l, p1, 0)
+	profile1, err := parcaprofile.FromPprof(ctx, log.NewNopLogger(), l, p1, 0)
 	require.NoError(b, err)
-	profile2, err := parcaprofile.ProfileFromPprof(ctx, log.NewNopLogger(), l, p2, 0)
+	profile2, err := parcaprofile.FromPprof(ctx, log.NewNopLogger(), l, p2, 0)
 	require.NoError(b, err)
 
 	b.Run("simple", func(b *testing.B) {

--- a/pkg/storage/diff_flat_test.go
+++ b/pkg/storage/diff_flat_test.go
@@ -38,7 +38,7 @@ func TestDiffFlatProfileSimple(t *testing.T) {
 	s1 := parcaprofile.MakeSample(3, []uuid.UUID{uuid2, uuid1})
 	k1 := uuid.MustParse("00000000-0000-0000-0000-0000000000e1")
 
-	p1 := &parcaprofile.FlatProfile{
+	p1 := &parcaprofile.Profile{
 		Meta: parcaprofile.InstantProfileMeta{
 			PeriodType: parcaprofile.ValueType{Type: "cpu", Unit: "cycles"},
 			SampleType: parcaprofile.ValueType{Type: "numSamples", Unit: "count"},
@@ -54,7 +54,7 @@ func TestDiffFlatProfileSimple(t *testing.T) {
 	s2 := parcaprofile.MakeSample(1, []uuid.UUID{uuid3, uuid1})
 	k2 := uuid.MustParse("00000000-0000-0000-0000-0000000000e2")
 
-	p2 := &parcaprofile.FlatProfile{
+	p2 := &parcaprofile.Profile{
 		Meta: parcaprofile.InstantProfileMeta{
 			PeriodType: parcaprofile.ValueType{Type: "cpu", Unit: "cycles"},
 			SampleType: parcaprofile.ValueType{Type: "numSamples", Unit: "count"},
@@ -100,7 +100,7 @@ func TestDiffFlatProfileDeep(t *testing.T) {
 	k2 := uuid.MustParse("00000000-0000-0000-0000-0000000000e2")
 	k3 := uuid.MustParse("00000000-0000-0000-0000-0000000000e3")
 
-	p1 := &parcaprofile.FlatProfile{
+	p1 := &parcaprofile.Profile{
 		Meta: parcaprofile.InstantProfileMeta{
 			PeriodType: parcaprofile.ValueType{Type: "cpu", Unit: "cycles"},
 			SampleType: parcaprofile.ValueType{Type: "numSamples", Unit: "count"},
@@ -121,7 +121,7 @@ func TestDiffFlatProfileDeep(t *testing.T) {
 
 	k4 := uuid.MustParse("00000000-0000-0000-0000-0000000000e4")
 
-	p2 := &parcaprofile.FlatProfile{
+	p2 := &parcaprofile.Profile{
 		Meta: parcaprofile.InstantProfileMeta{
 			PeriodType: parcaprofile.ValueType{Type: "cpu", Unit: "cycles"},
 			SampleType: parcaprofile.ValueType{Type: "numSamples", Unit: "count"},

--- a/pkg/storage/head.go
+++ b/pkg/storage/head.go
@@ -241,7 +241,7 @@ type initAppender struct {
 	head *Head
 }
 
-func (a *initAppender) AppendFlat(ctx context.Context, p *profile.FlatProfile) error {
+func (a *initAppender) AppendFlat(ctx context.Context, p *profile.Profile) error {
 	if a.app != nil {
 		return a.app.AppendFlat(ctx, p)
 	}

--- a/pkg/storage/head_read_test.go
+++ b/pkg/storage/head_read_test.go
@@ -51,7 +51,7 @@ func TestHeadIndexReader_LabelValues(t *testing.T) {
 			{Name: "tens", Value: fmt.Sprintf("value%d", i/10)},
 		})
 		require.NoError(t, err)
-		err = app.AppendFlat(ctx, &profile.FlatProfile{
+		err = app.AppendFlat(ctx, &profile.Profile{
 			Meta: profile.InstantProfileMeta{
 				Timestamp: int64(100 + i),
 			},

--- a/pkg/storage/head_test.go
+++ b/pkg/storage/head_test.go
@@ -41,7 +41,7 @@ func TestHead_MaxTime(t *testing.T) {
 	k := profile.MakeStacktraceKey(s)
 
 	for i := int64(1); i < 500; i++ {
-		require.NoError(t, app.AppendFlat(ctx, &profile.FlatProfile{
+		require.NoError(t, app.AppendFlat(ctx, &profile.Profile{
 			Meta:        profile.InstantProfileMeta{Timestamp: i},
 			FlatSamples: map[string]*profile.Sample{string(k): s},
 		}))
@@ -141,7 +141,7 @@ func TestHead_Truncate(t *testing.T) {
 		require.NoError(t, err)
 
 		for i := int64(1); i <= 500; i++ {
-			require.NoError(t, app.AppendFlat(ctx, &profile.FlatProfile{
+			require.NoError(t, app.AppendFlat(ctx, &profile.Profile{
 				Meta:        profile.InstantProfileMeta{Timestamp: i},
 				FlatSamples: map[string]*profile.Sample{string(k): s},
 			}))
@@ -152,7 +152,7 @@ func TestHead_Truncate(t *testing.T) {
 		require.NoError(t, err)
 
 		for i := int64(100); i < 768; i++ {
-			require.NoError(t, app.AppendFlat(ctx, &profile.FlatProfile{
+			require.NoError(t, app.AppendFlat(ctx, &profile.Profile{
 				Meta:        profile.InstantProfileMeta{Timestamp: i},
 				FlatSamples: map[string]*profile.Sample{string(k): s},
 			}))

--- a/pkg/storage/interface_test.go
+++ b/pkg/storage/interface_test.go
@@ -43,7 +43,7 @@ func TestScaledInstantProfile(t *testing.T) {
 	k2 := profile.MakeStacktraceKey(s2)
 	k3 := profile.MakeStacktraceKey(s3)
 
-	p := &profile.FlatProfile{
+	p := &profile.Profile{
 		FlatSamples: map[string]*profile.Sample{
 			string(k1): s1,
 			string(k2): s2,
@@ -66,7 +66,7 @@ func TestScaledInstantProfile(t *testing.T) {
 func TestSliceProfileSeriesIterator(t *testing.T) {
 	it := &SliceProfileSeriesIterator{
 		i:       -1,
-		samples: []profile.InstantProfile{&profile.FlatProfile{}},
+		samples: []profile.InstantProfile{&profile.Profile{}},
 	}
 
 	require.True(t, it.Next())

--- a/pkg/storage/merge.go
+++ b/pkg/storage/merge.go
@@ -87,7 +87,7 @@ func MergeSeriesSetProfiles(ctx context.Context, tracer trace.Tracer, set Series
 				for it.Next() {
 					// Have to copy as profile pointer is not stable for more than the
 					// current iteration.
-					profileCh <- profile.CopyInstantFlatProfile(it.At())
+					profileCh <- profile.CopyInstantProfile(it.At())
 					i++
 				}
 				profileSpan.End()
@@ -210,7 +210,7 @@ func MergeProfilesConcurrent(
 						return err
 					}
 
-					resCh <- profile.CopyInstantFlatProfile(m)
+					resCh <- profile.CopyInstantProfile(m)
 				}
 			}
 		})

--- a/pkg/storage/merge_flat_test.go
+++ b/pkg/storage/merge_flat_test.go
@@ -32,7 +32,7 @@ import (
 	parcaprofile "github.com/parca-dev/parca/pkg/profile"
 )
 
-func TestMergeFlatProfileSimple(t *testing.T) {
+func TestMergeProfileSimple(t *testing.T) {
 	uuid1 := uuid.MustParse("00000000-0000-0000-0000-000000000001")
 	uuid2 := uuid.MustParse("00000000-0000-0000-0000-000000000002")
 	uuid3 := uuid.MustParse("00000000-0000-0000-0000-000000000003")
@@ -92,7 +92,7 @@ func TestMergeFlatProfileSimple(t *testing.T) {
 	}, merged[string(k2[:])])
 }
 
-func TestMergeFlatProfileDeep(t *testing.T) {
+func TestMergeProfileDeep(t *testing.T) {
 	uuid1 := uuid.MustParse("00000000-0000-0000-0000-000000000001")
 	uuid2 := uuid.MustParse("00000000-0000-0000-0000-000000000002")
 	uuid3 := uuid.MustParse("00000000-0000-0000-0000-000000000003")
@@ -176,7 +176,7 @@ func TestMergeFlatProfileDeep(t *testing.T) {
 	}, merged[string(k5[:])])
 }
 
-func TestMergeFlatProfile(t *testing.T) {
+func TestMergeProfile(t *testing.T) {
 	uuid1 := uuid.MustParse("00000000-0000-0000-0000-000000000001")
 	uuid2 := uuid.MustParse("00000000-0000-0000-0000-000000000002")
 	uuid3 := uuid.MustParse("00000000-0000-0000-0000-000000000003")
@@ -297,7 +297,7 @@ func TestMergeSingleFlat(t *testing.T) {
 		l.Close()
 	})
 	require.NoError(t, err)
-	prof, err := parcaprofile.FlatProfileFromPprof(ctx, log.NewNopLogger(), l, p, 0)
+	prof, err := parcaprofile.ProfileFromPprof(ctx, log.NewNopLogger(), l, p, 0)
 	require.NoError(t, err)
 
 	m, err := MergeProfiles(prof)
@@ -324,7 +324,7 @@ func TestMergeManyFlat(t *testing.T) {
 		l.Close()
 	})
 	require.NoError(t, err)
-	prof, err := parcaprofile.FlatProfileFromPprof(ctx, log.NewNopLogger(), l, p, 0)
+	prof, err := parcaprofile.ProfileFromPprof(ctx, log.NewNopLogger(), l, p, 0)
 	require.NoError(t, err)
 
 	num := 1000
@@ -335,7 +335,7 @@ func TestMergeManyFlat(t *testing.T) {
 
 	m, err := MergeProfiles(profiles...)
 	require.NoError(t, err)
-	parcaprofile.CopyInstantFlatProfile(m)
+	parcaprofile.CopyInstantProfile(m)
 }
 
 func BenchmarkFlatMerge(b *testing.B) {
@@ -361,16 +361,16 @@ func BenchmarkFlatMerge(b *testing.B) {
 		l.Close()
 	})
 	require.NoError(b, err)
-	profile1, err := parcaprofile.FlatProfileFromPprof(ctx, log.NewNopLogger(), l, p1, 0)
+	profile1, err := parcaprofile.ProfileFromPprof(ctx, log.NewNopLogger(), l, p1, 0)
 	require.NoError(b, err)
-	profile2, err := parcaprofile.FlatProfileFromPprof(ctx, log.NewNopLogger(), l, p2, 0)
+	profile2, err := parcaprofile.ProfileFromPprof(ctx, log.NewNopLogger(), l, p2, 0)
 	require.NoError(b, err)
 
 	b.ReportAllocs()
 	b.ResetTimer()
 	m, err := MergeProfiles(profile1, profile2)
 	require.NoError(b, err)
-	parcaprofile.CopyInstantFlatProfile(m)
+	parcaprofile.CopyInstantProfile(m)
 }
 
 func BenchmarkMergeFlatMany(b *testing.B) {
@@ -398,7 +398,7 @@ func BenchmarkMergeFlatMany(b *testing.B) {
 				l.Close()
 			}()
 
-			prof, err := parcaprofile.FlatProfileFromPprof(ctx, logger, l, p, 0)
+			prof, err := parcaprofile.ProfileFromPprof(ctx, logger, l, p, 0)
 			require.NoError(b, err)
 
 			profiles := make([]parcaprofile.InstantProfile, 0, n)
@@ -411,7 +411,7 @@ func BenchmarkMergeFlatMany(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				m, err := MergeProfiles(profiles...)
 				require.NoError(b, err)
-				parcaprofile.CopyInstantFlatProfile(m)
+				parcaprofile.CopyInstantProfile(m)
 			}
 		})
 	}

--- a/pkg/storage/merge_flat_test.go
+++ b/pkg/storage/merge_flat_test.go
@@ -40,7 +40,7 @@ func TestMergeFlatProfileSimple(t *testing.T) {
 	s1 := parcaprofile.MakeSample(2, []uuid.UUID{uuid2, uuid1})
 	k1 := uuid.MustParse("00000000-0000-0000-0000-0000000000e1")
 
-	p1 := &parcaprofile.FlatProfile{
+	p1 := &parcaprofile.Profile{
 		Meta: parcaprofile.InstantProfileMeta{
 			PeriodType: parcaprofile.ValueType{Type: "cpu", Unit: "cycles"},
 			SampleType: parcaprofile.ValueType{Type: "numSamples", Unit: "count"},
@@ -56,7 +56,7 @@ func TestMergeFlatProfileSimple(t *testing.T) {
 	s2 := parcaprofile.MakeSample(1, []uuid.UUID{uuid3, uuid1})
 	k2 := uuid.MustParse("00000000-0000-0000-0000-0000000000e2")
 
-	p2 := &parcaprofile.FlatProfile{
+	p2 := &parcaprofile.Profile{
 		Meta: parcaprofile.InstantProfileMeta{
 			PeriodType: parcaprofile.ValueType{Type: "cpu", Unit: "cycles"},
 			SampleType: parcaprofile.ValueType{Type: "numSamples", Unit: "count"},
@@ -108,7 +108,7 @@ func TestMergeFlatProfileDeep(t *testing.T) {
 	k3 := uuid.MustParse("00000000-0000-0000-0000-0000000000e3")
 	k4 := uuid.MustParse("00000000-0000-0000-0000-0000000000e4")
 
-	p1 := &parcaprofile.FlatProfile{
+	p1 := &parcaprofile.Profile{
 		Meta: parcaprofile.InstantProfileMeta{
 			PeriodType: parcaprofile.ValueType{Type: "cpu", Unit: "cycles"},
 			SampleType: parcaprofile.ValueType{Type: "numSamples", Unit: "count"},
@@ -127,7 +127,7 @@ func TestMergeFlatProfileDeep(t *testing.T) {
 	s5 := parcaprofile.MakeSample(3, []uuid.UUID{uuid3, uuid2, uuid2})
 	k5 := uuid.MustParse("00000000-0000-0000-0000-0000000000e5")
 
-	p2 := &parcaprofile.FlatProfile{
+	p2 := &parcaprofile.Profile{
 		Meta: parcaprofile.InstantProfileMeta{
 			PeriodType: parcaprofile.ValueType{Type: "cpu", Unit: "cycles"},
 			SampleType: parcaprofile.ValueType{Type: "numSamples", Unit: "count"},
@@ -196,7 +196,7 @@ func TestMergeFlatProfile(t *testing.T) {
 	k4 := uuid.MustParse("00000000-0000-0000-0000-0000000000e4")
 	k5 := uuid.MustParse("00000000-0000-0000-0000-0000000000e5")
 
-	p1 := &parcaprofile.FlatProfile{
+	p1 := &parcaprofile.Profile{
 		Meta: parcaprofile.InstantProfileMeta{
 			PeriodType: parcaprofile.ValueType{Type: "cpu", Unit: "cycles"},
 			SampleType: parcaprofile.ValueType{Type: "numSamples", Unit: "count"},
@@ -219,7 +219,7 @@ func TestMergeFlatProfile(t *testing.T) {
 	k6 := uuid.MustParse("00000000-0000-0000-0000-0000000000e6")
 	k7 := uuid.MustParse("00000000-0000-0000-0000-0000000000e7")
 
-	p2 := &parcaprofile.FlatProfile{
+	p2 := &parcaprofile.Profile{
 		Meta: parcaprofile.InstantProfileMeta{
 			PeriodType: parcaprofile.ValueType{Type: "cpu", Unit: "cycles"},
 			SampleType: parcaprofile.ValueType{Type: "numSamples", Unit: "count"},

--- a/pkg/storage/merge_flat_test.go
+++ b/pkg/storage/merge_flat_test.go
@@ -297,7 +297,7 @@ func TestMergeSingleFlat(t *testing.T) {
 		l.Close()
 	})
 	require.NoError(t, err)
-	prof, err := parcaprofile.ProfileFromPprof(ctx, log.NewNopLogger(), l, p, 0)
+	prof, err := parcaprofile.FromPprof(ctx, log.NewNopLogger(), l, p, 0)
 	require.NoError(t, err)
 
 	m, err := MergeProfiles(prof)
@@ -324,7 +324,7 @@ func TestMergeManyFlat(t *testing.T) {
 		l.Close()
 	})
 	require.NoError(t, err)
-	prof, err := parcaprofile.ProfileFromPprof(ctx, log.NewNopLogger(), l, p, 0)
+	prof, err := parcaprofile.FromPprof(ctx, log.NewNopLogger(), l, p, 0)
 	require.NoError(t, err)
 
 	num := 1000
@@ -361,9 +361,9 @@ func BenchmarkFlatMerge(b *testing.B) {
 		l.Close()
 	})
 	require.NoError(b, err)
-	profile1, err := parcaprofile.ProfileFromPprof(ctx, log.NewNopLogger(), l, p1, 0)
+	profile1, err := parcaprofile.FromPprof(ctx, log.NewNopLogger(), l, p1, 0)
 	require.NoError(b, err)
-	profile2, err := parcaprofile.ProfileFromPprof(ctx, log.NewNopLogger(), l, p2, 0)
+	profile2, err := parcaprofile.FromPprof(ctx, log.NewNopLogger(), l, p2, 0)
 	require.NoError(b, err)
 
 	b.ReportAllocs()
@@ -398,7 +398,7 @@ func BenchmarkMergeFlatMany(b *testing.B) {
 				l.Close()
 			}()
 
-			prof, err := parcaprofile.ProfileFromPprof(ctx, logger, l, p, 0)
+			prof, err := parcaprofile.FromPprof(ctx, logger, l, p, 0)
 			require.NoError(b, err)
 
 			profiles := make([]parcaprofile.InstantProfile, 0, n)

--- a/pkg/storage/querier_bench_test.go
+++ b/pkg/storage/querier_bench_test.go
@@ -41,7 +41,7 @@ func BenchmarkHeadQuerier_Select(b *testing.B) {
 	for i := 1; i <= numSeries; i++ {
 		app, err := h.Appender(ctx, labels.FromStrings("foo", "bar", "s", fmt.Sprintf("%d%s", i, postingsBenchSuffix)))
 		require.NoError(b, err)
-		err = app.AppendFlat(ctx, &parcaprofile.FlatProfile{
+		err = app.AppendFlat(ctx, &parcaprofile.Profile{
 			Meta: parcaprofile.InstantProfileMeta{
 				Timestamp: int64(i),
 			},

--- a/pkg/storage/series.go
+++ b/pkg/storage/series.go
@@ -135,7 +135,7 @@ type MemSeriesAppender struct {
 
 const samplesPerChunk = 120
 
-func (a *MemSeriesAppender) AppendFlat(ctx context.Context, p *profile.FlatProfile) error {
+func (a *MemSeriesAppender) AppendFlat(ctx context.Context, p *profile.Profile) error {
 	ctx, span := a.s.tracer.Start(ctx, "AppendFlat")
 	defer span.End()
 

--- a/pkg/storage/series_iterator_range.go
+++ b/pkg/storage/series_iterator_range.go
@@ -217,7 +217,7 @@ func (it *MemRangeSeriesIterator) Next() bool {
 }
 
 func (it *MemRangeSeriesIterator) At() profile.InstantProfile {
-	return &MemSeriesInstantFlatProfile{
+	return &MemSeriesInstantProfile{
 		PeriodType: it.s.periodType,
 		SampleType: it.s.sampleType,
 
@@ -232,7 +232,7 @@ func (it *MemRangeSeriesIterator) Err() error {
 	return it.err
 }
 
-type MemSeriesInstantFlatProfile struct {
+type MemSeriesInstantProfile struct {
 	PeriodType profile.ValueType
 	SampleType profile.ValueType
 
@@ -243,7 +243,7 @@ type MemSeriesInstantFlatProfile struct {
 	sampleIterators map[string]*MultiChunksIterator
 }
 
-func (m MemSeriesInstantFlatProfile) ProfileMeta() profile.InstantProfileMeta {
+func (m MemSeriesInstantProfile) ProfileMeta() profile.InstantProfileMeta {
 	return profile.InstantProfileMeta{
 		PeriodType: m.PeriodType,
 		SampleType: m.SampleType,
@@ -253,7 +253,7 @@ func (m MemSeriesInstantFlatProfile) ProfileMeta() profile.InstantProfileMeta {
 	}
 }
 
-func (m MemSeriesInstantFlatProfile) Samples() map[string]*profile.Sample {
+func (m MemSeriesInstantProfile) Samples() map[string]*profile.Sample {
 	samples := make(map[string]*profile.Sample, len(m.sampleIterators))
 	for k, it := range m.sampleIterators {
 		samples[k] = &profile.Sample{

--- a/pkg/storage/series_iterator_range_test.go
+++ b/pkg/storage/series_iterator_range_test.go
@@ -40,7 +40,7 @@ func TestMemRangeSeries_Iterator(t *testing.T) {
 
 	for i := 1; i <= 500; i++ {
 		s1.Value = int64(i)
-		p := &profile.FlatProfile{
+		p := &profile.Profile{
 			Meta: profile.InstantProfileMeta{
 				Timestamp: int64(i),
 				Duration:  time.Second.Nanoseconds(),

--- a/pkg/storage/series_iterator_root.go
+++ b/pkg/storage/series_iterator_root.go
@@ -132,7 +132,7 @@ func (it *MemRootSeriesIterator) Next() bool {
 }
 
 func (it *MemRootSeriesIterator) At() profile.InstantProfile {
-	return &profile.FlatProfile{
+	return &profile.Profile{
 		Meta: profile.InstantProfileMeta{
 			Timestamp:  it.timestampsIterator.At(),
 			PeriodType: it.s.periodType,

--- a/pkg/storage/series_iterator_root_test.go
+++ b/pkg/storage/series_iterator_root_test.go
@@ -33,7 +33,7 @@ func TestMemRootSeries_Iterator(t *testing.T) {
 
 	var i int64
 	for i = 1; i < 500; i++ {
-		p := &profile.FlatProfile{
+		p := &profile.Profile{
 			Meta: profile.InstantProfileMeta{
 				Timestamp: i,
 				Duration:  time.Second.Nanoseconds(),

--- a/pkg/storage/series_test.go
+++ b/pkg/storage/series_test.go
@@ -57,7 +57,7 @@ func TestMemSeries(t *testing.T) {
 	k11 := uuid.MustParse("00000000-0000-0000-0000-000000000e11")
 	k12 := uuid.MustParse("00000000-0000-0000-0000-000000000e12")
 
-	fp1 := &profile.FlatProfile{
+	fp1 := &profile.Profile{
 		Meta: profile.InstantProfileMeta{
 			PeriodType: profile.ValueType{},
 			SampleType: profile.ValueType{},
@@ -79,7 +79,7 @@ func TestMemSeries(t *testing.T) {
 	require.Equal(t, chunkenc.FromValuesXOR(2), s.samples[string(k12[:])][0])
 
 	s2 := profile.MakeSample(3, []uuid.UUID{uuid2, uuid1})
-	fp2 := &profile.FlatProfile{
+	fp2 := &profile.Profile{
 		Meta: profile.InstantProfileMeta{
 			PeriodType: profile.ValueType{},
 			SampleType: profile.ValueType{},
@@ -103,7 +103,7 @@ func TestMemSeries(t *testing.T) {
 	s3 := profile.MakeSample(4, []uuid.UUID{uuid3, uuid1})
 	k3 := uuid.MustParse("00000000-0000-0000-0000-0000000000e3")
 
-	fp3 := &profile.FlatProfile{
+	fp3 := &profile.Profile{
 		Meta: profile.InstantProfileMeta{
 			PeriodType: profile.ValueType{},
 			SampleType: profile.ValueType{},
@@ -128,7 +128,7 @@ func TestMemSeries(t *testing.T) {
 	s4 := profile.MakeSample(6, []uuid.UUID{uuid5, uuid2, uuid1})
 	k4 := uuid.MustParse("00000000-0000-0000-0000-0000000000e4")
 
-	fp4 := &profile.FlatProfile{
+	fp4 := &profile.Profile{
 		Meta: profile.InstantProfileMeta{
 			PeriodType: profile.ValueType{},
 			SampleType: profile.ValueType{},
@@ -152,7 +152,7 @@ func TestMemSeries(t *testing.T) {
 
 	// Merging another profileTree onto the existing one with one new Location
 	s5 := profile.MakeSample(7, []uuid.UUID{uuid2, uuid1})
-	fp5 := &profile.FlatProfile{
+	fp5 := &profile.Profile{
 		Meta: profile.InstantProfileMeta{
 			PeriodType: profile.ValueType{},
 			SampleType: profile.ValueType{},
@@ -202,7 +202,7 @@ func TestMemSeriesMany(t *testing.T) {
 		s1.Value = int64(i)
 		s2.Value = int64(2 * i)
 
-		err = app.AppendFlat(ctx, &profile.FlatProfile{
+		err = app.AppendFlat(ctx, &profile.Profile{
 			Meta: profile.InstantProfileMeta{
 				Timestamp: int64(i),
 				Duration:  snano,
@@ -265,7 +265,7 @@ func TestMemSeries_truncateChunksBefore(t *testing.T) {
 			require.NoError(t, err)
 
 			for i := int64(1); i <= 500; i++ {
-				require.NoError(t, app.AppendFlat(ctx, &profile.FlatProfile{
+				require.NoError(t, app.AppendFlat(ctx, &profile.Profile{
 					Meta: profile.InstantProfileMeta{Timestamp: i},
 				}))
 			}
@@ -301,7 +301,7 @@ func TestMemSeries_truncateFlatChunksBeforeConcurrent(t *testing.T) {
 	k1 := profile.MakeStacktraceKey(s1)
 
 	for i := int64(1); i < 500; i++ {
-		require.NoError(t, app.AppendFlat(ctx, &profile.FlatProfile{
+		require.NoError(t, app.AppendFlat(ctx, &profile.Profile{
 			Meta: profile.InstantProfileMeta{Timestamp: i},
 			FlatSamples: map[string]*profile.Sample{
 				string(k1): s1,
@@ -322,7 +322,7 @@ func TestMemSeries_truncateFlatChunksBeforeConcurrent(t *testing.T) {
 
 	// Test for appending working correctly after truncating.
 	for i := int64(500); i < 1_000; i++ {
-		require.NoError(t, app.AppendFlat(ctx, &profile.FlatProfile{
+		require.NoError(t, app.AppendFlat(ctx, &profile.Profile{
 			Meta: profile.InstantProfileMeta{Timestamp: i},
 			FlatSamples: map[string]*profile.Sample{
 				string(k1): s1,
@@ -340,7 +340,7 @@ func TestMemSeries_truncateFlatChunksBeforeConcurrent(t *testing.T) {
 
 	// Append more profiles after truncating all chunks.
 	for i := int64(1_100); i < 1_234; i++ {
-		require.NoError(t, app.AppendFlat(ctx, &profile.FlatProfile{
+		require.NoError(t, app.AppendFlat(ctx, &profile.Profile{
 			Meta: profile.InstantProfileMeta{Timestamp: i},
 			FlatSamples: map[string]*profile.Sample{
 				string(k1): s1,
@@ -366,7 +366,7 @@ func BenchmarkMemSeries_truncateChunksBefore(b *testing.B) {
 	})
 	sampleKey := profile.MakeStacktraceKey(sample)
 
-	p := &profile.FlatProfile{
+	p := &profile.Profile{
 		Meta: profile.InstantProfileMeta{},
 		FlatSamples: map[string]*profile.Sample{
 			string(sampleKey): sample,


### PR DESCRIPTION
Closes #608

Please let me know if there's any contributing guideline I missed. I had some confusion regarding repo forks that I mentioned in [an issue](https://github.com/parca-dev/parca/issues/707#issuecomment-1058937048), but I've gone ahead with forking this repo, adding the remote, pushing to it, and opening the PR here.

In this commit, I've only refactored the `FlatProfile` struct to `Profile` and wherever it's used. There are still some places which include the name `FlatProfile`, shall I refactor them as well? This would also involve removing the [InstantFlatProfile interface](https://github.com/parca-dev/parca/blob/8ad0e103287156104c4bd0d977efc64fdbbf8056/pkg/profile/profile.go#L59), as there is already an `InstantProfile` interface with the same methods.