### PR TITLE
env.sh: add support for arm64

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -1,14 +1,21 @@
 #! /usr/bin/env bash
 set -euo pipefail
 
-curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
-chmod +x ./minikube-linux-amd64
-sudo mv minikube-linux-amd64 /usr/local/bin/minikube
+ARCH_UNAME=$(uname -m)
+if [ "$ARCH_UNAME" = "x86_64" ]; then
+        ARCH=amd64
+else
+        ARCH=arm64
+fi
+
+curl -LO "https://storage.googleapis.com/minikube/releases/latest/minikube-linux-$ARCH"
+chmod +x "./minikube-linux-$ARCH"
+sudo mv "minikube-linux-$ARCH" /usr/local/bin/minikube
 
 curl -fsSL https://raw.githubusercontent.com/tilt-dev/tilt/master/scripts/install.sh | bash
 
-CTLPTL_VERSION="0.5.0"
-curl -fsSL https://github.com/tilt-dev/ctlptl/releases/download/v$CTLPTL_VERSION/ctlptl.$CTLPTL_VERSION.linux.x86_64.tar.gz | sudo tar -xzv -C /usr/local/bin ctlptl
+CTLPTL_VERSION="0.5.1"
+curl -fsSL "https://github.com/tilt-dev/ctlptl/releases/download/v$CTLPTL_VERSION/ctlptl.$CTLPTL_VERSION.linux.$ARCH.tar.gz" | sudo tar -xzv -C /usr/local/bin ctlptl
 
 go install github.com/campoy/embedmd@latest
 


### PR DESCRIPTION
Currently we download the x86 binaries even on arm, let's fetch
the `tilt` + `minikube` binaries for the matching architecture

Had to bump `ctlptl` to 0.5.1 as they started generating the arm64
builds starting that version. Changes between [v0.5.0-v0.5.1](https://github.com/tilt-dev/ctlptl/compare/v0.5.0...v0.5.1)

**Test plan**:
```shell
$ ./env.sh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
 35 68.2M   35 24.4M    0     0  6040k      0  0:00:11  0:00:04  0:00:07 6039k^C
[vagrant@bazinga parca]$ ./env.sh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 68.2M  100 68.2M    0     0  6127k      0  0:00:11  0:00:11 --:--:-- 6057k
+ tar -xzv tilt
+ curl -fsSL https://github.com/tilt-dev/tilt/releases/download/v0.27.0/tilt.0.27.0.linux.arm64.tar.gz
tilt
+ copy_binary
+ [[ :/home/vagrant/.local/bin:/home/vagrant/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/usr/local/go/bin:/bin:/usr/local/go/bin:/home/vagrant/go/bin: == *\:\/\h\o\m\e\/\v\a\g\r\a\n\t\/\.\l\o\c\a\l\/\b\i\n\:* ]]
+ '[' '!' -d /home/vagrant/.local/bin ']'
+ mv tilt /home/vagrant/.local/bin/tilt
+ set +x
Tilt installed!
For the latest Tilt news, subscribe: https://tilt.dev/subscribe
Run `tilt up` to start.
ctlptl
$ echo $?
0
```