### PR TITLE
Use correct base images for correct architecture

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -28,13 +28,13 @@ jobs:
         run: make container
 
       - name: Check images created
-        run: buildah images | grep 'ghcr.io/parca-dev/parca'
+        run: podman images | grep 'ghcr.io/parca-dev/parca'
 
       - name: Login to registry
         if: ${{ github.event_name != 'pull_request' }}
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | buildah login -u parca-dev --password-stdin ghcr.io
-          echo "${{ secrets.QUAY_PASSWORD }}" | buildah login -u "${{ secrets.QUAY_USERNAME }}" --password-stdin quay.io
+          echo "${{ secrets.GITHUB_TOKEN }}" | podman login -u parca-dev --password-stdin ghcr.io
+          echo "${{ secrets.QUAY_PASSWORD }}" | podman login -u "${{ secrets.QUAY_USERNAME }}" --password-stdin quay.io
 
       - name: Push container
         if: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,8 +105,7 @@ jobs:
 
       - name: Login to registry
         run: |
-          echo "${{ secrets.PERSONAL_ACCESS_TOKEN }}" | buildah login -u parca-dev --password-stdin ghcr.io
-
+          echo "${{ secrets.PERSONAL_ACCESS_TOKEN }}" | podman login -u parca-dev --password-stdin ghcr.io
       - name: Push container
         run: |
           make push-container

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,6 @@ else
 	COMMIT := $(shell echo $(GITHUB_SHA) | cut -c1-8)
 endif
 VERSION ?= $(if $(RELEASE_TAG),$(RELEASE_TAG),$(shell $(CMD_GIT) describe --tags 2>/dev/null || echo '$(BRANCH)$(COMMIT)'))
-ALL_ARCH ?= amd64 arm arm64
 OUT_DOCKER ?= ghcr.io/parca-dev/parca
 
 .PHONY: build
@@ -91,21 +90,19 @@ proto/vendor:
 
 .PHONY: container-dev
 container-dev:
-       buildah build-using-dockerfile --timestamp 0 --layers --build-arg VERSION=$(VERSION) --build-arg COMMIT=$(COMMIT) -t $(OUT_DOCKER):$(VERSION) .
+    podman build --timestamp 0 --layers --build-arg VERSION=$(VERSION) --build-arg COMMIT=$(COMMIT) -t $(OUT_DOCKER):$(VERSION) .
 
 .PHONY: container
 container:
-	for arch in $(ALL_ARCH); do \
-	buildah build-using-dockerfile --build-arg VERSION=$(VERSION) --build-arg COMMIT=$(COMMIT) --build-arg ARCH=$$arch --arch $$arch --timestamp 0 --manifest $(OUT_DOCKER):$(VERSION); \
-	done
+	 ./scripts/make-containers.sh $(VERSION) $(COMMIT) $(OUT_DOCKER):$(VERSION)
 
 .PHONY: push-container
 push-container:
-	buildah manifest push --all $(OUT_DOCKER):$(VERSION) docker://$(OUT_DOCKER):$(VERSION)
+	podman push $(OUT_DOCKER):$(VERSION) $(OUT_DOCKER):$(VERSION)
 
 .PHONY: push-quay-container
 push-quay-container:
-	buildah manifest push --all $(OUT_DOCKER):$(VERSION) docker://quay.io/parca/parca:$(VERSION)
+	podman push $(OUT_DOCKER):$(VERSION) quay.io/parca/parca:$(VERSION)
 
 .PHONY: deploy/manifests
 deploy/manifests:

