### PR TITLE
debuginfod: Fix tests depends on external service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,13 @@ check-license:
 go/test:
 	 go test -v `go list ./...`
 
+VCR_FILES ?= $(shell find ./pkg/*/testdata -name "fixtures.yaml")
+
+.PHONY: go/test-clean
+go/test-clean:
+	rm -f $(VCR_FILES)
+
+
 UI_FILES ?= $(shell find ./ui -name "*" -not -path "./ui/lib/node_modules/*" -not -path "./ui/node_modules/*" -not -path "./ui/packages/app/template/node_modules/*" -not -path "./ui/packages/app/web/node_modules/*" -not -path "./ui/packages/app/web/build/*")
 
 .PHONY: ui/build

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/prometheus/client_golang v1.12.1
 	github.com/prometheus/common v0.34.0
 	github.com/prometheus/prometheus v1.8.2-0.20220315145411-881111fec433
+	github.com/sebdah/goldie/v2 v2.5.3
 	github.com/segmentio/parquet-go v0.0.0-20220421002521-93f8e5ed3407
 	github.com/stretchr/testify v1.7.1
 	github.com/thanos-io/objstore v0.0.0-20220324101945-f2f24637ce2e
@@ -177,6 +178,7 @@ require (
 	github.com/rs/xid v1.2.1 // indirect
 	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.9 // indirect
 	github.com/segmentio/encoding v0.3.3 // indirect
+	github.com/sergi/go-diff v1.2.0 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/tencentyun/cos-go-sdk-v5 v0.7.34 // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.1.2
 	github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be
 	github.com/dgraph-io/badger/v3 v3.2103.2
+	github.com/dnaeon/go-vcr v1.2.0
 	github.com/fatih/semgroup v1.2.0
 	github.com/felixge/fgprof v0.9.2
 	github.com/go-chi/chi/v5 v5.0.7
@@ -32,7 +33,6 @@ require (
 	github.com/prometheus/client_golang v1.12.1
 	github.com/prometheus/common v0.34.0
 	github.com/prometheus/prometheus v1.8.2-0.20220315145411-881111fec433
-	github.com/sebdah/goldie/v2 v2.5.3
 	github.com/segmentio/parquet-go v0.0.0-20220421002521-93f8e5ed3407
 	github.com/stretchr/testify v1.7.1
 	github.com/thanos-io/objstore v0.0.0-20220324101945-f2f24637ce2e
@@ -178,7 +178,6 @@ require (
 	github.com/rs/xid v1.2.1 // indirect
 	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.9 // indirect
 	github.com/segmentio/encoding v0.3.3 // indirect
-	github.com/sergi/go-diff v1.2.0 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/tencentyun/cos-go-sdk-v5 v0.7.34 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1359,6 +1359,8 @@ github.com/sclevine/agouti v3.0.0+incompatible/go.mod h1:b4WX9W9L1sfQKXeJf1mUTLZ
 github.com/sclevine/spec v1.2.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 h1:nn5Wsu0esKSJiIVhscUtVbo7ada43DJhG55ua/hjS5I=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
+github.com/sebdah/goldie/v2 v2.5.3 h1:9ES/mNN+HNUbNWpVAlrzuZ7jE+Nrczbj8uFRjM7624Y=
+github.com/sebdah/goldie/v2 v2.5.3/go.mod h1:oZ9fp0+se1eapSRjfYbsV/0Hqhbuu3bJVvKI/NNtssI=
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/seccomp/libseccomp-golang v0.9.2-0.20210429002308-3879420cc921/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
 github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
@@ -1367,6 +1369,8 @@ github.com/segmentio/encoding v0.3.3/go.mod h1:n0JeuIqEQrQoPDGsjo8UNd1iA0U8d8+oH
 github.com/segmentio/parquet-go v0.0.0-20220421002521-93f8e5ed3407 h1:Pz9rS42lX6XZ+GBsV2SdGyNDalo5beooPXMO7dCe1G0=
 github.com/segmentio/parquet-go v0.0.0-20220421002521-93f8e5ed3407/go.mod h1:HBHoETTgIDcNyTWTVOvCelN6kbFozuTNZPLyRIBjW2E=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
+github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
+github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/shurcooL/vfsgen v0.0.0-20200824052919-0d455de96546/go.mod h1:TrYk7fJVaAttu97ZZKrO9UbRa8izdowaMIZcxYMbVaw=

--- a/go.sum
+++ b/go.sum
@@ -1359,8 +1359,6 @@ github.com/sclevine/agouti v3.0.0+incompatible/go.mod h1:b4WX9W9L1sfQKXeJf1mUTLZ
 github.com/sclevine/spec v1.2.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 h1:nn5Wsu0esKSJiIVhscUtVbo7ada43DJhG55ua/hjS5I=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
-github.com/sebdah/goldie/v2 v2.5.3 h1:9ES/mNN+HNUbNWpVAlrzuZ7jE+Nrczbj8uFRjM7624Y=
-github.com/sebdah/goldie/v2 v2.5.3/go.mod h1:oZ9fp0+se1eapSRjfYbsV/0Hqhbuu3bJVvKI/NNtssI=
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/seccomp/libseccomp-golang v0.9.2-0.20210429002308-3879420cc921/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
 github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
@@ -1369,8 +1367,6 @@ github.com/segmentio/encoding v0.3.3/go.mod h1:n0JeuIqEQrQoPDGsjo8UNd1iA0U8d8+oH
 github.com/segmentio/parquet-go v0.0.0-20220421002521-93f8e5ed3407 h1:Pz9rS42lX6XZ+GBsV2SdGyNDalo5beooPXMO7dCe1G0=
 github.com/segmentio/parquet-go v0.0.0-20220421002521-93f8e5ed3407/go.mod h1:HBHoETTgIDcNyTWTVOvCelN6kbFozuTNZPLyRIBjW2E=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
-github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
-github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/shurcooL/vfsgen v0.0.0-20200824052919-0d455de96546/go.mod h1:TrYk7fJVaAttu97ZZKrO9UbRa8izdowaMIZcxYMbVaw=

--- a/pkg/debuginfo/debuginfod.go
+++ b/pkg/debuginfo/debuginfod.go
@@ -41,7 +41,9 @@ func (NopDebugInfodClient) GetDebugInfo(context.Context, string) (io.ReadCloser,
 }
 
 type HTTPDebugInfodClient struct {
-	logger          log.Logger
+	logger log.Logger
+	client *http.Client
+
 	UpstreamServers []*url.URL
 	timeoutDuration time.Duration
 }
@@ -71,6 +73,7 @@ func NewHTTPDebugInfodClient(logger log.Logger, serverURLs []string, timeoutDura
 		logger:          logger,
 		UpstreamServers: parsedURLs,
 		timeoutDuration: timeoutDuration,
+		client:          http.DefaultClient,
 	}, nil
 }
 
@@ -186,7 +189,7 @@ func (c *HTTPDebugInfodClient) request(ctx context.Context, u url.URL, buildID s
 		return nil, fmt.Errorf("create request: %w", err)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := c.client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %w", err)
 	}

--- a/pkg/debuginfo/debuginfod.go
+++ b/pkg/debuginfo/debuginfod.go
@@ -149,11 +149,17 @@ func (c *HTTPDebugInfodClient) GetDebugInfo(ctx context.Context, buildID string)
 	//"https://debuginfod.archlinux.org/"
 	//"https://debuginfod.centos.org/"
 	for _, u := range c.UpstreamServers {
-		ctx, cancel := context.WithTimeout(ctx, c.timeoutDuration)
-		defer cancel()
-
 		serverURL := *u
-		rc, err := c.request(ctx, serverURL, buildID)
+		rc, err := func(serverURL url.URL) (io.ReadCloser, error) {
+			ctx, cancel := context.WithTimeout(ctx, c.timeoutDuration)
+			defer cancel()
+
+			rc, err := c.request(ctx, serverURL, buildID)
+			if err != nil {
+				return nil, err
+			}
+			return rc, nil
+		}(serverURL)
 		if err != nil {
 			level.Warn(logger).Log(
 				"msg", "failed to download debug info file from upstream debuginfod server, trying next one (if exists)",
@@ -161,7 +167,9 @@ func (c *HTTPDebugInfodClient) GetDebugInfo(ctx context.Context, buildID string)
 			)
 			continue
 		}
-		return rc, nil
+		if rc != nil {
+			return rc, nil
+		}
 	}
 	return nil, errDebugInfoNotFound
 }


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>


The library used: ~https://github.com/sebdah/goldie~ https://github.com/dnaeon/go-vcr (goldie needs https://pkg.go.dev/net/http/httptest#ResponseRecorder which is useful when you test against your own server. Unfortunately, in this case we need to request to an external service. One alternative would be to create a proxy and use `ResponseRecorder `but I think it won't worth the hassle, so I used the go-vcr package directly.)

About golden test files: https://www.youtube.com/watch?v=yszygk1cpEc

