### PR TITLE
use crane to get the container digest to use to sing it

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -54,13 +54,17 @@ jobs:
         if: ${{ github.event_name != 'pull_request' }}
         uses: sigstore/cosign-installer@v2.3.0
 
+      - name: Install crane
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: imjasonh/setup-crane@v0.1
+
       - name: Login to registry
         if: ${{ github.event_name != 'pull_request' }}
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | podman login -u parca-dev --password-stdin ghcr.io
           echo "${{ secrets.QUAY_PASSWORD }}" | podman login -u "${{ secrets.QUAY_USERNAME }}" --password-stdin quay.io
 
-      - name: Push container
+      - name: Push and sign container
         if: ${{ github.event_name != 'pull_request' }}
         env:
           COSIGN_EXPERIMENTAL: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,9 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@v2.3.0
 
+      - name: Install crane
+        uses: imjasonh/setup-crane@v0.1
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
 

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,8 @@ push-container:
 
 .PHONY: sign-container
 sign-container:
-	cosign sign --force -a GIT_HASH=$(COMMIT) -a GIT_VERSION=$(VERSION) $(OUT_DOCKER)@$(shell podman inspect $(OUT_DOCKER):$(VERSION) --format "{{ .Digest }}")
+	crane digest $(OUT_DOCKER):$(VERSION)
+	cosign sign --force -a GIT_HASH=$(COMMIT) -a GIT_VERSION=$(VERSION) $(OUT_DOCKER)@$(shell crane digest $(OUT_DOCKER):$(VERSION))
 
 .PHONY: push-quay-container
 push-quay-container:


### PR DESCRIPTION
was trying to debug and reproduce locally but could not find why podman is giving a different digest from the image that is pushed to the registry. 
job that failed https://github.com/parca-dev/parca/actions/runs/2321776702

So I propose to use the crane tool (https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane.md) which is a nice and simple tool to manage easily the container.

if the maintainers agree I can open the PR in the other repo to use the same approach

a sample successfully run in my fork https://github.com/cpanato/parca/runs/6434708198?check_suite_focus=true

and checking the signature

