### PR TITLE
pkg/parcacol: Add 2 columns for pprofLabel and pprofNumLabel

### DIFF
--- a/pkg/parca/parca_test.go
+++ b/pkg/parca/parca_test.go
@@ -25,20 +25,23 @@ import (
 	"testing"
 	"time"
 
+	"github.com/apache/arrow/go/v7/arrow"
 	"github.com/apache/arrow/go/v7/arrow/memory"
 	"github.com/cenkalti/backoff/v4"
 	"github.com/fatih/semgroup"
 	"github.com/go-kit/log"
 	"github.com/google/pprof/profile"
+	"github.com/polarsignals/arcticdb"
+	columnstore "github.com/polarsignals/arcticdb"
+	"github.com/polarsignals/arcticdb/query"
+	"github.com/polarsignals/arcticdb/query/logicalplan"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/model/labels"
-	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/protobuf/types/known/timestamppb"
 
 	pb "github.com/parca-dev/parca/gen/proto/go/parca/profilestore/v1alpha1"
 	querypb "github.com/parca-dev/parca/gen/proto/go/parca/query/v1alpha1"
@@ -46,9 +49,6 @@ import (
 	"github.com/parca-dev/parca/pkg/parcacol"
 	parcaprofile "github.com/parca-dev/parca/pkg/profile"
 	queryservice "github.com/parca-dev/parca/pkg/query"
-	"github.com/polarsignals/arcticdb"
-	columnstore "github.com/polarsignals/arcticdb"
-	"github.com/polarsignals/arcticdb/query"
 )
 
 func benchmarkSetup(ctx context.Context, b *testing.B) (pb.ProfileStoreServiceClient, <-chan struct{}) {
@@ -295,12 +295,6 @@ func TestConsistency(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	for _, s := range p1.Sample {
-		s.Label = nil
-		s.NumLabel = nil
-		s.NumUnit = nil
-	}
-
 	p1 = p1.Compact()
 
 	p, err := parcaprofile.FromPprof(ctx, logger, m, p1, 0, false)
@@ -311,30 +305,33 @@ func TestConsistency(t *testing.T) {
 
 	table.Sync()
 
-	api := queryservice.NewColumnQueryAPI(
-		logger,
-		tracer,
-		m,
-		query.NewEngine(
-			memory.DefaultAllocator,
-			colDB.TableProvider(),
-		),
-		"stacktraces",
+	q := query.NewEngine(
+		memory.DefaultAllocator,
+		colDB.TableProvider(),
 	)
 
-	ts := timestamppb.New(timestamp.Time(p1.TimeNanos / time.Millisecond.Nanoseconds()))
-	res, err := api.Query(ctx, &querypb.QueryRequest{
-		ReportType: querypb.QueryRequest_REPORT_TYPE_PPROF,
-		Options: &querypb.QueryRequest_Single{
-			Single: &querypb.SingleProfile{
-				Query: `{__name__="alloc_objects_count"}`,
-				Time:  ts,
-			},
-		},
-	})
+	var ar arrow.Record
+	err = q.ScanTable("stacktraces").
+		Filter(logicalplan.And(
+			logicalplan.Col("timestamp").Eq(logicalplan.Literal(p1.TimeNanos/time.Millisecond.Nanoseconds())),
+			logicalplan.Col("labels.__name__").Eq(logicalplan.Literal("alloc_objects_count")),
+		)).
+		Aggregate(
+			logicalplan.Sum(logicalplan.Col("value")),
+			logicalplan.Col("stacktrace"),
+		).
+		Execute(func(r arrow.Record) error {
+			r.Retain()
+			ar = r
+			return nil
+		})
+	require.NoError(t, err)
+	defer ar.Release()
+
+	st, err := parcacol.ArrowRecordToStacktraceSamples(ctx, m, ar, "sum(value)")
 	require.NoError(t, err)
 
-	resProf, err := profile.ParseData(res.Report.(*querypb.QueryResponse_Pprof).Pprof)
+	resProf, err := queryservice.GenerateFlatPprof(ctx, m, st)
 	require.NoError(t, err)
 
 	require.Equal(t, len(p1.Sample), len(resProf.Sample))

--- a/pkg/parcacol/parcacol_test.go
+++ b/pkg/parcacol/parcacol_test.go
@@ -1,0 +1,45 @@
+package parcacol
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+
+	"github.com/parca-dev/parca/pkg/metastore"
+)
+
+func TestFlatProfileToBuffer(t *testing.T) {
+	// Create a test sample without pprof labels.
+	s := Samples{{
+		SampleType:     "alloc_objects",
+		SampleUnit:     "count",
+		PeriodType:     "space",
+		PeriodUnit:     "bytes",
+		PprofLabels:    nil,
+		PprofNumLabels: nil,
+		Labels: labels.Labels{
+			{Name: "__name__", Value: "alloc_objects_count"},
+		},
+		Stacktrace: extractLocationIDs([]*metastore.Location{{ID: uuid.New()}}),
+		Timestamp:  1608199718549,
+		Duration:   0,
+		Period:     524288,
+		Value:      14044,
+	}}
+
+	buf, err := s.ToBuffer(Schema())
+	require.NoError(t, err)
+	require.Equal(t, map[string][]string{
+		columnLabels:         {"__name__"},
+		columnPprofLabels:    {},
+		columnPprofNumLabels: {},
+	}, buf.DynamicColumns())
+
+	// Add pprof labels to the test sample.
+	s[0].PprofNumLabels = labels.Labels{{Name: "bytes", Value: "32"}}
+
+	buf, err = s.ToBuffer(Schema())
+	require.NoError(t, err)
+}

--- a/pkg/parcacol/sample.go
+++ b/pkg/parcacol/sample.go
@@ -9,25 +9,31 @@ import (
 )
 
 type Sample struct {
-	SampleType string
-	SampleUnit string
-	PeriodType string
-	PeriodUnit string
-	Labels     labels.Labels
-	Stacktrace []byte
-	Timestamp  int64
-	Duration   int64
-	Period     int64
-	Value      int64
+	SampleType     string
+	SampleUnit     string
+	PeriodType     string
+	PeriodUnit     string
+	PprofLabels    labels.Labels
+	PprofNumLabels labels.Labels
+	Labels         labels.Labels
+	Stacktrace     []byte
+	Timestamp      int64
+	Duration       int64
+	Period         int64
+	Value          int64
 }
 
 type Samples []Sample
 
 func (s Samples) ToBuffer(schema *dynparquet.Schema) (*dynparquet.Buffer, error) {
 	names := s.SampleLabelNames()
+	pprofLabels := s.pprofLabelsNames()
+	pprofNumLabels := s.pprofNumLabelsNames()
 
 	pb, err := schema.NewBuffer(map[string][]string{
-		"labels": names,
+		columnLabels:         names,
+		columnPprofLabels:    pprofLabels,
+		columnPprofNumLabels: pprofNumLabels,
 	})
 	if err != nil {
 		return nil, err
@@ -35,7 +41,7 @@ func (s Samples) ToBuffer(schema *dynparquet.Schema) (*dynparquet.Buffer, error)
 
 	var r parquet.Row
 	for _, sample := range s {
-		r = sample.ToParquetRow(r[:0], names)
+		r = sample.ToParquetRow(r[:0], names, pprofLabels, pprofNumLabels)
 		err := pb.WriteRow(r)
 		if err != nil {
 			return nil, err
@@ -62,46 +68,136 @@ func (s Samples) SampleLabelNames() []string {
 	return names
 }
 
-func (s Sample) ToParquetRow(row parquet.Row, labelNames []string) parquet.Row {
+func (s Samples) pprofLabelsNames() []string {
+	names := []string{}
+	seen := map[string]struct{}{}
+
+	for _, sample := range s {
+		for _, label := range sample.PprofLabels {
+			if _, ok := seen[label.Name]; !ok {
+				names = append(names, label.Name)
+				seen[label.Name] = struct{}{}
+			}
+		}
+	}
+	sort.Strings(names)
+
+	return names
+}
+
+func (s Samples) pprofNumLabelsNames() []string {
+	names := []string{}
+	seen := map[string]struct{}{}
+
+	for _, sample := range s {
+		for _, label := range sample.PprofNumLabels {
+			if _, ok := seen[label.Name]; !ok {
+				names = append(names, label.Name)
+				seen[label.Name] = struct{}{}
+			}
+		}
+	}
+	sort.Strings(names)
+
+	return names
+}
+
+func (s Sample) ToParquetRow(row parquet.Row, labelNames, pprofLabelNames, pprofNumLabelNames []string) parquet.Row {
 	// The order of these appends is important. Parquet values must be in the
 	// order of the schema and the schema orders columns by their names.
-
-	nameNumber := len(labelNames)
-	labelLen := len(s.Labels)
+	labelNamesLen := len(labelNames)
+	pprofLabelsNamesLen := len(pprofLabelNames)
+	pprofNumLabelsNamesLen := len(pprofNumLabelNames)
+	dynamicNum := labelNamesLen + pprofLabelsNamesLen + pprofNumLabelsNamesLen
 
 	if row == nil {
-		row = make([]parquet.Value, 0, nameNumber+9)
+		row = make([]parquet.Value, 0, 9+dynamicNum)
 	}
 
 	row = append(row, parquet.ValueOf(s.Duration).Level(0, 0, 0))
 
+	// Labels
+
 	i, j := 0, 0
-	for i < nameNumber {
+	for i < labelNamesLen {
+		columnIndex := i + 1
+
 		if labelNames[i] == s.Labels[j].Name {
-			row = append(row, parquet.ValueOf(s.Labels[j].Value).Level(0, 1, i+1))
+			row = append(row, parquet.ValueOf(s.Labels[j].Value).Level(0, 1, columnIndex))
 			i++
 			j++
 
-			if j >= labelLen {
-				for ; i < nameNumber; i++ {
-					row = append(row, parquet.ValueOf(nil).Level(0, 0, i+1))
+			if j >= len(s.Labels) {
+				for ; i < labelNamesLen; i++ {
+					row = append(row, parquet.ValueOf(nil).Level(0, 0, columnIndex))
 				}
 				break
 			}
 		} else {
-			row = append(row, parquet.ValueOf(nil).Level(0, 0, i+1))
+			// If nothing matches we add a NULL to the column
+			row = append(row, parquet.ValueOf(nil).Level(0, 0, columnIndex))
 			i++
 		}
 	}
 
-	row = append(row, parquet.ValueOf(s.Period).Level(0, 0, nameNumber+1))
-	row = append(row, parquet.ValueOf(s.PeriodType).Level(0, 0, nameNumber+2))
-	row = append(row, parquet.ValueOf(s.PeriodUnit).Level(0, 0, nameNumber+3))
-	row = append(row, parquet.ValueOf(s.SampleType).Level(0, 0, nameNumber+4))
-	row = append(row, parquet.ValueOf(s.SampleUnit).Level(0, 0, nameNumber+5))
-	row = append(row, parquet.ValueOf(s.Stacktrace).Level(0, 0, nameNumber+6))
-	row = append(row, parquet.ValueOf(s.Timestamp).Level(0, 0, nameNumber+7))
-	row = append(row, parquet.ValueOf(s.Value).Level(0, 0, nameNumber+8))
+	// pprofLabels
+
+	i, j = 0, 0
+	for i < pprofLabelsNamesLen {
+		columnIndex := labelNamesLen + i + 1 // add the previous labelName column index on top
+
+		if pprofLabelNames[i] == s.PprofLabels[j].Name {
+			row = append(row, parquet.ValueOf(s.PprofLabels[j].Value).Level(0, 1, columnIndex))
+			i++
+			j++
+
+			if j >= len(s.PprofLabels) {
+				for ; i < pprofLabelsNamesLen; i++ {
+					row = append(row, parquet.ValueOf(nil).Level(0, 0, columnIndex))
+				}
+				break
+			}
+		} else {
+			// If nothing matches we add a NULL to the column
+			row = append(row, parquet.ValueOf(nil).Level(0, 0, columnIndex))
+			i++
+		}
+	}
+
+	// pprofNumLabels
+
+	i, j = 0, 0
+	for i < pprofNumLabelsNamesLen {
+		// add the previous labelNames and pprofLabelsNames column index on top
+		columnIndex := labelNamesLen + pprofLabelsNamesLen + i + 1
+
+		if pprofNumLabelNames[i] == s.PprofNumLabels[j].Name {
+			row = append(row, parquet.ValueOf(s.PprofNumLabels[j].Value).Level(0, 1, columnIndex))
+			i++
+			j++
+
+			if j >= len(s.PprofNumLabels) {
+				for ; i < pprofNumLabelsNamesLen; i++ {
+					row = append(row, parquet.ValueOf(nil).Level(0, 0, columnIndex))
+				}
+				break
+			}
+		} else {
+			// If nothing matches we add a NULL to the column
+			row = append(row, parquet.ValueOf(nil).Level(0, 0, columnIndex))
+			i++
+		}
+	}
+
+	// We add these columns at their index with the initial padding of the size of dynamic columns.
+	row = append(row, parquet.ValueOf(s.Period).Level(0, 0, dynamicNum+1))
+	row = append(row, parquet.ValueOf(s.PeriodType).Level(0, 0, dynamicNum+2))
+	row = append(row, parquet.ValueOf(s.PeriodUnit).Level(0, 0, dynamicNum+3))
+	row = append(row, parquet.ValueOf(s.SampleType).Level(0, 0, dynamicNum+4))
+	row = append(row, parquet.ValueOf(s.SampleUnit).Level(0, 0, dynamicNum+5))
+	row = append(row, parquet.ValueOf(s.Stacktrace).Level(0, 0, dynamicNum+6))
+	row = append(row, parquet.ValueOf(s.Timestamp).Level(0, 0, dynamicNum+7))
+	row = append(row, parquet.ValueOf(s.Value).Level(0, 0, dynamicNum+8))
 
 	return row
 }

--- a/pkg/parcacol/schema.go
+++ b/pkg/parcacol/schema.go
@@ -6,17 +6,19 @@ import (
 )
 
 const (
-	schemaName       = "parca"
-	columnSampleType = "sample_type"
-	columnSampleUnit = "sample_unit"
-	columnPeriodType = "period_type"
-	columnPeriodUnit = "period_unit"
-	columnLabels     = "labels"
-	columnStacktrace = "stacktrace"
-	columnTimestamp  = "timestamp"
-	columnDuration   = "duration"
-	columnPeriod     = "period"
-	columnValue      = "value"
+	schemaName           = "parca"
+	columnSampleType     = "sample_type"
+	columnSampleUnit     = "sample_unit"
+	columnPeriodType     = "period_type"
+	columnPeriodUnit     = "period_unit"
+	columnPprofLabels    = "pprof_labels"
+	columnPprofNumLabels = "pprof_num_labels"
+	columnLabels         = "labels"
+	columnStacktrace     = "stacktrace"
+	columnTimestamp      = "timestamp"
+	columnDuration       = "duration"
+	columnPeriod         = "period"
+	columnValue          = "value"
 )
 
 func Schema() *dynparquet.Schema {
@@ -38,6 +40,14 @@ func Schema() *dynparquet.Schema {
 			Name:          columnPeriodUnit,
 			StorageLayout: parquet.Encoded(parquet.String(), &parquet.RLEDictionary),
 			Dynamic:       false,
+		}, {
+			Name:          columnPprofLabels,
+			StorageLayout: parquet.Encoded(parquet.Optional(parquet.String()), &parquet.RLEDictionary),
+			Dynamic:       true,
+		}, {
+			Name:          columnPprofNumLabels,
+			StorageLayout: parquet.Encoded(parquet.Optional(parquet.String()), &parquet.RLEDictionary),
+			Dynamic:       true,
 		}, {
 			Name:          columnLabels,
 			StorageLayout: parquet.Encoded(parquet.Optional(parquet.String()), &parquet.RLEDictionary),
@@ -68,6 +78,8 @@ func Schema() *dynparquet.Schema {
 			dynparquet.Ascending(columnSampleUnit),
 			dynparquet.Ascending(columnPeriodType),
 			dynparquet.Ascending(columnPeriodUnit),
+			dynparquet.NullsFirst(dynparquet.Ascending(columnPprofLabels)),
+			dynparquet.NullsFirst(dynparquet.Ascending(columnPprofNumLabels)),
 			dynparquet.NullsFirst(dynparquet.Ascending(columnLabels)),
 			dynparquet.NullsFirst(dynparquet.Ascending(columnStacktrace)),
 			dynparquet.Ascending(columnTimestamp),


### PR DESCRIPTION
I've add two new columns for pprof labels.
The `TestConsistency` test works until the point where each row needs to be written and afaik panics trying to read values from a non existing dictionary: 
https://github.com/segmentio/parquet-go/blob/672347989f74307da3611cc2c2716c279704e946/dictionary.go#L103

