### PR TITLE
pkg/profilestore: Encode debug log paths

### DIFF
--- a/pkg/profilestore/profilecolumnstore.go
+++ b/pkg/profilestore/profilecolumnstore.go
@@ -16,6 +16,7 @@ package profilestore
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -97,7 +98,7 @@ func (s *ProfileColumnStore) WriteRaw(ctx context.Context, r *profilestorepb.Wri
 			}
 
 			if s.debugValueLog {
-				dir := fmt.Sprintf("tmp/%s", ls.String())
+				dir := fmt.Sprintf("tmp/%s", base64.StdEncoding.EncodeToString([]byte(ls.String())))
 				err := os.MkdirAll(dir, os.ModePerm)
 				if err != nil {
 					level.Error(s.logger).Log("msg", "failed to create debug-value-log directory", "err", err)


### PR DESCRIPTION
Labelsets can contain `/` so we need to encode the directory names
appropriately.