### PR TITLE
env-local-test.sh: Fix file format and ctlptl link

### DIFF
--- a/env-local-test.sh
+++ b/env-local-test.sh
@@ -14,5 +14,5 @@ sudo mv "minikube-linux-$ARCH" /usr/local/bin/minikube
 
 curl -fsSL https://raw.githubusercontent.com/tilt-dev/tilt/master/scripts/install.sh | bash
 
-CTLPTL_VERSION="0.5.1"
+CTLPTL_VERSION="0.8.1"
 curl -fsSL "https://github.com/tilt-dev/ctlptl/releases/download/v$CTLPTL_VERSION/ctlptl.$CTLPTL_VERSION.linux.$(if [ $ARCH=amd64 ]; then echo "$ARCH_UNAME"; else echo "$ARCH"; fi).tar.gz" | sudo tar -xzv -C /usr/local/bin ctlptl

--- a/env-local-test.sh
+++ b/env-local-test.sh
@@ -15,4 +15,4 @@ sudo mv "minikube-linux-$ARCH" /usr/local/bin/minikube
 curl -fsSL https://raw.githubusercontent.com/tilt-dev/tilt/master/scripts/install.sh | bash
 
 CTLPTL_VERSION="0.5.1"
-curl -fsSL "https://github.com/tilt-dev/ctlptl/releases/download/v$CTLPTL_VERSION/ctlptl.$CTLPTL_VERSION.linux.$ARCH.tar.gz" | sudo tar -xzv -C /usr/local/bin ctlptl
+curl -fsSL "https://github.com/tilt-dev/ctlptl/releases/download/v$CTLPTL_VERSION/ctlptl.$CTLPTL_VERSION.linux.$(if [ $ARCH=amd64 ]; then echo "$ARCH_UNAME"; else echo "$ARCH"; fi).tar.gz" | sudo tar -xzv -C /usr/local/bin ctlptl


### PR DESCRIPTION
The above file did not have executable permission so when running `make
dev/setup` it failed.

For `amd64` arch `ctlptl` releases use `arch_uname` in the link. Fixed
it so that file work correctly. For more information check
https://github.com/tilt-dev/ctlptl/releases/tag/v0.5.1

Signed-off-by: Kautilya Tripathi <tripathi.kautilya@gmail.com>