### PR TITLE
pkg/query: Add stripEmptyNodes helper for flamegraphs

### DIFF
--- a/pkg/query/query_test.go
+++ b/pkg/query/query_test.go
@@ -720,3 +720,33 @@ func Test_QueryRange_MultipleLabels_NoMatch(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 0, len(resp.GetSeries()))
 }
+
+func Test_stripEmptyNodes(t *testing.T) {
+	original := &pb.Flamegraph{
+		Root: &pb.FlamegraphRootNode{
+			Cumulative: 7,
+			Children: []*pb.FlamegraphNode{
+				{Cumulative: 0},
+				{Cumulative: 1},
+				{Cumulative: 0},
+				{Cumulative: 2},
+				{Cumulative: 0},
+				{Cumulative: 4},
+				{Cumulative: 0},
+				{Cumulative: 0},
+			},
+		},
+	}
+	expected := &pb.Flamegraph{
+		Root: &pb.FlamegraphRootNode{
+			Cumulative: 7,
+			Children: []*pb.FlamegraphNode{
+				{Cumulative: 1},
+				{Cumulative: 2},
+				{Cumulative: 4},
+			},
+		},
+	}
+
+	require.Equal(t, expected, stripEmptyNodes(original))
+}


### PR DESCRIPTION
This should get rid of all empty (meaning the cumulative value is zero) such that we don't even send metadata along for those nodes.
