### PR TITLE
pkg/query: Aggregate by dynamic pprof label columns for consistency

### DIFF
--- a/pkg/query/columnquery.go
+++ b/pkg/query/columnquery.go
@@ -420,6 +420,8 @@ func (q *ColumnQueryAPI) findSingle(ctx context.Context, sel []*labels.Matcher, 
 		Aggregate(
 			logicalplan.Sum(logicalplan.Col("value")),
 			logicalplan.Col("stacktrace"),
+			logicalplan.DynCol("pprof_labels"),
+			logicalplan.DynCol("pprof_num_labels"),
 		).
 		Execute(func(r arrow.Record) error {
 			r.Retain()


### PR DESCRIPTION
This finally fixes the `TestConsistency`. As the pprof labels might differ for the same stack trace we need to aggregate by those pprof label columns too, to get a consistent and feature-parity pprof profile back.