### PR TITLE
demangler: add tests for the Cpp and Rust demanglers

### DIFF
--- a/pkg/symbol/demangle/demangle.go
+++ b/pkg/symbol/demangle/demangle.go
@@ -47,8 +47,8 @@ func NewDemangler(mode string, force bool) *Demangler {
 	}
 }
 
-// Demangle updates the function names in a profile with demangled C++
-// names, simplified according to demanglerMode. If force is set,
+// Demangle updates the function names in a profile demangling C++ and
+// Rust names, simplified according to demanglerMode. If force is set,
 // overwrite any names that appear already demangled.
 // A modified version of pprof demangler.
 func (d *Demangler) Demangle(fn *pb.Function) *pb.Function {

--- a/pkg/symbol/demangle/demangle_test.go
+++ b/pkg/symbol/demangle/demangle_test.go
@@ -1,0 +1,99 @@
+// Copyright 2021 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package demangle
+
+import (
+	"testing"
+
+	pb "github.com/parca-dev/parca/gen/proto/go/parca/metastore/v1alpha1"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Basic demangler tests to make sure that demangling is not completely
+// broken for C++ or Rust.
+
+func TestDemanglerAlreadyDemangled(t *testing.T) {
+	demangler := NewDemangler("simple", true)
+
+	function := pb.Function{
+		SystemName: "main",
+	}
+	expected_function := pb.Function{
+		Name:       "main",
+		SystemName: "main",
+	}
+
+	demangled := demangler.Demangle(&function)
+	require.Equal(t, &expected_function, demangled)
+}
+
+func TestDemanglerSimpleCppDemangling(t *testing.T) {
+	demangler := NewDemangler("simple", true)
+
+	function := pb.Function{
+		SystemName: "_ZNSaIcEC1ERKS_",
+	}
+	expected_function := pb.Function{
+		Name:       "std::allocator::allocator",
+		SystemName: "_ZNSaIcEC1ERKS_",
+	}
+
+	demangled := demangler.Demangle(&function)
+	require.Equal(t, &expected_function, demangled)
+}
+
+func TestDemangleNone(t *testing.T) {
+	demangler := NewDemangler("none", true)
+
+	function := pb.Function{
+		SystemName: "_ZNSaIcEC1ERKS_",
+	}
+	expected_function := pb.Function{
+		SystemName: "_ZNSaIcEC1ERKS_",
+	}
+
+	demangled := demangler.Demangle(&function)
+	require.Equal(t, &expected_function, demangled)
+}
+
+func TestDemanglerTemplatesCppDemangling(t *testing.T) {
+	demangler := NewDemangler("templates", true)
+
+	function := pb.Function{
+		SystemName: "_ZNSaIcEC1ERKS_",
+	}
+	expected_function := pb.Function{
+		Name:       "std::allocator<char>::allocator",
+		SystemName: "_ZNSaIcEC1ERKS_",
+	}
+
+	demangled := demangler.Demangle(&function)
+	require.Equal(t, &expected_function, demangled)
+}
+
+func TestDemanglerSimpleRustDemangling(t *testing.T) {
+	demangler := NewDemangler("simple", true)
+
+	function := pb.Function{
+		SystemName: "_ZN11collections5slice29_$LT$impl$u20$$u5b$T$u5d$$GT$10as_mut_ptr17hf12a6d0409938c96E",
+	}
+	expected_function := pb.Function{
+		Name:       "collections::slice::<impl [T]>::as_mut_ptr",
+		SystemName: "_ZN11collections5slice29_$LT$impl$u20$$u5b$T$u5d$$GT$10as_mut_ptr17hf12a6d0409938c96E",
+	}
+
+	demangled := demangler.Demangle(&function)
+	require.Equal(t, &expected_function, demangled)
+}


### PR DESCRIPTION
Saw that @kakkoyun opened an issue to add Rust demangling support
(https://github.com/parca-dev/parca/issues/612) and was going to add another
library or implement it myself, but noticed that [the library we are currently
using for C++ demangling](https://github.com/ianlancetaylor/demangle) already supports the Rust mangling scheme!

Happy days!

This PR updates the comment in `demangle.go` and adds some unit tests for the
demangler to make sure we don't regress on basic functionality and set ups
the file for further testcases once we expand the languages we support.

Have decided to create independent test cases as I think it's more readable and
easier to understand, but happy to change it if you would rather use parametric
tests.

Please, let me know if you have any feedback!

Note: Something we probably want to bear in mind is that Rust's default mangling
scheme will change in the future: https://github.com/rust-lang/rust/issues/60705

**Test plan**

```
$ go test github.com/parca-dev/parca/pkg/symbol/demangle
ok      github.com/parca-dev/parca/pkg/symbol/demangle  0.004s
```