### PR TITLE
pkg/query: Fix incorrect aggregation of flat values in table

### DIFF
--- a/pkg/query/columnquery.go
+++ b/pkg/query/columnquery.go
@@ -364,7 +364,7 @@ func (q *ColumnQueryAPI) renderReport(ctx context.Context, p *profile.Stacktrace
 			Report: &pb.QueryResponse_Pprof{Pprof: buf.Bytes()},
 		}, nil
 	case pb.QueryRequest_REPORT_TYPE_TOP:
-		top, err := GenerateTopTable(ctx, q.metaStore, p)
+		top, err := GenerateTopTable(ctx, p)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "failed to generate pprof: %v", err.Error())
 		}

--- a/pkg/query/query.go
+++ b/pkg/query/query.go
@@ -320,7 +320,7 @@ func (q *Query) renderReport(ctx context.Context, p profile.InstantProfile, typ 
 			Report: &pb.QueryResponse_Pprof{Pprof: buf.Bytes()},
 		}, nil
 	case pb.QueryRequest_REPORT_TYPE_TOP:
-		top, err := GenerateTopTable(ctx, q.metaStore, samples)
+		top, err := GenerateTopTable(ctx, samples)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "failed to generate top table: %v", err.Error())
 		}

--- a/pkg/query/top.go
+++ b/pkg/query/top.go
@@ -22,11 +22,10 @@ import (
 
 	metastorev1alpha1 "github.com/parca-dev/parca/gen/proto/go/parca/metastore/v1alpha1"
 	pb "github.com/parca-dev/parca/gen/proto/go/parca/query/v1alpha1"
-	"github.com/parca-dev/parca/pkg/metastore"
 	parcaprofile "github.com/parca-dev/parca/pkg/profile"
 )
 
-func GenerateTopTable(ctx context.Context, metaStore metastore.ProfileMetaStore, p *parcaprofile.StacktraceSamples) (*pb.Top, error) {
+func GenerateTopTable(ctx context.Context, p *parcaprofile.StacktraceSamples) (*pb.Top, error) {
 	// Iterate over all samples and their locations.
 	// Calculate the cumulative value of all locations of all samples.
 	// In the end return a *pb.TopNode for each location including all the metadata we have.
@@ -36,6 +35,10 @@ func GenerateTopTable(ctx context.Context, metaStore metastore.ProfileMetaStore,
 			if node, found := locationsTopNodes[location.ID]; found {
 				node.Cumulative += sample.Value
 				node.Diff += sample.DiffValue
+
+				if i == 0 {
+					node.Flat += sample.Value
+				}
 			} else {
 				node := &pb.TopNode{
 					Cumulative: sample.Value,


### PR DESCRIPTION
Previously we were only setting the flat value when we see the leaf for the first time, but it's possible that the same function occurs in many leafs, thus it's "cumulative flat value" is different. It also meant that whatever the first leaf value was that we saw was the one used. With this patch they are now correctly summed up.

@metalmatze 