### PR TITLE
Properly handle base images for multi-arch releases

### DIFF
--- a/.github/workflows/codeql-analysis-go.yml
+++ b/.github/workflows/codeql-analysis-go.yml
@@ -14,9 +14,17 @@ name: "CodeQL"
 on:
   push:
     branches: [ main ]
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ main ]
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
   schedule:
     - cron: '19 8 * * 1'
 
@@ -32,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'go', 'javascript' ]
+        language: [ 'go' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
         # Learn more:
         # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed

--- a/.github/workflows/codeql-analysis-go.yml
+++ b/.github/workflows/codeql-analysis-go.yml
@@ -46,34 +46,34 @@ jobs:
         # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+          # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v1
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 https://git.io/JvXDl
 
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
+      # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+      #    and modify them (or add more) to build your code if your project
+      #    uses a compiled language
 
-    #- run: |
-    #   make bootstrap
-    #   make release
+      #- run: |
+      #   make bootstrap
+      #   make release
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql-analysis-js.yml
+++ b/.github/workflows/codeql-analysis-js.yml
@@ -42,34 +42,34 @@ jobs:
         # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+          # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v1
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 https://git.io/JvXDl
 
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
+      # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+      #    and modify them (or add more) to build your code if your project
+      #    uses a compiled language
 
-    #- run: |
-    #   make bootstrap
-    #   make release
+      #- run: |
+      #   make bootstrap
+      #   make release
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql-analysis-js.yml
+++ b/.github/workflows/codeql-analysis-js.yml
@@ -1,0 +1,75 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - ui/**
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ main ]
+    paths:
+      - ui/**
+  schedule:
+    - cron: '19 8 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'javascript' ]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
+        # Learn more:
+        # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 https://git.io/JvXDl
+
+    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+    #    and modify them (or add more) to build your code if your project
+    #    uses a compiled language
+
+    #- run: |
+    #   make bootstrap
+    #   make release
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -28,13 +28,13 @@ jobs:
         run: make container
 
       - name: Check images created
-        run: buildah images | grep 'ghcr.io/parca-dev/parca'
+        run: podman images | grep 'ghcr.io/parca-dev/parca'
 
       - name: Login to registry
         if: ${{ github.event_name != 'pull_request' }}
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | buildah login -u parca-dev --password-stdin ghcr.io
-          echo "${{ secrets.QUAY_PASSWORD }}" | buildah login -u "${{ secrets.QUAY_USERNAME }}" --password-stdin quay.io
+          echo "${{ secrets.GITHUB_TOKEN }}" | podman login -u parca-dev --password-stdin ghcr.io
+          echo "${{ secrets.QUAY_PASSWORD }}" | podman login -u "${{ secrets.QUAY_USERNAME }}" --password-stdin quay.io
 
       - name: Push container
         if: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -3,12 +3,26 @@ name: Container
 on:
   push:
     branches: [ main ]
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - Dockerfile*
+      - .dockerignore
+      - ui/**
   pull_request:
     branches: [ main ]
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - Dockerfile*
+      - .dockerignore
+      - ui/**
 
 jobs:
   build:
-    name: Container build and push
+    name: Container build and push (when merged)
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,36 +15,7 @@ on:
       - 'go.sum'
 
 jobs:
-  goreleaser:
-    name: Goreleaser Dry
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Set up Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: ^1.16
-
-      - name: Build UI
-        run: make ui/build
-
-      - name: Validate
-        uses: goreleaser/goreleaser-action@v2
-        with:
-          distribution: goreleaser
-          version: latest
-          args: check
-
-      - name: Dry Run
-        uses: goreleaser/goreleaser-action@v2
-        with:
-          distribution: goreleaser
-          version: latest
-          args: release --rm-dist --skip-validate --skip-publish
-
-  build:
+  build-and-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,9 +28,6 @@ jobs:
       - name: Build UI
         run: make ui/build
 
-      - name: Format
-        run: make format
-
       - name: Test
         run: make go/test
 

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -3,15 +3,16 @@ on:
   push:
     tags:
       - v*
-    branches:
-      - master
-      - main
+    branches: [ main ]
     paths:
       - '**.go'
   pull_request:
+    branches: [ main ]
+    paths:
+      - '**.go'
 
 jobs:
-  golangci:
+  lint:
     name: lint
     runs-on: ubuntu-latest
     steps:
@@ -19,8 +20,13 @@ jobs:
         with:
           go-version: ^1.16
       - uses: actions/checkout@v3
+
       - name: Build UI
         run: make ui/build
+
+      - name: Format
+        run: make format && git diff --exit-code
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.1.0
         with:

--- a/.github/workflows/publish-ui.yml
+++ b/.github/workflows/publish-ui.yml
@@ -2,7 +2,7 @@ name: Publish UI Components
 
 on:
   pull_request:
-    types: [closed]
+    types: [ closed ]
     branches: [ main ]
 
 jobs:

--- a/.github/workflows/publish-ui.yml
+++ b/.github/workflows/publish-ui.yml
@@ -1,4 +1,4 @@
-name: Publish
+name: Publish UI Components
 
 on:
   pull_request:

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -1,0 +1,58 @@
+name: Goreleaser (Dry Run)
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - Dockerfile*
+      - .dockerignore
+      - ui/**
+  pull_request:
+    branches: [ main ]
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - Dockerfile*
+      - .dockerignore
+      - ui/**
+
+permissions:
+  contents: write
+
+jobs:
+   goreleaser:
+    name: Goreleaser Dry Run
+    runs-on: ubuntu-latest
+#    env:
+#      DOCKER_CLI_EXPERIMENTAL: "enabled"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.16
+
+      - name: Build UI
+        run: make ui/build
+
+      - name: Validate
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          distribution: goreleaser
+          version: latest
+          args: check
+
+      - name: Dry Run
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --rm-dist --skip-validate --skip-publish

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -50,9 +50,15 @@ jobs:
           version: latest
           args: check
 
+      - name: Set Tag
+        run: |
+          echo "goreleaser_current_tag=`git describe --match 'v*' --tags`" >> $GITHUB_ENV
+
       - name: Dry Run
         uses: goreleaser/goreleaser-action@v2
         with:
           distribution: goreleaser
           version: latest
           args: release --rm-dist --skip-validate --skip-publish
+        env:
+          GORELEASER_CURRENT_TAG: "${{ env.goreleaser_current_tag }}"

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -27,13 +27,16 @@ jobs:
    goreleaser:
     name: Goreleaser Dry Run
     runs-on: ubuntu-latest
-#    env:
-#      DOCKER_CLI_EXPERIMENTAL: "enabled"
+    env:
+      DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
 
       - name: Set up Go
         uses: actions/setup-go@v2

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -24,7 +24,7 @@ permissions:
   contents: write
 
 jobs:
-   goreleaser:
+  goreleaser:
     name: Goreleaser Dry Run
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,3 +96,20 @@ jobs:
       - name: Publish Vercel
         run: |
           curl -X POST "https://api.vercel.com/v1/integrations/deploy/${{ secrets.VERCEL_WEBHOOK }}"
+
+  container:
+      name: Build and release container images
+      runs-on: ubuntu-latest
+      steps:
+        - name: Check out code into the Go module directory
+          uses: actions/checkout@v3
+
+        - name: Build container
+          run: make container
+
+        - name: Login to registry
+          run: |
+            echo "${{ secrets.PERSONAL_ACCESS_TOKEN }}" | podman login -u parca-dev --password-stdin ghcr.io
+        - name: Push container
+          run: |
+            make push-container

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,18 +98,18 @@ jobs:
           curl -X POST "https://api.vercel.com/v1/integrations/deploy/${{ secrets.VERCEL_WEBHOOK }}"
 
   container:
-      name: Build and release container images
-      runs-on: ubuntu-latest
-      steps:
-        - name: Check out code into the Go module directory
-          uses: actions/checkout@v3
+    name: Build and release container images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
 
-        - name: Build container
-          run: make container
+      - name: Build container
+        run: make container
 
-        - name: Login to registry
-          run: |
-            echo "${{ secrets.PERSONAL_ACCESS_TOKEN }}" | podman login -u parca-dev --password-stdin ghcr.io
-        - name: Push container
-          run: |
-            make push-container
+      - name: Login to registry
+        run: |
+          echo "${{ secrets.PERSONAL_ACCESS_TOKEN }}" | podman login -u parca-dev --password-stdin ghcr.io
+      - name: Push container
+        run: |
+          make push-container

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ permissions:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    env:
+      DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -25,13 +27,15 @@ jobs:
       - name: Build UI
         run: make ui/build
 
-      # TODO(kakkoyun): Disabled until fixing the authentication issue.
-      #      - name: Login to Github Container Registry
-      #        uses: docker/login-action@v1
-      #        with:
-      #          registry: ghcr.io
-      #          username: ${{ github.actor }}
-      #          password: ${{ secrets.PERSONAL_ACCESS_TOKEN }} # GITHUB_TOKEN
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }} # actor
+          password: ${{ secrets.PERSONAL_ACCESS_TOKEN }} # GITHUB_TOKEN
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
@@ -44,7 +48,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   manifests:
-    name: Manifests generate and release
+    name: Generate and release Kubernetes Manifests
     runs-on: ubuntu-latest
     needs: goreleaser
     steps:
@@ -92,21 +96,3 @@ jobs:
       - name: Publish Vercel
         run: |
           curl -X POST "https://api.vercel.com/v1/integrations/deploy/${{ secrets.VERCEL_WEBHOOK }}"
-
-  container:
-    name: Container build and push
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
-
-      - name: Build container
-        run: make container
-
-      - name: Login to registry
-        run: |
-          echo "${{ secrets.PERSONAL_ACCESS_TOKEN }}" | buildah login -u parca-dev --password-stdin ghcr.io
-
-      - name: Push container
-        run: |
-          make push-container

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -75,122 +75,126 @@ changelog:
       - '^docs:'
       - '^test:'
 
-dockers:
-  # https://goreleaser.com/customization/docker/
-  - id: amd64
-    use: buildx
-    image_templates:
-      - parca-dev/{{ .ProjectName }}:{{ .Version }}-amd64
-      - parca-dev/{{ .ProjectName }}:latest-amd64
-    dockerfile: Dockerfile.release
-    extra_files:
-      - parca.yaml
-    build_flag_templates:
-      - --platform=linux/amd64
-      - --label=org.opencontainers.image.title={{ .ProjectName }}
-      - --label=org.opencontainers.image.description={{ .ProjectName }}
-      - --label=org.opencontainers.image.url=https://github.com/parca-dev/{{ .ProjectName }}
-      - --label=org.opencontainers.image.source=https://github.com/parca-dev/{{ .ProjectName }}
-      - --label=org.opencontainers.image.created={{.CommitDate}}
-      - --label=org.opencontainers.image.version={{ .Version }}
-      - --label=org.opencontainers.image.revision={{ .FullCommit }}
-      - --label=org.opencontainers.image.licenses=Apache-2.0
+# It's still not possible to use docker (buildx) for reproducible builds.
+# And Goreleaser only supports podman with pro version, (https://goreleaser.com/customization/docker/#podman)
+# for full build pipeline transparency, we don't want to use pro version for Parca.
 
-  - id: arm64
-    use: buildx
-    image_templates:
-      - parca-dev/{{ .ProjectName }}:{{ .Version }}-arm64v8
-      - parca-dev/{{ .ProjectName }}:latest-arm64v8
-    goarch: arm64
-    dockerfile: Dockerfile.release
-    extra_files:
-      - parca.yaml
-    build_flag_templates:
-      - --platform=linux/arm64/v8
-      - --label=org.opencontainers.image.title={{ .ProjectName }}
-      - --label=org.opencontainers.image.description={{ .ProjectName }}
-      - --label=org.opencontainers.image.url=https://github.com/parca-dev/{{ .ProjectName }}
-      - --label=org.opencontainers.image.source=https://github.com/parca-dev/{{ .ProjectName }}
-      - --label=org.opencontainers.image.version={{ .Version }}
-      - --label=org.opencontainers.image.created={{.CommitDate}}
-      - --label=org.opencontainers.image.revision={{ .FullCommit }}
-      - --label=org.opencontainers.image.licenses=Apache-2.0
-
-  - id: armv6
-    use: buildx
-    image_templates:
-      - parca-dev/{{ .ProjectName }}:{{ .Version }}-armv6
-      - parca-dev/{{ .ProjectName }}:latest-armv6
-    goarch: arm
-    goarm: 6
-    dockerfile: Dockerfile.release
-    extra_files:
-      - parca.yaml
-    build_flag_templates:
-      - --platform=linux/arm64/v8
-      - --label=org.opencontainers.image.title={{ .ProjectName }}
-      - --label=org.opencontainers.image.description={{ .ProjectName }}
-      - --label=org.opencontainers.image.url=https://github.com/parca-dev/{{ .ProjectName }}
-      - --label=org.opencontainers.image.source=https://github.com/parca-dev/{{ .ProjectName }}
-      - --label=org.opencontainers.image.version={{ .Version }}
-      - --label=org.opencontainers.image.created={{.CommitDate}}
-      - --label=org.opencontainers.image.revision={{ .FullCommit }}
-      - --label=org.opencontainers.image.licenses=Apache-2.0
-
-  - id: armv7
-    use: buildx
-    image_templates:
-      - parca-dev/{{ .ProjectName }}:{{ .Version }}-armv7
-      - parca-dev/{{ .ProjectName }}:latest-armv7
-    goarch: arm
-    goarm: 7
-    dockerfile: Dockerfile.release
-    extra_files:
-      - parca.yaml
-    build_flag_templates:
-      - --platform=linux/arm64/v8
-      - --label=org.opencontainers.image.title={{ .ProjectName }}
-      - --label=org.opencontainers.image.description={{ .ProjectName }}
-      - --label=org.opencontainers.image.url=https://github.com/parca-dev/{{ .ProjectName }}
-      - --label=org.opencontainers.image.source=https://github.com/parca-dev/{{ .ProjectName }}
-      - --label=org.opencontainers.image.version={{ .Version }}
-      - --label=org.opencontainers.image.created={{.CommitDate}}
-      - --label=org.opencontainers.image.revision={{ .FullCommit }}
-      - --label=org.opencontainers.image.licenses=Apache-2.0
-
-  - id: 386
-    use: buildx
-    image_templates:
-      - parca-dev/{{ .ProjectName }}:{{ .Version }}-i386
-      - parca-dev/{{ .ProjectName }}:latest-i386
-    goarch: 386
-    dockerfile: Dockerfile.release
-    extra_files:
-      - parca.yaml
-    build_flag_templates:
-      - --platform=linux/386
-      - --label=org.opencontainers.image.title={{ .ProjectName }}
-      - --label=org.opencontainers.image.description={{ .ProjectName }}
-      - --label=org.opencontainers.image.url=https://github.com/parca-dev/{{ .ProjectName }}
-      - --label=org.opencontainers.image.source=https://github.com/parca-dev/{{ .ProjectName }}
-      - --label=org.opencontainers.image.version={{ .Version }}
-      - --label=org.opencontainers.image.created={{.CommitDate}}
-      - --label=org.opencontainers.image.revision={{ .FullCommit }}
-      - --label=org.opencontainers.image.licenses=Apache-2.0
-
-docker_manifests:
-  - name_template: ghcr.io/parca-dev/{{ .ProjectName }}:{{ .Version }}
-    image_templates:
-      - ghcr.io/parca-dev/{{ .ProjectName }}:{{ .Version }}-x86_64
-      - ghcr.io/parca-dev/{{ .ProjectName }}:{{ .Version }}-arm64v8
-      - ghcr.io/parca-dev/{{ .ProjectName }}:{{ .Version }}-i386
-      - ghcr.io/parca-dev/{{ .ProjectName }}:{{ .Version }}-armv6
-      - ghcr.io/parca-dev/{{ .ProjectName }}:{{ .Version }}-armv7
-
-  - name_template: ghcr.io/parca-dev/{{ .ProjectName }}:latest
-    image_templates:
-      - ghcr.io/parca-dev/{{ .ProjectName }}:{{ .Version }}-x86_64
-      - ghcr.io/parca-dev/{{ .ProjectName }}:{{ .Version }}-arm64v8
-      - ghcr.io/parca-dev/{{ .ProjectName }}:{{ .Version }}-i386
-      - ghcr.io/parca-dev/{{ .ProjectName }}:latest-armv6
-      - ghcr.io/parca-dev/{{ .ProjectName }}:latest-armv7
+#dockers:
+#  # https://goreleaser.com/customization/docker/
+#  - id: amd64
+#    use: buildx
+#    image_templates:
+#      - parca-dev/{{ .ProjectName }}:{{ .Version }}-amd64
+#      - parca-dev/{{ .ProjectName }}:latest-amd64
+#    dockerfile: Dockerfile.release
+#    extra_files:
+#      - parca.yaml
+#    build_flag_templates:
+#      - --platform=linux/amd64
+#      - --label=org.opencontainers.image.title={{ .ProjectName }}
+#      - --label=org.opencontainers.image.description={{ .ProjectName }}
+#      - --label=org.opencontainers.image.url=https://github.com/parca-dev/{{ .ProjectName }}
+#      - --label=org.opencontainers.image.source=https://github.com/parca-dev/{{ .ProjectName }}
+#      - --label=org.opencontainers.image.created={{.CommitDate}}
+#      - --label=org.opencontainers.image.version={{ .Version }}
+#      - --label=org.opencontainers.image.revision={{ .FullCommit }}
+#      - --label=org.opencontainers.image.licenses=Apache-2.0
+#
+#  - id: arm64
+#    use: buildx
+#    image_templates:
+#      - parca-dev/{{ .ProjectName }}:{{ .Version }}-arm64v8
+#      - parca-dev/{{ .ProjectName }}:latest-arm64v8
+#    goarch: arm64
+#    dockerfile: Dockerfile.release
+#    extra_files:
+#      - parca.yaml
+#    build_flag_templates:
+#      - --platform=linux/arm64/v8
+#      - --label=org.opencontainers.image.title={{ .ProjectName }}
+#      - --label=org.opencontainers.image.description={{ .ProjectName }}
+#      - --label=org.opencontainers.image.url=https://github.com/parca-dev/{{ .ProjectName }}
+#      - --label=org.opencontainers.image.source=https://github.com/parca-dev/{{ .ProjectName }}
+#      - --label=org.opencontainers.image.version={{ .Version }}
+#      - --label=org.opencontainers.image.created={{.CommitDate}}
+#      - --label=org.opencontainers.image.revision={{ .FullCommit }}
+#      - --label=org.opencontainers.image.licenses=Apache-2.0
+#
+#  - id: armv6
+#    use: buildx
+#    image_templates:
+#      - parca-dev/{{ .ProjectName }}:{{ .Version }}-armv6
+#      - parca-dev/{{ .ProjectName }}:latest-armv6
+#    goarch: arm
+#    goarm: 6
+#    dockerfile: Dockerfile.release
+#    extra_files:
+#      - parca.yaml
+#    build_flag_templates:
+#      - --platform=linux/arm64/v8
+#      - --label=org.opencontainers.image.title={{ .ProjectName }}
+#      - --label=org.opencontainers.image.description={{ .ProjectName }}
+#      - --label=org.opencontainers.image.url=https://github.com/parca-dev/{{ .ProjectName }}
+#      - --label=org.opencontainers.image.source=https://github.com/parca-dev/{{ .ProjectName }}
+#      - --label=org.opencontainers.image.version={{ .Version }}
+#      - --label=org.opencontainers.image.created={{.CommitDate}}
+#      - --label=org.opencontainers.image.revision={{ .FullCommit }}
+#      - --label=org.opencontainers.image.licenses=Apache-2.0
+#
+#  - id: armv7
+#    use: buildx
+#    image_templates:
+#      - parca-dev/{{ .ProjectName }}:{{ .Version }}-armv7
+#      - parca-dev/{{ .ProjectName }}:latest-armv7
+#    goarch: arm
+#    goarm: 7
+#    dockerfile: Dockerfile.release
+#    extra_files:
+#      - parca.yaml
+#    build_flag_templates:
+#      - --platform=linux/arm64/v8
+#      - --label=org.opencontainers.image.title={{ .ProjectName }}
+#      - --label=org.opencontainers.image.description={{ .ProjectName }}
+#      - --label=org.opencontainers.image.url=https://github.com/parca-dev/{{ .ProjectName }}
+#      - --label=org.opencontainers.image.source=https://github.com/parca-dev/{{ .ProjectName }}
+#      - --label=org.opencontainers.image.version={{ .Version }}
+#      - --label=org.opencontainers.image.created={{.CommitDate}}
+#      - --label=org.opencontainers.image.revision={{ .FullCommit }}
+#      - --label=org.opencontainers.image.licenses=Apache-2.0
+#
+#  - id: 386
+#    use: buildx
+#    image_templates:
+#      - parca-dev/{{ .ProjectName }}:{{ .Version }}-i386
+#      - parca-dev/{{ .ProjectName }}:latest-i386
+#    goarch: 386
+#    dockerfile: Dockerfile.release
+#    extra_files:
+#      - parca.yaml
+#    build_flag_templates:
+#      - --platform=linux/386
+#      - --label=org.opencontainers.image.title={{ .ProjectName }}
+#      - --label=org.opencontainers.image.description={{ .ProjectName }}
+#      - --label=org.opencontainers.image.url=https://github.com/parca-dev/{{ .ProjectName }}
+#      - --label=org.opencontainers.image.source=https://github.com/parca-dev/{{ .ProjectName }}
+#      - --label=org.opencontainers.image.version={{ .Version }}
+#      - --label=org.opencontainers.image.created={{.CommitDate}}
+#      - --label=org.opencontainers.image.revision={{ .FullCommit }}
+#      - --label=org.opencontainers.image.licenses=Apache-2.0
+#
+#docker_manifests:
+#  - name_template: ghcr.io/parca-dev/{{ .ProjectName }}:{{ .Version }}
+#    image_templates:
+#      - ghcr.io/parca-dev/{{ .ProjectName }}:{{ .Version }}-x86_64
+#      - ghcr.io/parca-dev/{{ .ProjectName }}:{{ .Version }}-arm64v8
+#      - ghcr.io/parca-dev/{{ .ProjectName }}:{{ .Version }}-i386
+#      - ghcr.io/parca-dev/{{ .ProjectName }}:{{ .Version }}-armv6
+#      - ghcr.io/parca-dev/{{ .ProjectName }}:{{ .Version }}-armv7
+#
+#  - name_template: ghcr.io/parca-dev/{{ .ProjectName }}:latest
+#    image_templates:
+#      - ghcr.io/parca-dev/{{ .ProjectName }}:{{ .Version }}-x86_64
+#      - ghcr.io/parca-dev/{{ .ProjectName }}:{{ .Version }}-arm64v8
+#      - ghcr.io/parca-dev/{{ .ProjectName }}:{{ .Version }}-i386
+#      - ghcr.io/parca-dev/{{ .ProjectName }}:latest-armv6
+#      - ghcr.io/parca-dev/{{ .ProjectName }}:latest-armv7

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,6 +5,8 @@ builds:
   - main: ./cmd/parca/
     id: "parca"
     binary: parca
+    # https://goreleaser.com/customization/build/#reproducible-builds
+    mod_timestamp: '{{ .CommitTimestamp }}'
     env:
       - CGO_ENABLED=0
     goos:
@@ -23,6 +25,7 @@ builds:
       - -trimpath
       - -v
     ldflags:
+      # Default is `-s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser`.
       - -X main.version={{.Version}} -X main.commit={{.Commit}}
     ignore:
       - goos: darwin
@@ -88,7 +91,7 @@ dockers:
       - --label=org.opencontainers.image.description={{ .ProjectName }}
       - --label=org.opencontainers.image.url=https://github.com/parca-dev/{{ .ProjectName }}
       - --label=org.opencontainers.image.source=https://github.com/parca-dev/{{ .ProjectName }}
-      - --label=org.opencontainers.image.created={{.Date}}
+      - --label=org.opencontainers.image.created={{.CommitDate}}
       - --label=org.opencontainers.image.version={{ .Version }}
       - --label=org.opencontainers.image.revision={{ .FullCommit }}
       - --label=org.opencontainers.image.licenses=Apache-2.0
@@ -109,7 +112,7 @@ dockers:
       - --label=org.opencontainers.image.url=https://github.com/parca-dev/{{ .ProjectName }}
       - --label=org.opencontainers.image.source=https://github.com/parca-dev/{{ .ProjectName }}
       - --label=org.opencontainers.image.version={{ .Version }}
-      - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
+      - --label=org.opencontainers.image.created={{.CommitDate}}
       - --label=org.opencontainers.image.revision={{ .FullCommit }}
       - --label=org.opencontainers.image.licenses=Apache-2.0
 
@@ -130,7 +133,7 @@ dockers:
       - --label=org.opencontainers.image.url=https://github.com/parca-dev/{{ .ProjectName }}
       - --label=org.opencontainers.image.source=https://github.com/parca-dev/{{ .ProjectName }}
       - --label=org.opencontainers.image.version={{ .Version }}
-      - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
+      - --label=org.opencontainers.image.created={{.CommitDate}}
       - --label=org.opencontainers.image.revision={{ .FullCommit }}
       - --label=org.opencontainers.image.licenses=Apache-2.0
 
@@ -151,7 +154,7 @@ dockers:
       - --label=org.opencontainers.image.url=https://github.com/parca-dev/{{ .ProjectName }}
       - --label=org.opencontainers.image.source=https://github.com/parca-dev/{{ .ProjectName }}
       - --label=org.opencontainers.image.version={{ .Version }}
-      - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
+      - --label=org.opencontainers.image.created={{.CommitDate}}
       - --label=org.opencontainers.image.revision={{ .FullCommit }}
       - --label=org.opencontainers.image.licenses=Apache-2.0
 
@@ -171,7 +174,7 @@ dockers:
       - --label=org.opencontainers.image.url=https://github.com/parca-dev/{{ .ProjectName }}
       - --label=org.opencontainers.image.source=https://github.com/parca-dev/{{ .ProjectName }}
       - --label=org.opencontainers.image.version={{ .Version }}
-      - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
+      - --label=org.opencontainers.image.created={{.CommitDate}}
       - --label=org.opencontainers.image.revision={{ .FullCommit }}
       - --label=org.opencontainers.image.licenses=Apache-2.0
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,11 +11,30 @@ builds:
       - linux
       - windows
       - darwin
+    goarch:
+      - amd64
+      - arm64
+      - '386'
+      - arm
+    goarm:
+      - '6'
+      - '7'
     flags:
       - -trimpath
       - -v
     ldflags:
       - -X main.version={{.Version}} -X main.commit={{.Commit}}
+    ignore:
+      - goos: darwin
+        goarch: '386'
+      - goos: windows
+        goarch: arm
+        goarm: '6'
+      - goos: windows
+        goarch: arm
+        goarm: '7'
+      - goos: windows
+        goarch: '386'
 archives:
   - replacements:
       darwin: Darwin
@@ -30,6 +49,8 @@ checksum:
   name_template: 'checksums.txt'
 snapshot:
   name_template: "{{ incpatch .Tag }}-next"
+source:
+  enabled: true
 release:
   prerelease: auto
   # Defaults to empty.
@@ -51,13 +72,122 @@ changelog:
       - '^docs:'
       - '^test:'
 
-# Disabled until fixing the authentication issue with ghcr.
-#dockers:
-#  - id: parca
-#    goos: linux
-#    goarch: amd64
-#    dockerfile: Dockerfile.release
-#    extra_files:
-#    - parca.yaml
-#    image_templates:
-#    - ghcr.io/parca-dev/parca:{{ .Tag }}
+dockers:
+  # https://goreleaser.com/customization/docker/
+  - id: amd64
+    use: buildx
+    image_templates:
+      - parca-dev/{{ .ProjectName }}:{{ .Version }}-amd64
+      - parca-dev/{{ .ProjectName }}:latest-amd64
+    dockerfile: Dockerfile.release
+    extra_files:
+      - parca.yaml
+    build_flag_templates:
+      - --platform=linux/amd64
+      - --label=org.opencontainers.image.title={{ .ProjectName }}
+      - --label=org.opencontainers.image.description={{ .ProjectName }}
+      - --label=org.opencontainers.image.url=https://github.com/parca-dev/{{ .ProjectName }}
+      - --label=org.opencontainers.image.source=https://github.com/parca-dev/{{ .ProjectName }}
+      - --label=org.opencontainers.image.created={{.Date}}
+      - --label=org.opencontainers.image.version={{ .Version }}
+      - --label=org.opencontainers.image.revision={{ .FullCommit }}
+      - --label=org.opencontainers.image.licenses=Apache-2.0
+
+  - id: arm64
+    use: buildx
+    image_templates:
+      - parca-dev/{{ .ProjectName }}:{{ .Version }}-arm64v8
+      - parca-dev/{{ .ProjectName }}:latest-arm64v8
+    goarch: arm64
+    dockerfile: Dockerfile.release
+    extra_files:
+      - parca.yaml
+    build_flag_templates:
+      - --platform=linux/arm64/v8
+      - --label=org.opencontainers.image.title={{ .ProjectName }}
+      - --label=org.opencontainers.image.description={{ .ProjectName }}
+      - --label=org.opencontainers.image.url=https://github.com/parca-dev/{{ .ProjectName }}
+      - --label=org.opencontainers.image.source=https://github.com/parca-dev/{{ .ProjectName }}
+      - --label=org.opencontainers.image.version={{ .Version }}
+      - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
+      - --label=org.opencontainers.image.revision={{ .FullCommit }}
+      - --label=org.opencontainers.image.licenses=Apache-2.0
+
+  - id: armv6
+    use: buildx
+    image_templates:
+      - parca-dev/{{ .ProjectName }}:{{ .Version }}-armv6
+      - parca-dev/{{ .ProjectName }}:latest-armv6
+    goarch: arm
+    goarm: 6
+    dockerfile: Dockerfile.release
+    extra_files:
+      - parca.yaml
+    build_flag_templates:
+      - --platform=linux/arm64/v8
+      - --label=org.opencontainers.image.title={{ .ProjectName }}
+      - --label=org.opencontainers.image.description={{ .ProjectName }}
+      - --label=org.opencontainers.image.url=https://github.com/parca-dev/{{ .ProjectName }}
+      - --label=org.opencontainers.image.source=https://github.com/parca-dev/{{ .ProjectName }}
+      - --label=org.opencontainers.image.version={{ .Version }}
+      - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
+      - --label=org.opencontainers.image.revision={{ .FullCommit }}
+      - --label=org.opencontainers.image.licenses=Apache-2.0
+
+  - id: armv7
+    use: buildx
+    image_templates:
+      - parca-dev/{{ .ProjectName }}:{{ .Version }}-armv7
+      - parca-dev/{{ .ProjectName }}:latest-armv7
+    goarch: arm
+    goarm: 7
+    dockerfile: Dockerfile.release
+    extra_files:
+      - parca.yaml
+    build_flag_templates:
+      - --platform=linux/arm64/v8
+      - --label=org.opencontainers.image.title={{ .ProjectName }}
+      - --label=org.opencontainers.image.description={{ .ProjectName }}
+      - --label=org.opencontainers.image.url=https://github.com/parca-dev/{{ .ProjectName }}
+      - --label=org.opencontainers.image.source=https://github.com/parca-dev/{{ .ProjectName }}
+      - --label=org.opencontainers.image.version={{ .Version }}
+      - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
+      - --label=org.opencontainers.image.revision={{ .FullCommit }}
+      - --label=org.opencontainers.image.licenses=Apache-2.0
+
+  - id: 386
+    use: buildx
+    image_templates:
+      - parca-dev/{{ .ProjectName }}:{{ .Version }}-i386
+      - parca-dev/{{ .ProjectName }}:latest-i386
+    goarch: 386
+    dockerfile: Dockerfile.release
+    extra_files:
+      - parca.yaml
+    build_flag_templates:
+      - --platform=linux/386
+      - --label=org.opencontainers.image.title={{ .ProjectName }}
+      - --label=org.opencontainers.image.description={{ .ProjectName }}
+      - --label=org.opencontainers.image.url=https://github.com/parca-dev/{{ .ProjectName }}
+      - --label=org.opencontainers.image.source=https://github.com/parca-dev/{{ .ProjectName }}
+      - --label=org.opencontainers.image.version={{ .Version }}
+      - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
+      - --label=org.opencontainers.image.revision={{ .FullCommit }}
+      - --label=org.opencontainers.image.licenses=Apache-2.0
+
+docker_manifests:
+  - name_template: ghcr.io/parca-dev/{{ .ProjectName }}:{{ .Version }}
+    image_templates:
+      - ghcr.io/parca-dev/{{ .ProjectName }}:{{ .Version }}-x86_64
+      - ghcr.io/parca-dev/{{ .ProjectName }}:{{ .Version }}-arm64v8
+      - ghcr.io/parca-dev/{{ .ProjectName }}:{{ .Version }}-i386
+      - ghcr.io/parca-dev/{{ .ProjectName }}:{{ .Version }}-armv6
+      - ghcr.io/parca-dev/{{ .ProjectName }}:{{ .Version }}-armv7
+
+  - name_template: ghcr.io/parca-dev/{{ .ProjectName }}:latest
+    image_templates:
+      - ghcr.io/parca-dev/{{ .ProjectName }}:{{ .Version }}-x86_64
+      - ghcr.io/parca-dev/{{ .ProjectName }}:{{ .Version }}-arm64v8
+      - ghcr.io/parca-dev/{{ .ProjectName }}:{{ .Version }}-i386
+      - ghcr.io/parca-dev/{{ .ProjectName }}:latest-armv6
+      - ghcr.io/parca-dev/{{ .ProjectName }}:latest-armv7

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:17.7.1-alpine3.14 AS ui-deps
+FROM node:17.7.1-alpine3.15 AS ui-deps
 
 WORKDIR /app
 
@@ -7,7 +7,7 @@ COPY ui/packages/app/web/package.json ./packages/app/web/package.json
 COPY ui/package.json ui/yarn.lock ./
 RUN yarn workspace @parca/web install --frozen-lockfile
 
-FROM node:17.7.1-alpine3.14 AS ui-builder
+FROM node:17.7.1-alpine3.15 AS ui-builder
 
 WORKDIR /app
 
@@ -15,10 +15,11 @@ COPY ui .
 COPY --from=ui-deps /app/node_modules ./node_modules
 RUN yarn workspace @parca/web build
 
-FROM golang:1.17.8-alpine AS builder
+FROM golang:1.17.8-alpine3.15 AS builder
 
 WORKDIR /app
 
+RUN apk update && apk add --no-cache build-base
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.8.2
 RUN go install github.com/grpc-ecosystem/grpc-health-probe@latest
 
@@ -36,7 +37,7 @@ COPY ./gen /app/gen
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -gcflags="all=-N -l" -o parca ./cmd/parca
 
-FROM golang:1.17.8-alpine
+FROM golang:1.17.8-alpine3.15
 
 COPY --from=builder /go/bin/dlv /
 COPY --from=builder /go/bin/grpc-health-probe /

--- a/Dockerfile.go.dev
+++ b/Dockerfile.go.dev
@@ -1,8 +1,9 @@
 # Designed to only used by Tilt to iterate faster on the API.
-FROM golang:1.17.8-alpine AS builder
+FROM golang:1.17.8-alpine3.15 AS builder
 
 WORKDIR /app
 
+RUN apk update && apk add --no-cache build-base
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.8.2
 RUN go install github.com/grpc-ecosystem/grpc-health-probe@latest
 
@@ -26,7 +27,7 @@ COPY ./gen /app/gen
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -gcflags="all=-N -l" -o parca ./cmd/parca
 
-FROM golang:1.17.8-alpine
+FROM golang:1.17.8-alpine3.15
 
 COPY --from=builder /go/bin/dlv /
 COPY --from=builder /go/bin/grpc-health-probe /

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,8 +1,18 @@
-# this image is what docker.io/alpine:3.14.1 on August 13 2021
-FROM docker.io/alpine@sha256:be9bdc0ef8e96dbc428dc189b31e2e3b05523d96d12ed627c37aa2936653258c
+FROM golang:1.17.8-alpine3.15 as builder
+
+WORKDIR /app
+
+RUN go install github.com/grpc-ecosystem/grpc-health-probe@latest
+# Predicatable path for copying over to final image
+RUN if [ "$(go env GOHOSTARCH)" != "$(go env GOARCH)" ]; then mv "$(go env GOPATH)/bin/$(go env GOOS)_$(go env GOARCH)/grpc-health-probe" "$(go env GOPATH)/bin/grpc-health-probe"; fi
+
+FROM alpine:3.15.0
+
 USER nobody
 
-COPY --chown=0:0 parca.yaml /
-COPY --chown=0:0 parca /
+COPY parca /parca
+COPY --chown=0:0 parca.yaml /parca.yaml
+
+COPY --chown=0:0 --from=builder /go/bin/grpc-health-probe /
 
 CMD ["/parca"]

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ proto/vendor:
 
 .PHONY: container-dev
 container-dev:
-       buildah build-using-dockerfile --timestamp 0 --layers --build-arg VERSION=$(VERSION) --build-arg COMMIT=$(COMMIT) -t $(OUT_DOCKER):$(VERSION) .
+    podman build --timestamp 0 --layers --build-arg VERSION=$(VERSION) --build-arg COMMIT=$(COMMIT) -t $(OUT_DOCKER):$(VERSION) .
 
 .PHONY: container
 container:
@@ -98,11 +98,11 @@ container:
 
 .PHONY: push-container
 push-container:
-	buildah manifest push --all $(OUT_DOCKER):$(VERSION) docker://$(OUT_DOCKER):$(VERSION)
+	podman push $(OUT_DOCKER):$(VERSION) $(OUT_DOCKER):$(VERSION)
 
 .PHONY: push-quay-container
 push-quay-container:
-	buildah manifest push --all $(OUT_DOCKER):$(VERSION) docker://quay.io/parca/parca:$(VERSION)
+	podman push $(OUT_DOCKER):$(VERSION) quay.io/parca/parca:$(VERSION)
 
 .PHONY: deploy/manifests
 deploy/manifests:

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,6 @@ else
 	COMMIT := $(shell echo $(GITHUB_SHA) | cut -c1-8)
 endif
 VERSION ?= $(if $(RELEASE_TAG),$(RELEASE_TAG),$(shell $(CMD_GIT) describe --tags 2>/dev/null || echo '$(BRANCH)$(COMMIT)'))
-ALL_ARCH ?= amd64 arm arm64
 OUT_DOCKER ?= ghcr.io/parca-dev/parca
 
 .PHONY: build
@@ -95,9 +94,7 @@ container-dev:
 
 .PHONY: container
 container:
-	for arch in $(ALL_ARCH); do \
-	buildah build-using-dockerfile --build-arg VERSION=$(VERSION) --build-arg COMMIT=$(COMMIT) --build-arg ARCH=$$arch --arch $$arch --timestamp 0 --manifest $(OUT_DOCKER):$(VERSION); \
-	done
+	 ./scripts/make-containers.sh $(VERSION) $(COMMIT) $(OUT_DOCKER):$(VERSION)
 
 .PHONY: push-container
 push-container:

--- a/scripts/make-containers.sh
+++ b/scripts/make-containers.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set +x
+
+VERSION="$1"
+COMMIT="$2"
+MANIFEST="$3"
+ARCHS=('amd64' 'arm64' 'armv6' 'armv7' '386')
+
+# SHA order is respectively ('amd64' 'arm64' 'armv6' 'armv7' '386')
+# this image is what docker.io/golang:1.17.8-alpine3.15 on March 14 2021
+DOCKER_GOLANG_ALPINE_SHAS=(
+    'docker.io/golang@sha256:e2e68a9cdd5da82458652fdac3908a3a270686b38039f2829855398e2e06019d'
+    'docker.io/golang@sha256:a55e3394bce5523e660d9ee17adb827731ddd02559e75aabe3c5417778f8941e'
+    'docker.io/golang@sha256:3eb758fdfa1fa203d5503921d5bc18765c733add0cfbf98a3302e6a055cebaa1'
+    'docker.io/golang@sha256:96b13a554921ea4e4d4435244497708779e9047863c77fcc89892b4fd5ef4ac1'
+    'docker.io/golang@sha256:46a83fb9832e1aeed048139e4bc63bbfe039462ea12114dc2d1b2cd7574db7b2'
+)
+
+# SHA order is respectively ('amd64' 'arm64' 'armv6' 'armv7' '386')
+# this image is what node:17.7.1-alpine3.15 is on March 14 2021
+DOCKER_NODE_ALPINE_SHAS=(
+    'docker.io/library/node@sha256:10ef59da5b5ccdbaff99a81df1bcccb0500723633ce406efed6f1fb74adc8568'
+    'docker.io/library/node@sha256:8ca33e44fa0be3989b4dbced274f0fa17cc9ded52e3c0824725264b32bdf7c38'
+    'docker.io/library/node@sha256:9d674d6222f95556b5a4e2162cc09450928dec5979b99f208b6b0526c6c41e98'
+    'docker.io/library/node@sha256:6c8a221b76847a08a3789c2a18fa194e6a5825a7a1037f3d47396fbdf7cfeca7'
+    'docker.io/library/node@sha256:10ef59da5b5ccdbaff99a81df1bcccb0500723633ce406efed6f1fb74adc8568' # this is an amd64 image, unfortunately there is no 386 image for nodejs.
+)
+
+# SHA order is respectively ('amd64' 'arm64' 'armv6' 'armv7' '386')
+# this image is what docker.io/alpine:3.15.0 on March 14 2021
+DOCKER_ALPINE_SHAS=(
+    'docker.io/alpine@sha256:e7d88de73db3d3fd9b2d63aa7f447a10fd0220b7cbf39803c803f2af9ba256b3'
+    'docker.io/alpine@sha256:c74f1b1166784193ea6c8f9440263b9be6cae07dfe35e32a5df7a31358ac2060'
+    'docker.io/alpine@sha256:e047bc2af17934d38c5a7fa9f46d443f1de3a7675546402592ef805cfa929f9d'
+    'docker.io/alpine@sha256:8483ecd016885d8dba70426fda133c30466f661bb041490d525658f1aac73822'
+    'docker.io/alpine@sha256:2689e157117d2da668ad4699549e55eba1ceb79cb7862368b30919f0488213f4'
+)
+
+for i in "${!ARCHS[@]}"; do
+    ARCH=${ARCHS[$i]}
+    DOCKER_GOLANG_ALPINE_SHA=${DOCKER_GOLANG_ALPINE_SHAS[$i]}
+    DOCKER_NODE_ALPINE_SHA=${DOCKER_NODE_ALPINE_SHAS[$i]}
+    DOCKER_ALPINE_SHA=${DOCKER_ALPINE_SHAS[$i]}
+    echo "Building manifest for $MANIFEST with arch \"$ARCH\""
+    buildah build-using-dockerfile \
+        --build-arg VERSION="$VERSION" \
+        --build-arg COMMIT="$COMMIT" \
+        --build-arg GOLANG_BUILDER_BASE="$DOCKER_GOLANG_ALPINE_SHA" \
+        --build-arg NODE_BUILDER_BASE="$DOCKER_NODE_ALPINE_SHA" \
+        --build-arg RUNNER_BASE="$DOCKER_ALPINE_SHA" \
+        --build-arg ARCH="$ARCH" \
+        --arch "$ARCH" \
+        --timestamp 0 \
+        --manifest "$MANIFEST" .; \
+done

--- a/scripts/make-containers.sh
+++ b/scripts/make-containers.sh
@@ -42,7 +42,7 @@ for i in "${!ARCHS[@]}"; do
     DOCKER_NODE_ALPINE_SHA=${DOCKER_NODE_ALPINE_SHAS[$i]}
     DOCKER_ALPINE_SHA=${DOCKER_ALPINE_SHAS[$i]}
     echo "Building manifest for $MANIFEST with arch \"$ARCH\""
-    buildah build-using-dockerfile \
+    podman build \
         --build-arg VERSION="$VERSION" \
         --build-arg COMMIT="$COMMIT" \
         --build-arg GOLANG_BUILDER_BASE="$DOCKER_GOLANG_ALPINE_SHA" \


### PR DESCRIPTION
- Fix multi-arch base image problem
- ~This still keeps~ The builds scripts that uses podman/buildah for reproducible builds
- ~Goreleaser uses docker buildx to build images~ It's still not possible to use docker for reproducible builds. And Goreleaser only supports podman with pro version, for full build pipeline transparency sake we don't want to use pro version for Parca
- Pin and update base images
- Reorganize and reformat github/workflows

Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

Fixes #757 