### PR TITLE
ui: Gracefully handle undefined range keys

### DIFF
--- a/ui/packages/shared/components/src/DateTimeRangePicker/utils.ts
+++ b/ui/packages/shared/components/src/DateTimeRangePicker/utils.ts
@@ -114,7 +114,10 @@ export class DateTimeRange {
     return `absolute:${this.getFromDateStringKey()}-${this.getToDateStringKey()}`;
   }
 
-  static fromRangeKey(rangeKey: string) {
+  static fromRangeKey(rangeKey: string | undefined) {
+    if (rangeKey === undefined) {
+      return new DateTimeRange();
+    }
     try {
       const [rangeType, rangeValueKey] = rangeKey.split(':');
       if (rangeType === 'relative') {


### PR DESCRIPTION
Whenever a new query is started, the range key of the query is
undefined, so we need to be able to handle that state.