### PR TITLE
ui: Add rounded MatcherInput labels

### DIFF
--- a/ui/packages/shared/components/src/MatchersInput/index.tsx
+++ b/ui/packages/shared/components/src/MatchersInput/index.tsx
@@ -469,7 +469,7 @@ const MatchersInput = ({
         <ul className="flex space-x-2">
           {currentLabelsCollection &&
             currentLabelsCollection.map((value, i) => (
-              <li key={i} className="bg-indigo-600 w-fit py-1 px-2 text-gray-100 dark-gray-900">
+              <li key={i} className="bg-indigo-600 w-fit py-1 px-2 text-gray-100 dark-gray-900 rounded-md">
                 {value}
               </li>
             ))}


### PR DESCRIPTION
I'm not sure if these matcher input labels are so squared on purpose, but they somehow don't fit the rest of the UI all being rounded. 

The left one is how it currently looks and the right is my change. 
![matchers](https://user-images.githubusercontent.com/872251/160804656-724e5564-0f59-4eb8-a9c7-4dc97231232d.png)

