### PR TITLE
feat: empty state container for targets page

### DIFF
--- a/ui/packages/app/web/src/pages/layouts/Component404.tsx
+++ b/ui/packages/app/web/src/pages/layouts/Component404.tsx
@@ -1,5 +1,5 @@
 const Component404 = () => (
-  <p className="flex items-center justify-center text-2xl h-80">Page not found!</p>
+  <p className="flex items-center justify-center text-2xl h-80 text-gray-500">Page not found!</p>
 );
 
 export default Component404;

--- a/ui/packages/app/web/src/pages/targets.tsx
+++ b/ui/packages/app/web/src/pages/targets.tsx
@@ -1,5 +1,6 @@
 import React, {useState, useEffect} from 'react';
 import {TargetsRequest, TargetsResponse, ScrapeServiceClient, ServiceError} from '@parca/client';
+import {EmptyState} from '@parca/components';
 import TargetsTable from '../components/Targets/TargetsTable';
 
 export interface ITargetsResult {
@@ -51,18 +52,35 @@ const TargetsPage = (): JSX.Element => {
     <div className="flex flex-col">
       <div className="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
         <div className="py-2 align-middle inline-block min-w-full sm:px-6 lg:px-8">
-          <div className="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg">
-            {targetNamespaces?.map(namespace => {
-              const name = Object.keys(namespace)[0];
-              const targets = namespace[name];
-              return (
-                <div key={name} className="p-2 border-b-2">
-                  <div>{name}</div>
-                  <TargetsTable targets={targets} />
-                </div>
-              );
-            })}
-          </div>
+          <EmptyState
+            isEmpty={targetNamespaces?.length <= 0}
+            title="No targets available"
+            body={
+              <p>
+                For additional information see the{' '}
+                <a
+                  className="text-blue-500"
+                  href="https://www.parca.dev/docs/parca-agent-design#target-discovery"
+                >
+                  Target Discovery
+                </a>{' '}
+                documentation
+              </p>
+            }
+          >
+            <div className="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg">
+              {targetNamespaces?.map(namespace => {
+                const name = Object.keys(namespace)[0];
+                const targets = namespace[name];
+                return (
+                  <div key={name} className="p-2 border-b-2">
+                    <div>{name}</div>
+                    <TargetsTable targets={targets} />
+                  </div>
+                );
+              })}
+            </div>
+          </EmptyState>
         </div>
       </div>
     </div>

--- a/ui/packages/app/web/tailwind.config.js
+++ b/ui/packages/app/web/tailwind.config.js
@@ -10,6 +10,9 @@ module.exports = {
       maxWidth: {
         '1/2': '50%',
       },
+      minWidth: theme => ({
+        ...theme('spacing'),
+      }),
     },
   },
   variants: {},

--- a/ui/packages/shared/components/src/EmptyState/index.tsx
+++ b/ui/packages/shared/components/src/EmptyState/index.tsx
@@ -1,0 +1,40 @@
+interface EmptyStateProps {
+  isEmpty: boolean;
+  body?: string | JSX.Element | JSX.Element[];
+  title?: string;
+  icon?: SVGElement;
+  children: JSX.Element | JSX.Element[];
+}
+
+const DEFAULT_ICON = (
+  <svg width="64" height="41" viewBox="0 0 64 41" xmlns="http://www.w3.org/2000/svg">
+    <g transform="translate(0 1)" fill="none" fillRule="evenodd">
+      <ellipse fill="#F5F5F5" cx="32" cy="33" rx="32" ry="7"></ellipse>
+      <g fillRule="nonzero" stroke="#D9D9D9">
+        <path d="M55 12.76L44.854 1.258C44.367.474 43.656 0 42.907 0H21.093c-.749 0-1.46.474-1.947 1.257L9 12.761V22h46v-9.24z"></path>
+        <path
+          d="M41.613 15.931c0-1.605.994-2.93 2.227-2.931H55v18.137C55 33.26 53.68 35 52.05 35h-40.1C10.32 35 9 33.259 9 31.137V13h11.16c1.233 0 2.227 1.323 2.227 2.928v.022c0 1.605 1.005 2.901 2.237 2.901h14.752c1.232 0 2.237-1.308 2.237-2.913v-.007z"
+          fill="#FAFAFA"
+        ></path>
+      </g>
+    </g>
+  </svg>
+);
+
+const EmptyState = ({title, icon, body, isEmpty, children}: EmptyStateProps): JSX.Element => {
+  return isEmpty ? (
+    <div className="flex justify-center items-center flex-col h-64">
+      {icon ?? DEFAULT_ICON}
+      <p className="flex items-center justify-center text-xl p-4 text-gray-500">
+        {title ?? 'No data available'}
+      </p>
+      {body && (
+        <div className="flex items-center justify-center p-1 text-gray-500 text-sm">{body}</div>
+      )}
+    </div>
+  ) : (
+    <>{children}</>
+  );
+};
+
+export default EmptyState;

--- a/ui/packages/shared/components/src/index.tsx
+++ b/ui/packages/shared/components/src/index.tsx
@@ -13,6 +13,7 @@ import ProfileSelector from './ProfileSelector';
 import Select from './Select';
 import type {SelectElement} from './Select';
 import Tab from './Tab';
+import EmptyState from './EmptyState';
 
 export type {PillVariant, SelectElement};
 
@@ -32,4 +33,5 @@ export {
   ProfileSelector,
   Select,
   Tab,
+  EmptyState,
 };


### PR DESCRIPTION
resolves #669 

Creates a reusable EmptyState container component in the shared folder, which can be used throughout the application as a placeholder when data is not available