### PR TITLE
pkg/query: Fix diffing for distinct stacktraces

### DIFF
--- a/pkg/query/columnquery.go
+++ b/pkg/query/columnquery.go
@@ -524,16 +524,26 @@ func (q *ColumnQueryAPI) diffRequest(ctx context.Context, d *pb.DiffProfile, rep
 
 	// TODO: This is cheating a bit. This should be done with a sub-query in the columnstore.
 	diff := &profile.StacktraceSamples{}
-	stacktraceIndices := map[string]int{}
-	for i, s := range base.Samples {
-		stacktraceIndices[string(profile.MakeStacktraceKey(s))] = i
+
+	for i := range compare.Samples {
+		diff.Samples = append(diff.Samples, &profile.Sample{
+			Location:  compare.Samples[i].Location,
+			Value:     compare.Samples[i].Value,
+			DiffValue: compare.Samples[i].Value,
+			Label:     compare.Samples[i].Label,
+			NumLabel:  compare.Samples[i].NumLabel,
+			NumUnit:   compare.Samples[i].NumUnit,
+		})
 	}
 
-	for _, s := range compare.Samples {
-		if i, ok := stacktraceIndices[string(profile.MakeStacktraceKey(s))]; ok {
-			s.DiffValue = s.Value - base.Samples[i].Value
-		}
-		diff.Samples = append(diff.Samples, s)
+	for i := range base.Samples {
+		diff.Samples = append(diff.Samples, &profile.Sample{
+			Location:  base.Samples[i].Location,
+			DiffValue: -base.Samples[i].Value,
+			Label:     base.Samples[i].Label,
+			NumLabel:  base.Samples[i].NumLabel,
+			NumUnit:   base.Samples[i].NumUnit,
+		})
 	}
 
 	return q.renderReport(ctx, diff, reportType)

--- a/pkg/query/columnquery_test.go
+++ b/pkg/query/columnquery_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/apache/arrow/go/v8/arrow/memory"
 	"github.com/go-kit/log"
 	"github.com/google/pprof/profile"
+	"github.com/google/uuid"
 	columnstore "github.com/polarsignals/arcticdb"
 	"github.com/polarsignals/arcticdb/query"
 	"github.com/prometheus/client_golang/prometheus"
@@ -32,6 +33,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	metastorepb "github.com/parca-dev/parca/gen/proto/go/parca/metastore/v1alpha1"
 	pb "github.com/parca-dev/parca/gen/proto/go/parca/query/v1alpha1"
 	"github.com/parca-dev/parca/pkg/metastore"
 	"github.com/parca-dev/parca/pkg/parcacol"
@@ -179,6 +181,213 @@ func TestColumnQueryAPIQuery(t *testing.T) {
 
 	_, err = profile.ParseData(res.Report.(*pb.QueryResponse_Pprof).Pprof)
 	require.NoError(t, err)
+}
+
+func TestColumnQueryAPIQueryDiff(t *testing.T) {
+	ctx := context.Background()
+	logger := log.NewNopLogger()
+	reg := prometheus.NewRegistry()
+	tracer := trace.NewNoopTracerProvider().Tracer("")
+	col := columnstore.New(reg)
+	colDB := col.DB("parca")
+	table, err := colDB.Table(
+		"stacktraces",
+		columnstore.NewTableConfig(
+			parcacol.Schema(),
+			8196,
+			64*1024*1024,
+		),
+		logger,
+	)
+	require.NoError(t, err)
+	m := metastore.NewBadgerMetastore(
+		logger,
+		reg,
+		tracer,
+		metastore.NewRandomUUIDGenerator(),
+	)
+	t.Cleanup(func() {
+		m.Close()
+	})
+
+	f1 := &metastorepb.Function{
+		Name: "testFunc",
+	}
+	f1.Id, err = m.CreateFunction(ctx, f1)
+	require.NoError(t, err)
+
+	f2 := &metastorepb.Function{
+		Name: "testFunc",
+	}
+	f2.Id, err = m.CreateFunction(ctx, f2)
+	require.NoError(t, err)
+
+	loc1 := &metastore.Location{
+		Address: 0x1,
+		Lines: []metastore.LocationLine{{
+			Line:     1,
+			Function: f1,
+		}},
+	}
+	loc2 := &metastore.Location{
+		Address: 0x2,
+		Lines: []metastore.LocationLine{{
+			Line:     2,
+			Function: f2,
+		}},
+	}
+
+	id1, err := m.CreateLocation(ctx, loc1)
+	require.NoError(t, err)
+	loc1.ID, err = uuid.FromBytes(id1)
+	require.NoError(t, err)
+
+	id2, err := m.CreateLocation(ctx, loc2)
+	require.NoError(t, err)
+	loc2.ID, err = uuid.FromBytes(id2)
+	require.NoError(t, err)
+
+	_, err = parcacol.InsertProfileIntoTable(ctx, logger, table, labels.Labels{{
+		Name:  "job",
+		Value: "default",
+	}}, &parcaprofile.Profile{
+		Meta: parcaprofile.InstantProfileMeta{
+			Timestamp: 1,
+		},
+		FlatSamples: map[string]*parcaprofile.Sample{
+			"a": {
+				Location: []*metastore.Location{loc1},
+				Value:    1,
+			},
+		},
+	})
+	require.NoError(t, err)
+	_, err = parcacol.InsertProfileIntoTable(ctx, logger, table, labels.Labels{{
+		Name:  "job",
+		Value: "default",
+	}}, &parcaprofile.Profile{
+		Meta: parcaprofile.InstantProfileMeta{
+			Timestamp: 2,
+		},
+		FlatSamples: map[string]*parcaprofile.Sample{
+			"b": {
+				Location: []*metastore.Location{loc2},
+				Value:    2,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	api := NewColumnQueryAPI(
+		logger,
+		tracer,
+		m,
+		query.NewEngine(
+			memory.DefaultAllocator,
+			colDB.TableProvider(),
+		),
+		"stacktraces",
+	)
+
+	res, err := api.Query(ctx, &pb.QueryRequest{
+		Mode: pb.QueryRequest_MODE_DIFF,
+		Options: &pb.QueryRequest_Diff{
+			Diff: &pb.DiffProfile{
+				A: &pb.ProfileDiffSelection{
+					Mode: pb.ProfileDiffSelection_MODE_SINGLE_UNSPECIFIED,
+					Options: &pb.ProfileDiffSelection_Single{
+						Single: &pb.SingleProfile{
+							Query: `{job="default"}`,
+							Time:  timestamppb.New(timestamp.Time(1)),
+						},
+					},
+				},
+				B: &pb.ProfileDiffSelection{
+					Mode: pb.ProfileDiffSelection_MODE_SINGLE_UNSPECIFIED,
+					Options: &pb.ProfileDiffSelection_Single{
+						Single: &pb.SingleProfile{
+							Query: `{job="default"}`,
+							Time:  timestamppb.New(timestamp.Time(2)),
+						},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	fg := res.Report.(*pb.QueryResponse_Flamegraph).Flamegraph
+	require.Equal(t, int32(2), fg.Height)
+	require.Equal(t, 1, len(fg.Root.Children))
+	require.Equal(t, int64(2), fg.Root.Children[0].Cumulative)
+	require.Equal(t, int64(1), fg.Root.Children[0].Diff)
+
+	res, err = api.Query(ctx, &pb.QueryRequest{
+		Mode:       pb.QueryRequest_MODE_DIFF,
+		ReportType: *pb.QueryRequest_REPORT_TYPE_TOP.Enum(),
+		Options: &pb.QueryRequest_Diff{
+			Diff: &pb.DiffProfile{
+				A: &pb.ProfileDiffSelection{
+					Mode: pb.ProfileDiffSelection_MODE_SINGLE_UNSPECIFIED,
+					Options: &pb.ProfileDiffSelection_Single{
+						Single: &pb.SingleProfile{
+							Query: `{job="default"}`,
+							Time:  timestamppb.New(timestamp.Time(1)),
+						},
+					},
+				},
+				B: &pb.ProfileDiffSelection{
+					Mode: pb.ProfileDiffSelection_MODE_SINGLE_UNSPECIFIED,
+					Options: &pb.ProfileDiffSelection_Single{
+						Single: &pb.SingleProfile{
+							Query: `{job="default"}`,
+							Time:  timestamppb.New(timestamp.Time(2)),
+						},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	topList := res.Report.(*pb.QueryResponse_Top).Top.List
+	require.Equal(t, 1, len(topList))
+	require.Equal(t, int64(2), topList[0].Cumulative)
+	require.Equal(t, int64(1), topList[0].Diff)
+
+	res, err = api.Query(ctx, &pb.QueryRequest{
+		Mode:       pb.QueryRequest_MODE_DIFF,
+		ReportType: *pb.QueryRequest_REPORT_TYPE_PPROF.Enum(),
+		Options: &pb.QueryRequest_Diff{
+			Diff: &pb.DiffProfile{
+				A: &pb.ProfileDiffSelection{
+					Mode: pb.ProfileDiffSelection_MODE_SINGLE_UNSPECIFIED,
+					Options: &pb.ProfileDiffSelection_Single{
+						Single: &pb.SingleProfile{
+							Query: `{job="default"}`,
+							Time:  timestamppb.New(timestamp.Time(1)),
+						},
+					},
+				},
+				B: &pb.ProfileDiffSelection{
+					Mode: pb.ProfileDiffSelection_MODE_SINGLE_UNSPECIFIED,
+					Options: &pb.ProfileDiffSelection_Single{
+						Single: &pb.SingleProfile{
+							Query: `{job="default"}`,
+							Time:  timestamppb.New(timestamp.Time(2)),
+						},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	resProf, err := profile.ParseData(res.Report.(*pb.QueryResponse_Pprof).Pprof)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(resProf.Sample))
+	require.Equal(t, []int64{2}, resProf.Sample[0].Value)
+	require.Equal(t, []int64{-1}, resProf.Sample[1].Value)
 }
 
 func TestColumnQueryAPILabelNames(t *testing.T) {

--- a/pkg/query/pprof.go
+++ b/pkg/query/pprof.go
@@ -149,6 +149,10 @@ func GenerateFlatPprof(ctx context.Context, metaStore metastore.ProfileMetaStore
 			locations = append(locations, pl)
 		}
 
+		if s.Value == 0 && s.DiffValue != 0 {
+			s.Value = s.DiffValue
+		}
+
 		p.Sample = append(p.Sample, &profile.Sample{
 			Value:    []int64{s.Value},
 			Location: locations,


### PR DESCRIPTION
Previously we had a fast path for pre-processing diffs that are
identical. It turns out that this fast path messed up the data and was
hiding that some diffs were not done correctly. This primarily happened
when non-merged different binaries are compared.

cc @roidelapluie