### PR TITLE
Run `podman build` with as many workers as CPUs

### DIFF
--- a/scripts/make-containers.sh
+++ b/scripts/make-containers.sh
@@ -5,6 +5,7 @@ VERSION="$1"
 COMMIT="$2"
 MANIFEST="$3"
 ARCHS=('amd64' 'arm64' 'armv6' 'armv7' '386')
+NPROC=$(nproc --all)
 
 # SHA order is respectively ('amd64' 'arm64' 'armv6' 'armv7' '386')
 # this image is what docker.io/golang:1.17.8-alpine3.15 on March 14 2021
@@ -51,5 +52,6 @@ for i in "${!ARCHS[@]}"; do
         --build-arg ARCH="$ARCH" \
         --arch "$ARCH" \
         --timestamp 0 \
+        --jobs "$NPROC" \
         --manifest "$MANIFEST" .; \
 done


### PR DESCRIPTION
To try to make the build a bit faster. Right now it's taking ~45 minutes.

Ideally we would run builds in parallel, too but it seems like support
for this was recently merged (https://github.com/containers/podman/pull/13404), so let's
wait a bit for it to be stable and then we can add it as well if.