### PR TITLE
.gitattributes: Mark some paths as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+gen/ linguist-generated
+ui/packages/shared/client/src/ linguist-generated


### PR DESCRIPTION
So linguist doesn't tally them https://github.com/github/linguist/blob/master/docs/overrides.md

cc/ @brancz 