### PR TITLE
ui: Sort Targets by URL, make job name bigger

### DIFF
--- a/ui/packages/app/web/src/pages/targets.tsx
+++ b/ui/packages/app/web/src/pages/targets.tsx
@@ -1,5 +1,11 @@
-import React, {useState, useEffect} from 'react';
-import {TargetsRequest, TargetsResponse, ScrapeServiceClient, ServiceError} from '@parca/client';
+import React, {useEffect, useState} from 'react';
+import {
+  ScrapeServiceClient,
+  ServiceError,
+  Target,
+  TargetsRequest,
+  TargetsResponse,
+} from '@parca/client';
 import {EmptyState} from '@parca/components';
 import TargetsTable from '../components/Targets/TargetsTable';
 
@@ -71,10 +77,14 @@ const TargetsPage = (): JSX.Element => {
             <div className="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg">
               {targetNamespaces?.map(namespace => {
                 const name = Object.keys(namespace)[0];
-                const targets = namespace[name];
+                const targets = namespace[name].sort((a: Target.AsObject, b: Target.AsObject) => {
+                  return a.url.localeCompare(b.url);
+                });
                 return (
-                  <div key={name} className="p-2 border-b-2">
-                    <div>{name}</div>
+                  <div key={name} className="my-2 p-2 border-b-2">
+                    <div className="my-2">
+                      <span className="font-semibold text-xl">{name}</span>
+                    </div>
                     <TargetsTable targets={targets} />
                   </div>
                 );


### PR DESCRIPTION
The most important change in this PR is the fact that the targets for a job are now sorted by their URL. 
Sometimes, for debugging, I frequently reload the targets page, and not having the tables sorted makes it hard to follow what's going on.

Additionally, I've made the headline of each job bigger.

## Old
![old](https://user-images.githubusercontent.com/872251/160580083-18461dc5-6698-4b22-9f04-361320b6757d.png)
## New
![new](https://user-images.githubusercontent.com/872251/160580100-fcf009c7-608d-4d30-b168-4604280fbc77.png)

cc @monicawoj