### PR TITLE
Remove k8s namespace duplicate

### DIFF
--- a/deploy/main.jsonnet
+++ b/deploy/main.jsonnet
@@ -22,7 +22,6 @@ function(version='v0.0.3-alpha.2')
   });
 
   {
-    'parca-agent-namespace': ns,
     'parca-server-namespace': ns,
   } + {
     ['parca-server-' + name]: parca[name]

--- a/deploy/openshift.jsonnet
+++ b/deploy/openshift.jsonnet
@@ -23,7 +23,6 @@ function(version='v0.0.3-alpha.2')
   });
 
   {
-    'parca-agent-namespace': ns,
     'parca-server-namespace': ns,
   } + {
     ['parca-server-' + name]: parca[name]


### PR DESCRIPTION
It removes k8s namespace duplicates as advised in #871.

```sh
$ go install -a github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@latest
$ go install github.com/brancz/gojsontoyaml@latest
$ cd ./deploy/
$ make manifests
```

<details>
<summary>kubernetes</summary>

```yaml
apiVersion: v1
data:
  parca.yaml: |-
    "debug_info":
      "bucket":
        "config":
          "directory": "./tmp"
        "type": "FILESYSTEM"
      "cache":
        "config":
          "directory": "./tmp"
        "type": "FILESYSTEM"
kind: ConfigMap
metadata:
  name: parca-config
  namespace: parca
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app.kubernetes.io/component: observability
    app.kubernetes.io/instance: parca
    app.kubernetes.io/name: parca
    app.kubernetes.io/version: ns-dupl-8f3de8f9
  name: parca
  namespace: parca
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/component: observability
      app.kubernetes.io/instance: parca
      app.kubernetes.io/name: parca
  template:
    metadata:
      labels:
        app.kubernetes.io/component: observability
        app.kubernetes.io/instance: parca
        app.kubernetes.io/name: parca
        app.kubernetes.io/version: ns-dupl-8f3de8f9
    spec:
      containers:
      - args:
        - /parca
        - --config-path=/var/parca/parca.yaml
        - --log-level=info
        - --cors-allowed-origins=*
        - --debug-infod-upstream-servers=https://debuginfod.systemtap.org
        - --debug-infod-http-request-timeout=5m
        image: ghcr.io/parca-dev/parca:ns-dupl-8f3de8f9
        livenessProbe:
          exec:
            command:
            - /grpc-health-probe
            - -v
            - -addr=:7070
          initialDelaySeconds: 5
        name: parca
        ports:
        - containerPort: 7070
          name: http
        readinessProbe:
          exec:
            command:
            - /grpc-health-probe
            - -v
            - -addr=:7070
          initialDelaySeconds: 10
        resources: {}
        terminationMessagePolicy: FallbackToLogsOnError
        volumeMounts:
        - mountPath: /var/parca
          name: parca-config
      nodeSelector:
        kubernetes.io/os: linux
      securityContext:
        fsGroup: 65534
        runAsUser: 65534
      serviceAccountName: parca
      terminationGracePeriodSeconds: 120
      volumes:
      - configMap:
          name: parca-config
        name: parca-config
apiVersion: v1
kind: Namespace
metadata:
  labels:
    pod-security.kubernetes.io/audit: privileged
    pod-security.kubernetes.io/enforce: privileged
    pod-security.kubernetes.io/warn: privileged
  name: parca
apiVersion: policy/v1beta1
kind: PodSecurityPolicy
metadata:
  name: parca
spec:
  allowPrivilegeEscalation: false
  fsGroup:
    ranges:
    - max: 65535
      min: 1
    rule: MustRunAs
  requiredDropCapabilities:
  - ALL
  runAsUser:
    rule: MustRunAsNonRoot
  seLinux:
    rule: RunAsAny
  supplementalGroups:
    ranges:
    - max: 65535
      min: 1
    rule: MustRunAs
  volumes:
  - configMap
  - emptyDir
  - projected
  - secret
  - downwardAPI
  - persistentVolumeClaim
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  labels:
    app.kubernetes.io/component: observability
    app.kubernetes.io/instance: parca
    app.kubernetes.io/name: parca
    app.kubernetes.io/version: ns-dupl-8f3de8f9
  name: parca
  namespace: parca
rules:
- apiGroups:
  - policy
  resourceNames:
  - parca
  resources:
  - podsecuritypolicies
  verbs:
  - use
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  labels:
    app.kubernetes.io/component: observability
    app.kubernetes.io/instance: parca
    app.kubernetes.io/name: parca
    app.kubernetes.io/version: ns-dupl-8f3de8f9
  name: parca
  namespace: parca
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: parca
subjects:
- kind: ServiceAccount
  name: parca
apiVersion: v1
kind: Service
metadata:
  labels:
    app.kubernetes.io/component: observability
    app.kubernetes.io/instance: parca
    app.kubernetes.io/name: parca
    app.kubernetes.io/version: ns-dupl-8f3de8f9
  name: parca
  namespace: parca
spec:
  ports:
  - name: http
    port: 7070
    targetPort: 7070
  selector:
    app.kubernetes.io/component: observability
    app.kubernetes.io/instance: parca
    app.kubernetes.io/name: parca
apiVersion: v1
kind: ServiceAccount
metadata:
  labels:
    app.kubernetes.io/component: observability
    app.kubernetes.io/instance: parca
    app.kubernetes.io/name: parca
    app.kubernetes.io/version: ns-dupl-8f3de8f9
  name: parca
  namespace: parca
```
</details>

<details>
<summary>openshift</summary>

```yaml
apiVersion: v1
data:
  parca.yaml: |-
    "debug_info":
      "bucket":
        "config":
          "directory": "./tmp"
        "type": "FILESYSTEM"
      "cache":
        "config":
          "directory": "./tmp"
        "type": "FILESYSTEM"
kind: ConfigMap
metadata:
  name: parca-config
  namespace: parca
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app.kubernetes.io/component: observability
    app.kubernetes.io/instance: parca
    app.kubernetes.io/name: parca
    app.kubernetes.io/version: ns-dupl-8f3de8f9
  name: parca
  namespace: parca
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/component: observability
      app.kubernetes.io/instance: parca
      app.kubernetes.io/name: parca
  template:
    metadata:
      labels:
        app.kubernetes.io/component: observability
        app.kubernetes.io/instance: parca
        app.kubernetes.io/name: parca
        app.kubernetes.io/version: ns-dupl-8f3de8f9
    spec:
      containers:
      - args:
        - /parca
        - --config-path=/var/parca/parca.yaml
        - --log-level=info
        - --cors-allowed-origins=*
        - --debug-infod-upstream-servers=https://debuginfod.systemtap.org
        - --debug-infod-http-request-timeout=5m
        image: ghcr.io/parca-dev/parca:ns-dupl-8f3de8f9
        livenessProbe:
          exec:
            command:
            - /grpc-health-probe
            - -v
            - -addr=:7070
          initialDelaySeconds: 5
        name: parca
        ports:
        - containerPort: 7070
          name: http
        readinessProbe:
          exec:
            command:
            - /grpc-health-probe
            - -v
            - -addr=:7070
          initialDelaySeconds: 10
        resources: {}
        terminationMessagePolicy: FallbackToLogsOnError
        volumeMounts:
        - mountPath: /var/parca
          name: parca-config
      nodeSelector:
        kubernetes.io/os: linux
      securityContext: null
      serviceAccountName: parca
      terminationGracePeriodSeconds: 120
      volumes:
      - configMap:
          name: parca-config
        name: parca-config
apiVersion: v1
kind: Namespace
metadata:
  labels:
    pod-security.kubernetes.io/audit: privileged
    pod-security.kubernetes.io/enforce: privileged
    pod-security.kubernetes.io/warn: privileged
  name: parca
apiVersion: policy/v1beta1
kind: PodSecurityPolicy
metadata:
  name: parca
spec:
  allowPrivilegeEscalation: false
  fsGroup:
    ranges:
    - max: 65535
      min: 1
    rule: MustRunAs
  requiredDropCapabilities:
  - ALL
  runAsUser:
    rule: MustRunAsNonRoot
  seLinux:
    rule: RunAsAny
  supplementalGroups:
    ranges:
    - max: 65535
      min: 1
    rule: MustRunAs
  volumes:
  - configMap
  - emptyDir
  - projected
  - secret
  - downwardAPI
  - persistentVolumeClaim
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  labels:
    app.kubernetes.io/component: observability
    app.kubernetes.io/instance: parca
    app.kubernetes.io/name: parca
    app.kubernetes.io/version: ns-dupl-8f3de8f9
  name: parca
  namespace: parca
rules:
- apiGroups:
  - policy
  resourceNames:
  - parca
  resources:
  - podsecuritypolicies
  verbs:
  - use
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  labels:
    app.kubernetes.io/component: observability
    app.kubernetes.io/instance: parca
    app.kubernetes.io/name: parca
    app.kubernetes.io/version: ns-dupl-8f3de8f9
  name: parca
  namespace: parca
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: parca
subjects:
- kind: ServiceAccount
  name: parca
apiVersion: v1
kind: Service
metadata:
  labels:
    app.kubernetes.io/component: observability
    app.kubernetes.io/instance: parca
    app.kubernetes.io/name: parca
    app.kubernetes.io/version: ns-dupl-8f3de8f9
  name: parca
  namespace: parca
spec:
  ports:
  - name: http
    port: 7070
    targetPort: 7070
  selector:
    app.kubernetes.io/component: observability
    app.kubernetes.io/instance: parca
    app.kubernetes.io/name: parca
apiVersion: v1
kind: ServiceAccount
metadata:
  labels:
    app.kubernetes.io/component: observability
    app.kubernetes.io/instance: parca
    app.kubernetes.io/name: parca
    app.kubernetes.io/version: ns-dupl-8f3de8f9
  name: parca
  namespace: parca
```

</details>