### PR TITLE
Update go to use 1.18.2

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,8 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v3
         with:
-          go-version: ^1.17
+          go-version: '1.18'
+          check-latest: true
 
       - name: Build UI
         run: make ui/build

--- a/.github/workflows/go-build-test.yml
+++ b/.github/workflows/go-build-test.yml
@@ -23,7 +23,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: ^1.18
+          go-version: '1.18'
+          check-latest: true
 
       - name: Build UI
         run: make ui/build

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -22,7 +22,8 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: ^1.18
+          go-version: '1.18'
+          check-latest: true
       - uses: actions/checkout@v3
 
       - name: Build UI
@@ -34,4 +35,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.2.0
         with:
-          version: v1.45.2
+          version: v1.46.0

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -35,4 +35,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.2.0
         with:
-          version: v1.46.0
+          version: v1.45.2

--- a/.github/workflows/jsonnet.yml
+++ b/.github/workflows/jsonnet.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.16'
+          go-version: '1.18'
           check-latest: true
 
       - name: Set up Jsonnet

--- a/.github/workflows/jsonnet.yml
+++ b/.github/workflows/jsonnet.yml
@@ -23,7 +23,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: ^1.16
+          go-version: '1.16'
+          check-latest: true
 
       - name: Set up Jsonnet
         run: ./env-jsonnet.sh

--- a/.github/workflows/proto-gen.yaml
+++ b/.github/workflows/proto-gen.yaml
@@ -17,7 +17,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: ^1.18
+          go-version: '1.18'
+          check-latest: true
 
       - uses: bufbuild/buf-setup-action@v1.4.0
         with:

--- a/.github/workflows/proto-pr.yaml
+++ b/.github/workflows/proto-pr.yaml
@@ -17,7 +17,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: ^1.18
+          go-version: '1.18'
+          check-latest: true
 
       - uses: bufbuild/buf-setup-action@v1.4.0
         with:

--- a/.github/workflows/proto-push.yaml
+++ b/.github/workflows/proto-push.yaml
@@ -18,7 +18,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: ^1.18
+          go-version: '1.18'
+          check-latest: true
 
       - uses: bufbuild/buf-setup-action@v1.4.0
         with:

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -48,7 +48,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: ^1.16
+          go-version: '1.18'
+          check-latest: true
 
       - name: Set up environment
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: ^1.16
+          go-version: '1.18'
+          check-latest: true
 
       - name: Build UI
         run: make ui/build
@@ -57,7 +58,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: ^1.16
+          go-version: '1.18'
+          check-latest: true
 
       - name: Set up Jsonnet
         run: ./env-jsonnet.sh

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -15,7 +15,7 @@ COPY ui .
 COPY --from=ui-deps /app/node_modules ./node_modules
 RUN yarn workspace @parca/web build
 
-FROM golang:1.18.1-alpine3.15 AS builder
+FROM golang:1.18.2-alpine3.15 AS builder
 
 WORKDIR /app
 
@@ -37,7 +37,7 @@ COPY ./gen /app/gen
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -gcflags="all=-N -l" -o parca ./cmd/parca
 
-FROM golang:1.18.1-alpine3.15
+FROM golang:1.18.2-alpine3.15
 
 COPY --from=builder /go/bin/dlv /
 COPY --from=builder /go/bin/grpc-health-probe /

--- a/Dockerfile.go.dev
+++ b/Dockerfile.go.dev
@@ -1,5 +1,5 @@
 # Designed to only used by Tilt to iterate faster on the API.
-FROM golang:1.18.1-alpine3.15 AS builder
+FROM golang:1.18.2-alpine3.15 AS builder
 
 WORKDIR /app
 
@@ -27,7 +27,7 @@ COPY ./gen /app/gen
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -gcflags="all=-N -l" -o parca ./cmd/parca
 
-FROM golang:1.18.1-alpine3.15
+FROM golang:1.18.2-alpine3.15
 
 COPY --from=builder /go/bin/dlv /
 COPY --from=builder /go/bin/grpc-health-probe /

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,4 +1,4 @@
-FROM golang:1.18.1-alpine3.15 as builder
+FROM golang:1.18.2-alpine3.15 as builder
 
 WORKDIR /app
 

