### PR TITLE
area/ui: Update fonts in the UI

### DIFF
--- a/ui/packages/app/web/src/style/profile.css
+++ b/ui/packages/app/web/src/style/profile.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Roboto+Mono&display=swap');
+
 .profile-search-bar .queryExpressionInput {
   box-shadow: none;
   border-radius: 0;

--- a/ui/packages/app/web/src/style/profile.css
+++ b/ui/packages/app/web/src/style/profile.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Roboto+Mono&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@100;200;300;400;500;600&family=Roboto+Mono&display=swap');
 
 .profile-search-bar .queryExpressionInput {
   box-shadow: none;

--- a/ui/packages/app/web/tailwind.config.js
+++ b/ui/packages/app/web/tailwind.config.js
@@ -7,6 +7,9 @@ module.exports = {
   darkMode: 'class',
   theme: {
     extend: {
+      fontFamily: {
+        robotoMono: ['Roboto Mono', 'monospace'],
+      },
       maxWidth: {
         '1/2': '50%',
       },

--- a/ui/packages/app/web/tailwind.config.js
+++ b/ui/packages/app/web/tailwind.config.js
@@ -1,3 +1,5 @@
+const defaultTheme = require('tailwindcss/defaultTheme');
+
 module.exports = {
   content: [
     './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
@@ -9,6 +11,7 @@ module.exports = {
     extend: {
       fontFamily: {
         robotoMono: ['Roboto Mono', 'monospace'],
+        sans: ['Poppins', ...defaultTheme.fontFamily.sans],
       },
       maxWidth: {
         '1/2': '50%',

--- a/ui/packages/shared/profile/src/IcicleGraph.tsx
+++ b/ui/packages/shared/profile/src/IcicleGraph.tsx
@@ -6,7 +6,7 @@ import {Flamegraph, FlamegraphNode, FlamegraphRootNode} from '@parca/client';
 import {usePopper} from 'react-popper';
 import {getLastItem, valueFormatter} from '@parca/functions';
 
-const RowHeight = 20;
+const RowHeight = 26;
 
 const icicleRectStyles = {
   cursor: 'pointer',
@@ -65,7 +65,7 @@ function IcicleRect({
       />
       {width > 5 && (
         <svg width={width - 5} height={height}>
-          <text x={5} y={13} style={{fontSize: '12px'}}>
+          <text x={5} y={15} style={{fontSize: '12px'}}>
             {name}
           </text>
         </svg>
@@ -98,10 +98,10 @@ function diffColor(diff: number, cumulative: number): string {
     Math.abs(diff) > 0 ? Math.min((Math.abs(diffRatio) / 2 + 0.5) * 0.8, 0.8) : 0;
   const color =
     diff === 0
-      ? '#90c7e0'
+      ? '#B3BAE1'
       : diff > 0
-      ? `rgba(221, 46, 69, ${diffTransparency})`
-      : `rgba(59, 165, 93, ${diffTransparency})`;
+      ? `rgba(254, 153, 187, ${diffTransparency})`
+      : `rgba(164, 214, 153, ${diffTransparency})`;
 
   return color;
 }
@@ -521,7 +521,13 @@ export default function IcicleGraph({graph, width, setCurPath, curPath}: IcicleG
         hoveringNode={hoveringNode}
         contextElement={svg.current}
       />
-      <svg width={width} height={height} onMouseMove={onMouseMove} ref={svg}>
+      <svg
+        className="font-robotoMono"
+        width={width}
+        height={height}
+        onMouseMove={onMouseMove}
+        ref={svg}
+      >
         <g ref={ref}>
           <MemoizedIcicleGraphRootNode
             node={graph.root}

--- a/ui/packages/shared/profile/src/TopTable.tsx
+++ b/ui/packages/shared/profile/src/TopTable.tsx
@@ -167,7 +167,7 @@ export const TopTable = ({queryClient, profileSource}: ProfileViewProps): JSX.El
 
   return (
     <>
-      <div className="w-full">
+      <div className="w-full font-robotoMono">
         <table className="iciclegraph-table table-fixed text-left w-full divide-y divide-gray-200 dark:divide-gray-700">
           <thead className="bg-gray-50 dark:bg-gray-800">
             <tr>


### PR DESCRIPTION
This PR updates the fonts used in the Parca UI and also uses softer colors for the Icicle graph. 

The Icicle graph and Top table now use the `Roboto Mono` font and I also decided to update the main font being used in the UI to be `Poppins` since that's the font used in the upcoming Parca website redesign.

Resolves #877 

Some screenshots:
<img width="1797" alt="image" src="https://user-images.githubusercontent.com/9016992/164279296-a26f198b-15a9-4010-a03a-f35b83e61243.png">

<img width="1800" alt="image" src="https://user-images.githubusercontent.com/9016992/164279337-1f043a97-5627-4202-9210-3484de911739.png">

<img width="1799" alt="image" src="https://user-images.githubusercontent.com/9016992/164279403-7d9747c6-d605-4be1-894a-42cdb14ee0b8.png">

<img width="901" alt="image" src="https://user-images.githubusercontent.com/9016992/164279559-711da2d0-d667-4b3e-a2ea-a0cf798c0eb7.png">

<img width="1797" alt="image" src="https://user-images.githubusercontent.com/9016992/164279652-d24641c2-d333-4601-a68c-97d5186e6ae3.png">


and because it looks so gooood in **light mode**:
<img width="901" alt="image" src="https://user-images.githubusercontent.com/9016992/164280375-9cff53e4-4bce-499d-aba8-cf0efbf4e077.png">

