### PR TITLE
ui: Time Picker relative time ranges need to be positive

### DIFF
--- a/ui/packages/shared/components/src/DateTimeRangePicker/DateTimeRangePickerPanel/RelativeDatePicker/index.tsx
+++ b/ui/packages/shared/components/src/DateTimeRangePicker/DateTimeRangePickerPanel/RelativeDatePicker/index.tsx
@@ -87,6 +87,7 @@ const RelativeDatePicker = ({range, onChange = () => null}: RelativeDatePickerPr
             type="number"
             className="w-16 mr-2 text-sm"
             value={value}
+            min={0}
             onChange={e => setValue(parseInt(e.target.value, 10))}
           />
           <Select


### PR DESCRIPTION
It's possible to end up in this state. We should prevent that.
![range-negative](https://user-images.githubusercontent.com/872251/160416996-15ee67ea-f188-472c-9f03-21e74bab863b.png)
