### PR TITLE
ui: Fix passing gRPC metadata correctly

### DIFF
--- a/ui/packages/shared/components/src/MatchersInput/index.tsx
+++ b/ui/packages/shared/components/src/MatchersInput/index.tsx
@@ -53,7 +53,7 @@ export const useLabelNames = (client: QueryServiceClient): ILabelNamesResult => 
   const metadata = useGrpcMetadata();
 
   useEffect(() => {
-    const call = client.labels({match: []}, metadata);
+    const call = client.labels({match: []}, {meta: metadata});
 
     call.response
       .then(response => setResult({response: response}))
@@ -108,12 +108,12 @@ const MatchersInput = ({
   const {styles, attributes} = usePopper(divInputRef, popperElement, {
     placement: 'bottom-start',
   });
-  const grpcMetadata = useGrpcMetadata();
+  const metadata = useGrpcMetadata();
 
   const {response: labelNamesResponse, error: labelNamesError} = useLabelNames(queryClient);
 
   const getLabelNameValues = (labelName: string) => {
-    const call = queryClient.values({labelName: labelName, match: []}, grpcMetadata);
+    const call = queryClient.values({labelName: labelName, match: []}, {meta: metadata});
 
     call.response
       .then(response => setLabelValuesResponse(response.labelValues))

--- a/ui/packages/shared/components/src/ProfileMetricsGraph/index.tsx
+++ b/ui/packages/shared/components/src/ProfileMetricsGraph/index.tsx
@@ -49,7 +49,7 @@ export const useQueryRange = (
         end: Timestamp.fromDate(new Date(end)),
         limit: 0,
       },
-      metadata
+      {meta: metadata}
     );
 
     call.response

--- a/ui/packages/shared/components/src/ProfileSelector/index.tsx
+++ b/ui/packages/shared/components/src/ProfileSelector/index.tsx
@@ -57,7 +57,7 @@ export const useProfileTypes = (client: QueryServiceClient): IProfileTypesResult
   const metadata = useGrpcMetadata();
 
   useEffect(() => {
-    const call = client.profileTypes({}, metadata);
+    const call = client.profileTypes({}, {meta: metadata});
     call.response
       .then(response => setResult({response: response}))
       .catch(error => setResult({error: error}));

--- a/ui/packages/shared/profile/src/ProfileView.tsx
+++ b/ui/packages/shared/profile/src/ProfileView.tsx
@@ -46,7 +46,7 @@ export const ProfileView = ({
     QueryRequest_ReportType.FLAMEGRAPH_UNSPECIFIED
   );
   const [currentView, setCurrentView] = useState<string | undefined>(currentViewFromURL);
-  const grpcMetadata = useGrpcMetadata();
+  const metadata = useGrpcMetadata();
 
   useEffect(() => {
     let showLoaderTimeout;
@@ -110,7 +110,7 @@ export const ProfileView = ({
     };
 
     queryClient
-      .query(req, grpcMetadata)
+      .query(req, {meta: metadata})
       .response.then(response => {
         if (response.report.oneofKind !== 'pprof') {
           console.log('Expected pprof report, got:', response.report.oneofKind);

--- a/ui/packages/shared/profile/src/useQuery.tsx
+++ b/ui/packages/shared/profile/src/useQuery.tsx
@@ -31,7 +31,7 @@ export const useQuery = (
     const req = profileSource.QueryRequest();
     req.reportType = reportType;
 
-    const call = client.query(req, metadata);
+    const call = client.query(req, {meta: metadata});
 
     call.response
       .then(response => setResult({response: response, error: null, isLoading: false}))


### PR DESCRIPTION
Unfortunately because of https://github.com/timostamm/protobuf-ts/blob/55a7d5588afad4a98e57dc35789d97650d96da43/packages/runtime-rpc/src/rpc-options.ts#L57-L61, this slipped through transparently, while we actually meant to set https://github.com/timostamm/protobuf-ts/blob/55a7d5588afad4a98e57dc35789d97650d96da43/packages/runtime-rpc/src/rpc-options.ts#L23