--- a/proto/buf.lock
+++ b/proto/buf.lock
@@ -4,7 +4,7 @@ deps:
   - remote: buf.build
     owner: googleapis
     repository: googleapis
-    commit: f3590c56d388417ebbedefae77ac12bf
+    commit: 8bfe484050ce4f5c8d8baff70136e148
   - remote: buf.build
     owner: grpc-ecosystem
     repository: grpc-gateway

--- a/scripts/make-containers.sh
+++ b/scripts/make-containers.sh
@@ -27,7 +27,7 @@ DOCKER_NODE_ALPINE_SHAS=(
 )
 
 # SHA order is respectively ('amd64' 'arm64' 'armv6' 'armv7' '386')
-# this image is what docker.io/alpine:3.15.4 on May 11 2022.
+# this image is what docker.io/alpine:3.15.4 on May 12 2021
 # Here is how to obtain the digests:
 # for r in amd64 arm64v8 arm32v6 arm32v7 i386; do docker pull $r/alpine:3.15.4 | grep Digest; done
 DOCKER_ALPINE_SHAS=(

--- a/scripts/make-containers.sh
+++ b/scripts/make-containers.sh
@@ -27,7 +27,7 @@ DOCKER_NODE_ALPINE_SHAS=(
 )
 
 # SHA order is respectively ('amd64' 'arm64' 'armv6' 'armv7' '386')
-# this image is what docker.io/alpine:3.15.4 on May 12 2021
+# this image is what docker.io/alpine:3.15.4 on May 11 2022.
 # Here is how to obtain the digests:
 # for r in amd64 arm64v8 arm32v6 arm32v7 i386; do docker pull $r/alpine:3.15.4 | grep Digest; done
 DOCKER_ALPINE_SHAS=(

--- a/scripts/make-containers.sh
+++ b/scripts/make-containers.sh
@@ -7,13 +7,13 @@ MANIFEST="$3"
 ARCHS=('amd64' 'arm64' 'armv6' 'armv7' '386')
 
 # SHA order is respectively ('amd64' 'arm64' 'armv6' 'armv7' '386')
-# this image is what docker.io/golang:1.18.0-alpine3.15 on April 7 2022
+# this image is what docker.io/golang:1.18.2-alpine3.15 on May 12 2022
 DOCKER_GOLANG_ALPINE_SHAS=(
-    'docker.io/golang@sha256:7473adb02bd430045c938f61e2c2177ff62b28968579dfed99085a0960f76f5d'
-    'docker.io/golang@sha256:fe66e641602dfb60f5c746b57bde60fcafce94b44f2bc2ca2bdc1e3711b24911'
-    'docker.io/golang@sha256:674352693f4ce096d73fa32d81642ff004c3363caa43fbda13f30e60c564fd9d'
-    'docker.io/golang@sha256:1661ccca6a506959ff7ceee79ac0278785c71403de8cb03b5ad1672f466ab769'
-    'docker.io/golang@sha256:f65787ec108a90d8af2017a8685ae94f70205b24122fc5863f117d78c235e72f'
+    'docker.io/golang@sha256:3765360960a954c24b215518a41b0bf8e9e2fe3bd142b6f782fa56f8e00b8d21'
+    'docker.io/golang@sha256:394c1e739574aac2b389c628d0a199316164c3ed9d821c06ebe4ad3f133ed1f9'
+    'docker.io/golang@sha256:7110d5a775fc9007262b612dff9df2e77948b84ece26b0e358c948e89c20adfc'
+    'docker.io/golang@sha256:a1f7892284636a97476f7683b33df2a8b5f7c2e6387d397560ee76da2ca046f0'
+    'docker.io/golang@sha256:825a5233f6134b2da81bf0bd6d5deedb340a8f122799c31a32615bdfa7afd44a'
 )
 
 # SHA order is respectively ('amd64' 'arm64' 'armv6' 'armv7' '386')


### PR DESCRIPTION
- update go in the actions and use the recommended way to get the latest
- update go base image to 1.18.2