### PR TITLE
pkg/config: Support prefix for pprof config (#931)

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -209,7 +209,7 @@ func (c *ScrapeConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	// If path prefix is specified, add to PprofConfig path
 	if unmarshalled.ProfilingConfig.PprofPrefix != "" {
 		for pt := range unmarshalled.ProfilingConfig.PprofConfig {
-			unmarshalled.ProfilingConfig.PprofConfig[pt].Path = unmarshalled.ProfilingConfig.PprofPrefix + unmarshalled.ProfilingConfig.PprofConfig[pt].Path
+			unmarshalled.ProfilingConfig.PprofConfig[pt].Path = filepath.Join(unmarshalled.ProfilingConfig.PprofPrefix, unmarshalled.ProfilingConfig.PprofConfig[pt].Path)
 		}
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -170,6 +170,7 @@ type ServiceDiscoveryConfig struct {
 
 type ProfilingConfig struct {
 	PprofConfig PprofConfig `yaml:"pprof_config,omitempty"`
+	PprofPrefix string      `yaml:"path_prefix,omitempty"`
 }
 
 type PprofConfig map[string]*PprofProfilingConfig
@@ -202,6 +203,13 @@ func (c *ScrapeConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			if unmarshalled.ProfilingConfig.PprofConfig[pt].Path == "" {
 				unmarshalled.ProfilingConfig.PprofConfig[pt].Path = pc.Path
 			}
+		}
+	}
+
+	// If path prefix is specified, add to PprofConfig path
+	if unmarshalled.ProfilingConfig.PprofPrefix != "" {
+		for pt := range unmarshalled.ProfilingConfig.PprofConfig {
+			unmarshalled.ProfilingConfig.PprofConfig[pt].Path = unmarshalled.ProfilingConfig.PprofPrefix + unmarshalled.ProfilingConfig.PprofConfig[pt].Path
 		}
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -39,7 +39,7 @@ func TestLoadComplex(t *testing.T) {
 	// TODO: Make even more complex if necessary
 	complexYAML := `
 scrape_configs:
-  - job_name: 'conprof'
+  - job_name: 'parca'
     scrape_interval: 10s
     static_configs:
       - targets: [ 'localhost:10902' ]
@@ -47,7 +47,7 @@ scrape_configs:
       pprof_config:
         memory:
           enabled: true
-          path: /conprof/debug/pprof/allocs
+          path: /parca/debug/pprof/allocs
         fgprof:
           enabled: true
           path: /debug/fgprof
@@ -58,7 +58,7 @@ scrape_configs:
 	expected := &Config{
 		ScrapeConfigs: []*ScrapeConfig{
 			{
-				JobName:        "conprof",
+				JobName:        "parca",
 				ScrapeInterval: model.Duration(10 * time.Second),
 				ScrapeTimeout:  model.Duration(10 * time.Second),
 				Scheme:         "http",
@@ -66,7 +66,7 @@ scrape_configs:
 					PprofConfig: PprofConfig{
 						"memory": &PprofProfilingConfig{
 							Enabled: trueValue(),
-							Path:    "/conprof/debug/pprof/allocs",
+							Path:    "/parca/debug/pprof/allocs",
 						},
 						"block": &PprofProfilingConfig{
 							Enabled: trueValue(),
@@ -115,7 +115,7 @@ scrape_configs:
 func TestLoadPrefixConfig(t *testing.T) {
 	prefixYAML := `
 scrape_configs:
-  - job_name: 'conprof'
+  - job_name: 'parca'
     scrape_interval: 10s
     static_configs:
       - targets: [ 'localhost:10902' ]
@@ -124,7 +124,7 @@ scrape_configs:
       pprof_config:
         memory:
           enabled: true
-          path: /conprof/debug/pprof/allocs
+          path: /parca/debug/pprof/allocs
         fgprof:
           enabled: true
           path: /debug/fgprof
@@ -135,7 +135,7 @@ scrape_configs:
 	expected := &Config{
 		ScrapeConfigs: []*ScrapeConfig{
 			{
-				JobName:        "conprof",
+				JobName:        "parca",
 				ScrapeInterval: model.Duration(10 * time.Second),
 				ScrapeTimeout:  model.Duration(10 * time.Second),
 				Scheme:         "http",
@@ -144,7 +144,7 @@ scrape_configs:
 					PprofConfig: PprofConfig{
 						"memory": &PprofProfilingConfig{
 							Enabled: trueValue(),
-							Path:    "/test/prefix/conprof/debug/pprof/allocs",
+							Path:    "/test/prefix/parca/debug/pprof/allocs",
 						},
 						"block": &PprofProfilingConfig{
 							Enabled: trueValue(),


### PR DESCRIPTION
It seems I may have misunderstood the issue. 

Looking at the 2 configs in the issue description, I thought it meant discovering pprof configs (from somewhere) once the user has specified a particular prefix. However, from [this comment](https://github.com/parca-dev/parca/issues/931#issuecomment-1117506666) I realise it means not having to write a particular string repeatedly while specifying multiple configs. If it is the second case that needs to be addressed, this PR should be good.

Need help understanding relabelling though and what it means in the context of this issue.