### PR TITLE
pkg/parcaparquet: Store stacktrace UUIDs as []byte string

### DIFF
--- a/pkg/parcacol/parcacol.go
+++ b/pkg/parcacol/parcacol.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/google/uuid"
 	"github.com/polarsignals/arcticdb/dynparquet"
 	"github.com/prometheus/prometheus/model/labels"
 
@@ -97,10 +96,10 @@ func flatProfileToBuffer(logger log.Logger, ls labels.Labels, schema *dynparquet
 	return buf, nil
 }
 
-func extractLocationIDs(locs []*metastore.Location) []uuid.UUID {
-	res := make([]uuid.UUID, 0, len(locs))
+func extractLocationIDs(locs []*metastore.Location) []byte {
+	b := make([]byte, 0, len(locs)*16) // UUID are 16 bytes thus multiply by 16
 	for i := len(locs) - 1; i >= 0; i-- {
-		res = append(res, locs[i].ID)
+		b = append(b, locs[i].ID[:]...)
 	}
-	return res
+	return b
 }

--- a/pkg/parcaparquet/sample.go
+++ b/pkg/parcaparquet/sample.go
@@ -3,7 +3,6 @@ package parcaparquet
 import (
 	"sort"
 
-	"github.com/google/uuid"
 	"github.com/polarsignals/arcticdb/dynparquet"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/segmentio/parquet-go"
@@ -15,7 +14,7 @@ type Sample struct {
 	PeriodType string
 	PeriodUnit string
 	Labels     labels.Labels
-	Stacktrace []uuid.UUID
+	Stacktrace []byte
 	Timestamp  int64
 	Duration   int64
 	Period     int64
@@ -71,7 +70,7 @@ func (s Sample) ToParquetRow(row parquet.Row, labelNames []string) parquet.Row {
 	labelLen := len(s.Labels)
 
 	if row == nil {
-		row = make([]parquet.Value, 0, nameNumber+len(s.Stacktrace)+8)
+		row = make([]parquet.Value, 0, nameNumber+9)
 	}
 
 	row = append(row, parquet.ValueOf(s.Duration).Level(0, 0, 0))
@@ -100,13 +99,7 @@ func (s Sample) ToParquetRow(row parquet.Row, labelNames []string) parquet.Row {
 	row = append(row, parquet.ValueOf(s.PeriodUnit).Level(0, 0, nameNumber+3))
 	row = append(row, parquet.ValueOf(s.SampleType).Level(0, 0, nameNumber+4))
 	row = append(row, parquet.ValueOf(s.SampleUnit).Level(0, 0, nameNumber+5))
-	for i, location := range s.Stacktrace {
-		if i == 0 {
-			row = append(row, parquet.ValueOf(location).Level(0, 1, nameNumber+6))
-			continue
-		}
-		row = append(row, parquet.ValueOf(location).Level(1, 1, nameNumber+6))
-	}
+	row = append(row, parquet.ValueOf(s.Stacktrace).Level(0, 0, nameNumber+6))
 	row = append(row, parquet.ValueOf(s.Timestamp).Level(0, 0, nameNumber+7))
 	row = append(row, parquet.ValueOf(s.Value).Level(0, 0, nameNumber+8))
 

--- a/pkg/parcaparquet/schema.go
+++ b/pkg/parcaparquet/schema.go
@@ -5,58 +5,72 @@ import (
 	"github.com/segmentio/parquet-go"
 )
 
+const (
+	schemaName       = "parca"
+	columnSampleType = "sample_type"
+	columnSampleUnit = "sample_unit"
+	columnPeriodType = "period_type"
+	columnPeriodUnit = "period_unit"
+	columnLabels     = "labels"
+	columnStacktrace = "stacktrace"
+	columnTimestamp  = "timestamp"
+	columnDuration   = "duration"
+	columnPeriod     = "period"
+	columnValue      = "value"
+)
+
 func Schema() *dynparquet.Schema {
 	return dynparquet.NewSchema(
-		"parca",
+		schemaName,
 		[]dynparquet.ColumnDefinition{{
-			Name:          "sample_type",
+			Name:          columnSampleType,
 			StorageLayout: parquet.Encoded(parquet.String(), &parquet.RLEDictionary),
 			Dynamic:       false,
 		}, {
-			Name:          "sample_unit",
+			Name:          columnSampleUnit,
 			StorageLayout: parquet.Encoded(parquet.String(), &parquet.RLEDictionary),
 			Dynamic:       false,
 		}, {
-			Name:          "period_type",
+			Name:          columnPeriodType,
 			StorageLayout: parquet.Encoded(parquet.String(), &parquet.RLEDictionary),
 			Dynamic:       false,
 		}, {
-			Name:          "period_unit",
+			Name:          columnPeriodUnit,
 			StorageLayout: parquet.Encoded(parquet.String(), &parquet.RLEDictionary),
 			Dynamic:       false,
 		}, {
-			Name:          "labels",
+			Name:          columnLabels,
 			StorageLayout: parquet.Encoded(parquet.Optional(parquet.String()), &parquet.RLEDictionary),
 			Dynamic:       true,
 		}, {
-			Name:          "stacktrace",
-			StorageLayout: parquet.Encoded(parquet.Repeated(parquet.UUID()), &parquet.RLEDictionary),
+			Name:          columnStacktrace,
+			StorageLayout: parquet.Encoded(parquet.String(), &parquet.RLEDictionary),
 			Dynamic:       false,
 		}, {
-			Name:          "timestamp",
+			Name:          columnTimestamp,
 			StorageLayout: parquet.Int(64),
 			Dynamic:       false,
 		}, {
-			Name:          "duration",
+			Name:          columnDuration,
 			StorageLayout: parquet.Int(64),
 			Dynamic:       false,
 		}, {
-			Name:          "period",
+			Name:          columnPeriod,
 			StorageLayout: parquet.Int(64),
 			Dynamic:       false,
 		}, {
-			Name:          "value",
+			Name:          columnValue,
 			StorageLayout: parquet.Int(64),
 			Dynamic:       false,
 		}},
 		[]dynparquet.SortingColumn{
-			dynparquet.Ascending("sample_type"),
-			dynparquet.Ascending("sample_unit"),
-			dynparquet.Ascending("period_type"),
-			dynparquet.Ascending("period_unit"),
-			dynparquet.NullsFirst(dynparquet.Ascending("labels")),
-			dynparquet.NullsFirst(dynparquet.Ascending("stacktrace")),
-			dynparquet.Ascending("timestamp"),
+			dynparquet.Ascending(columnSampleType),
+			dynparquet.Ascending(columnSampleUnit),
+			dynparquet.Ascending(columnPeriodType),
+			dynparquet.Ascending(columnPeriodUnit),
+			dynparquet.NullsFirst(dynparquet.Ascending(columnLabels)),
+			dynparquet.NullsFirst(dynparquet.Ascending(columnStacktrace)),
+			dynparquet.Ascending(columnTimestamp),
 		},
 	)
 }

--- a/pkg/query/columnquery_test.go
+++ b/pkg/query/columnquery_test.go
@@ -10,11 +10,6 @@ import (
 	"github.com/apache/arrow/go/v7/arrow/memory"
 	"github.com/go-kit/log"
 	"github.com/google/pprof/profile"
-	pb "github.com/parca-dev/parca/gen/proto/go/parca/query/v1alpha1"
-	"github.com/parca-dev/parca/pkg/metastore"
-	"github.com/parca-dev/parca/pkg/parcacol"
-	"github.com/parca-dev/parca/pkg/parcaparquet"
-	parcaprofile "github.com/parca-dev/parca/pkg/profile"
 	columnstore "github.com/polarsignals/arcticdb"
 	"github.com/polarsignals/arcticdb/query"
 	"github.com/prometheus/client_golang/prometheus"
@@ -23,6 +18,12 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	pb "github.com/parca-dev/parca/gen/proto/go/parca/query/v1alpha1"
+	"github.com/parca-dev/parca/pkg/metastore"
+	"github.com/parca-dev/parca/pkg/parcacol"
+	"github.com/parca-dev/parca/pkg/parcaparquet"
+	parcaprofile "github.com/parca-dev/parca/pkg/profile"
 )
 
 func TestColumnQueryAPIQueryRange(t *testing.T) {


### PR DESCRIPTION
We therefore need to concatenate all UUIDs as 16-bytes and cast those []byte as string to be stored in our columnar store. For reading back we read the string as []byte and then split it every 16 byte and use as individual UUIDs.