```
$ cosign verify ghcr.io/cpanato/parca:test-4ddfa1ce | jq . | pbcopy

Verification for ghcr.io/cpanato/parca:test-4ddfa1ce --
The following checks were performed on each of these signatures:
  - The cosign claims were validated
  - Existence of the claims in the transparency log was verified offline
  - Any certificates were verified against the Fulcio roots.

[
  {
    "critical": {
      "identity": {
        "docker-reference": "ghcr.io/cpanato/parca"
      },
      "image": {
        "docker-manifest-digest": "sha256:60ff3421672b104d11b1a298ffd8603ec241a94c0532839f4de9bab7ba9b657d"
      },
      "type": "cosign container image signature"
    },
    "optional": {
      "Bundle": {
        "SignedEntryTimestamp": "MEUCIB+GHlctv0wI+fOH632SRLKYEqfbbAayjGwN/zLDAAs4AiEA7AEfzUxAHEuJ8cANX3zpkLSz3w+ricMT9TsPKai/q7I=",
        "Payload": {
          "body": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiI4MGZjZTFhZDhjODU1YTc5Y2YyZjVmN2MwNGFlODdmY2IyYjBjYzUyODU4MjFkNGVmMjMxZjNlZjNhZmFmZDlkIn19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FVUNJUUR0Ylg0OFFnQXVlcDdmRk1JSDVmVGh6QTV5Sy96bTc4bDFBSHJnQ2Q3bnB3SWdTYjV3dStMNzFvcU9DRWRZMW1XbWpuK0VWUU5yRlBtRFpxeFhLTmpTQlhZPSIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVUkVSRU5EUVhCUFowRjNTVUpCWjBsVVlWWktSVlJvTWxnM1ptNXpkMWt2UXpWa2RUY3JZblF3WVZSQlMwSm5aM0ZvYTJwUFVGRlJSRUY2UVhFS1RWSlZkMFYzV1VSV1VWRkxSWGQ0ZW1GWFpIcGtSemw1V2xNMWExcFlXWGhGVkVGUVFtZE9Wa0pCVFZSRFNFNXdXak5PTUdJelNteE5RalJZUkZSSmVRcE5SRlY0VGtSRmVrNUVTVEZQVm05WVJGUkplVTFFVlhoT1JFVjZUbFJKTVU5R2IzZEJSRUphVFVKTlIwSjVjVWRUVFRRNVFXZEZSME5EY1VkVFRUUTVDa0YzUlVoQk1FbEJRa2RoU1RodFkyaHNabHA1WVdwNFlrVklOQ3RuUkUxVVlYaFpRMGxITWpKVFprbHpPRmxzU1d4U1NHUk1UWE4zYlZScVluUlhOR29LVlZOSFVUSkJZVTF6T1RKcmFVcGFRV04zVFVWR2NUUktOREZ5TlU1bFQycG5aMGhCVFVsSlFuWkVRVTlDWjA1V1NGRTRRa0ZtT0VWQ1FVMURRalJCZHdwRmQxbEVWbEl3YkVKQmQzZERaMWxKUzNkWlFrSlJWVWhCZDAxM1JFRlpSRlpTTUZSQlVVZ3ZRa0ZKZDBGRVFXUkNaMDVXU0ZFMFJVWm5VVlUxUVdNckNsTXpXR2xhT1ZCeWRsTmlSVzlDYnpCek5HTnBUblpGZDBoM1dVUldVakJxUWtKbmQwWnZRVlZYVFVGbFdEVkdSbkJYWVhCbGMzbFJiMXBOYVRCRGNrWUtlR1p2ZDFobldVUldVakJTUVZGSUwwSkdVWGRWYjFwUllVaFNNR05JVFRaTWVUbHVZVmhTYjJSWFNYVlpNamwwVERKT2QxbFhOV2hrUnpoMlkwZEdlUXBaTWtWMlRHMWtjR1JIYURGWmFUa3pZak5LY2xwdGVIWmtNMDEyV1RJNWRXUkhSbkJpYlZaNVRHNXNkR0pGUW5sYVYxcDZUREpvYkZsWFVucE1NMUpzQ21NelVYZE9aMWxMUzNkWlFrSkJSMFIyZWtGQ1FYZFJiMDVIVW10YWJVVjRXVEpWTWsweVVURk9WMDVyVDFSRk5GbHFSbXhPUkU1c1dWUkZNMXBVUVRJS1QxUkJNazVYV1RKWlZGRjNXbXBCWWtKbmIzSkNaMFZGUVZsUEwwMUJSVVpDUVRGcVkwZEdkVmxZVW5aTU0wSm9ZMjFPYUUxRWEwZERhWE5IUVZGUlFncG5OemgzUVZGRlJVc3lhREJrU0VKNlQyazRkbVJIT1hKYVZ6UjFXVmRPTUdGWE9YVmplVFZ1WVZoU2IyUlhTakZqTWxaNVdUSTVkV1JIVm5Wa1F6VnFDbUl5TUhkSVVWbExTM2RaUWtKQlIwUjJla0ZDUW1kUlVHTnRWbTFqZVRsdldsZEdhMk41T1RCYVdFNHdUVUpqUjBOcGMwZEJVVkZDWnpjNGQwRlJVVVVLUTFWT2RtSnVVbWhoVnpWc1kycEJaa0puYjNKQ1owVkZRVmxQTDAxQlJVTkNRa1l6WWpOS2NscHRlSFprTVRscllWaE9kMWxZVW1waFJFRkxRbWRuY1Fwb2EycFBVRkZSUkVGM1RtNUJSRUpyUVdwQ2QwTXlRakoyTlN0TGFYaGFkMnRsWTNkdGNESXdSVWx0UjFjNVFWUnBVRGRoT1VOTVNuSXhVa3hFTUNzdkNuZ3pXRUZMTUZkcGFEQktkek1yWWs5bFozZERUVVIyVjJOeFlqbGxUa1ZKTlRablJqaHhaVXBHTkZSbGFHMDVRbEZvYkUxdFRHUllTakJyYjBwWVVua0tSMVowU1ZZd1dVeENXVkZ4ZHpOdFJ6aFVlRXhOVVQwOUNpMHRMUzB0UlU1RUlFTkZVbFJKUmtsRFFWUkZMUzB0TFMwSyJ9fX19",
          "integratedTime": 1652535781,
          "logIndex": 2343867,
          "logID": "c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d"
        }
      },
      "GIT_HASH": "4ddfa1ce",
      "GIT_VERSION": "test-4ddfa1ce",
      "Issuer": "https://token.actions.githubusercontent.com",
      "Subject": "https://github.com/cpanato/parca/.github/workflows/container.yml@refs/heads/test"
    }
  }
]
```