### PR TITLE
WIP run multiple podman jobs in parallel

### DIFF
--- a/scripts/make-containers.sh
+++ b/scripts/make-containers.sh
@@ -5,6 +5,7 @@ VERSION="$1"
 COMMIT="$2"
 MANIFEST="$3"
 ARCHS=('amd64' 'arm64' 'armv6' 'armv7' '386')
+NPROC=$(nproc --all)
 
 # SHA order is respectively ('amd64' 'arm64' 'armv6' 'armv7' '386')
 # this image is what docker.io/golang:1.17.8-alpine3.15 on March 14 2021
@@ -51,5 +52,6 @@ for i in "${!ARCHS[@]}"; do
         --build-arg ARCH="$ARCH" \
         --arch "$ARCH" \
         --timestamp 0 \
+        --jobs "$NPROC" \
         --manifest "$MANIFEST" .; \
 done


### PR DESCRIPTION
**WIP WIP WIP** moving from draft state so all the checks run

The last builds are taking a very long time (>35'). Let's see if this helps.

Running all the `podman build` concurrently might be even better, but unsure if this is valid as there might be some shared state