### PR TITLE
area/ui: Truncate date-time text when it overflows

### DIFF
--- a/ui/packages/shared/components/src/DateTimeRangePicker/DateTimeRangePickerTrigger.tsx
+++ b/ui/packages/shared/components/src/DateTimeRangePicker/DateTimeRangePickerTrigger.tsx
@@ -24,9 +24,12 @@ const DateTimeRangePickerTrigger = ({
             {'!justify-center, bg-gray-100 dark:bg-gray-800': isActive}
           )}
         >
-          {isActive && range.from.isRelative()
-            ? `${formatDateStringForUI(range.from)} → ${formatDateStringForUI(range.to)}`
-            : range.getRangeStringForUI()}
+          <span className="w-[147px] text-ellipsis overflow-hidden whitespace-nowrap">
+            {isActive && range.from.isRelative()
+              ? `${formatDateStringForUI(range.from)} → ${formatDateStringForUI(range.to)}`
+              : range.getRangeStringForUI()}
+          </span>
+
           <span className="px-2 cursor-pointer">{!isActive ? '▼' : '▲'}</span>
         </div>
       </Popover.Button>


### PR DESCRIPTION
This PR ensures that the date time text in the `DateTimePicker` is truncated whenever it gets too long. This happened especially when using the absolute version of the date picker and gave the `MatchersInput` search box extra height.

Before
<img width="1800" alt="image" src="https://user-images.githubusercontent.com/9016992/168591862-7872d12f-78a2-493b-9ce0-082867e7b899.png">


After
<img width="1800" alt="image" src="https://user-images.githubusercontent.com/9016992/168591790-ba6544c9-699b-4079-9da9-e3a056ff639b.png">