--- a/scripts/make-containers.sh
+++ b/scripts/make-containers.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set +x
+
+VERSION="$1"
+COMMIT="$2"
+MANIFEST="$3"
+ARCHS=('amd64' 'arm64' 'armv6' 'armv7' '386')
+
+# SHA order is respectively ('amd64' 'arm64' 'armv6' 'armv7' '386')
+# this image is what docker.io/golang:1.17.8-alpine3.15 on March 14 2021
+DOCKER_GOLANG_ALPINE_SHAS=(
+    'docker.io/golang@sha256:e2e68a9cdd5da82458652fdac3908a3a270686b38039f2829855398e2e06019d'
+    'docker.io/golang@sha256:a55e3394bce5523e660d9ee17adb827731ddd02559e75aabe3c5417778f8941e'
+    'docker.io/golang@sha256:3eb758fdfa1fa203d5503921d5bc18765c733add0cfbf98a3302e6a055cebaa1'
+    'docker.io/golang@sha256:96b13a554921ea4e4d4435244497708779e9047863c77fcc89892b4fd5ef4ac1'
+    'docker.io/golang@sha256:46a83fb9832e1aeed048139e4bc63bbfe039462ea12114dc2d1b2cd7574db7b2'
+)
+
+# SHA order is respectively ('amd64' 'arm64' 'armv6' 'armv7' '386')
+# this image is what node:17.7.1-alpine3.15 is on March 14 2021
+DOCKER_NODE_ALPINE_SHAS=(
+    'docker.io/library/node@sha256:10ef59da5b5ccdbaff99a81df1bcccb0500723633ce406efed6f1fb74adc8568'
+    'docker.io/library/node@sha256:8ca33e44fa0be3989b4dbced274f0fa17cc9ded52e3c0824725264b32bdf7c38'
+    'docker.io/library/node@sha256:9d674d6222f95556b5a4e2162cc09450928dec5979b99f208b6b0526c6c41e98'
+    'docker.io/library/node@sha256:6c8a221b76847a08a3789c2a18fa194e6a5825a7a1037f3d47396fbdf7cfeca7'
+    'docker.io/library/node@sha256:10ef59da5b5ccdbaff99a81df1bcccb0500723633ce406efed6f1fb74adc8568' # this is an amd64 image, unfortunately there is no 386 image for nodejs.
+)
+
+# SHA order is respectively ('amd64' 'arm64' 'armv6' 'armv7' '386')
+# this image is what docker.io/alpine:3.15.0 on March 14 2021
+DOCKER_ALPINE_SHAS=(
+    'docker.io/alpine@sha256:e7d88de73db3d3fd9b2d63aa7f447a10fd0220b7cbf39803c803f2af9ba256b3'
+    'docker.io/alpine@sha256:c74f1b1166784193ea6c8f9440263b9be6cae07dfe35e32a5df7a31358ac2060'
+    'docker.io/alpine@sha256:e047bc2af17934d38c5a7fa9f46d443f1de3a7675546402592ef805cfa929f9d'
+    'docker.io/alpine@sha256:8483ecd016885d8dba70426fda133c30466f661bb041490d525658f1aac73822'
+    'docker.io/alpine@sha256:2689e157117d2da668ad4699549e55eba1ceb79cb7862368b30919f0488213f4'
+)
+
+for i in "${!ARCHS[@]}"; do
+    ARCH=${ARCHS[$i]}
+    DOCKER_GOLANG_ALPINE_SHA=${DOCKER_GOLANG_ALPINE_SHAS[$i]}
+    DOCKER_NODE_ALPINE_SHA=${DOCKER_NODE_ALPINE_SHAS[$i]}
+    DOCKER_ALPINE_SHA=${DOCKER_ALPINE_SHAS[$i]}
+    echo "Building manifest for $MANIFEST with arch \"$ARCH\""
+    podman build \
+        --build-arg VERSION="$VERSION" \
+        --build-arg COMMIT="$COMMIT" \
+        --build-arg GOLANG_BUILDER_BASE="$DOCKER_GOLANG_ALPINE_SHA" \
+        --build-arg NODE_BUILDER_BASE="$DOCKER_NODE_ALPINE_SHA" \
+        --build-arg RUNNER_BASE="$DOCKER_ALPINE_SHA" \
+        --build-arg ARCH="$ARCH" \
+        --arch "$ARCH" \
+        --timestamp 0 \
+        --manifest "$MANIFEST" .; \
+done


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

- Use podman instead of buildah (podman is ubiquitously available across platforms)