### PR TITLE
Multi arch testing support for CI

### DIFF
--- a/.github/workflows/go-build-test.yml
+++ b/.github/workflows/go-build-test.yml
@@ -15,30 +15,150 @@ on:
       - 'go.sum'
 
 jobs:
-  build-and-test:
+  build-and-test-multi-arch:
     runs-on: ubuntu-latest
+    name: Build on ${{ matrix.arch }}
+    # Run steps on a matrix of 2 arch.
+    strategy:
+      matrix:
+        arch:
+          - x64
+          # Names as per arch/ubuntu docker images.
+          - arm64v8
     steps:
-      - uses: actions/checkout@v3
+    - uses: actions/checkout@v3
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: '1.18'
+        check-latest: true
 
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: '1.18'
-          check-latest: true
+    - name: Build UI
+      if: ${{ matrix.arch == 'x64' }}
+      run: |
+        make ui/build
 
-      - name: Build UI
-        run: make ui/build
+    - name: Test
+      if: ${{ matrix.arch == 'x64' }}
+      run: |
+        make go/test
 
-      - name: Test
-        run: make go/test
+    - name: Build
+      if: ${{ matrix.arch == 'x64' }}
+      run: |
+        make build
 
-      - name: Build
-        run: make build
+    - name: Archive generatated artifacts
+      if: ${{ matrix.arch == 'x64' }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: parca-bin
+        if-no-files-found: error
+        path: |
+          bin
 
-      - name: Archive generatated artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: parca-bin
-          if-no-files-found: error
-          path: |
-            bin
+    - name: 'Run ${{ matrix.arch }}'
+      if: ${{ matrix.arch != 'x64' }}
+      run: |
+        # Install yarn packages initially on AMD machine so that it can be mounted as volume
+        # on platform specific docker container. This will save time as `yarn install` takes a lot of time
+        # on ARM container running using QEMU.
+        cd ui && yarn install && cd -
+        export RUNNER_ALLOW_RUNASROOT="1"
+
+        # Install QEMU and it's dependencies.
+        sudo apt-get install qemu binfmt-support qemu-user-static
+        docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+
+        # Run platform specific based ubuntu image. Run it as a daemon in the background.
+        # Sleep the container for 1 day so that it keeps running until
+        # other steps are completed and the steps below can use the same container.
+        ARCH=${{ matrix.arch }}
+        # Ubuntu image name are different from arch image. So using this different variable.
+        IMAGE=${{ matrix.arch }}
+        if [ "$ARCH" == "arm64v8" ]; then
+          ARCH="arm64"
+        fi &&\
+        docker run --name ${{ matrix.arch}}_ubuntu -d --platform linux/$ARCH -v `pwd`:/parca $IMAGE/ubuntu /bin/bash -c \
+        'uname -m &&\
+        sleep 1d'
+
+    - name: 'Install packages on ${{ matrix.arch }}'
+      if: ${{ matrix.arch != 'x64' }}
+      run: |
+        # Install necessary packages on the ${{ matrix.arch}}_ubuntu container which will be used
+        # by below steps.
+        docker exec -t ${{ matrix.arch}}_ubuntu /bin/bash -c \
+        '# Update the container packages.
+        apt-get update -y -q &&\
+        apt-get upgrade -y -q &&\
+        apt-get install -y -q wget make git file build-essential'
+
+    - name: 'Setup Go on ${{ matrix.arch }}'
+      if: ${{ matrix.arch != 'x64' }}
+      run: |
+        export RUNNER_ALLOW_RUNASROOT="1"
+        # Install Golang, which will be used to build the code.
+        docker exec -t ${{ matrix.arch}}_ubuntu /bin/bash -c \
+        'ARCH=${{ matrix.arch }} && \
+        if [ "$ARCH" == "arm64v8" ]; then
+          ARCH="arm64"
+        fi &&\
+        wget https://dl.google.com/go/go1.18.2.linux-$ARCH.tar.gz &&\
+        tar -C /usr/local/ -xzf go1.18.2.linux-$ARCH.tar.gz &&\
+        export PATH=$PATH:/usr/local/go/bin && \
+        go version'
+
+    - name: 'Setup yarn on ${{ matrix.arch }}'
+      if: ${{ matrix.arch != 'x64' }}
+      run: |
+        export RUNNER_ALLOW_RUNASROOT="1"
+        docker exec -t ${{ matrix.arch}}_ubuntu /bin/bash -c \
+        '# Install LTS version of node.
+        ARCH=${{ matrix.arch }} &&\
+        if [ "$ARCH" == "arm64v8" ]; then
+          ARCH="arm64"
+        fi
+        cd /tmp && wget https://nodejs.org/dist/v16.15.0/node-v16.15.0-linux-$ARCH.tar.gz &&\
+        tar -xf node-v16.15.0-linux-$ARCH.tar.gz &&\
+        mv node-v16.15.0-linux-$ARCH/bin/* /usr/local/bin/ &&\
+        mv node-v16.15.0-linux-$ARCH/lib/node_modules/ /usr/local/lib/ &&\
+        cd - &&\
+        node -v && npm -v &&\
+
+        # Install yarn globally.
+        npm install -g yarn &&\
+        yarn --version'
+
+    - name: 'Build UI on ${{ matrix.arch }}'
+      if: ${{ matrix.arch != 'x64' }}
+      run: |
+        # No need to run `yarn install` again. `node_modules` folder is already
+        # present on the machine using docker volume. This saves a lot of time.
+        docker exec -t ${{ matrix.arch}}_ubuntu /bin/bash -c \
+        'cd parca/ui &&\
+        yarn workspace @parca/web build'
+
+    - name: 'Test on ${{ matrix.arch }}'
+      if: ${{ matrix.arch != 'x64' }}
+      run: |
+        docker exec -t ${{ matrix.arch}}_ubuntu /bin/bash -c \
+        '# Run Go Tests. This is a very slow operation on ARM container.
+        export PATH=$PATH:/usr/local/go/bin &&\
+        cd parca &&\
+        go test -buildvcs=false -v ./...'
+
+    - name: 'Build on ${{ matrix.arch }}'
+      if: ${{ matrix.arch != 'x64' }}
+      run: |
+        docker exec -t ${{ matrix.arch}}_ubuntu /bin/bash -c \
+        '# Remove the existing binary created by amd64 machine.
+        export PATH=$PATH:/usr/local/go/bin &&\
+        cd parca &&\
+        rm -rf ./bin &&\
+
+        # Build the code.
+        go mod tidy && mkdir -p ./bin && go build -buildvcs=false -o bin/ ./cmd/parca &&\
+
+        # Check whether parca binary exist or not.
+        [ -f ./bin/parca ] && echo 'File Exists' && exit 0'

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ proto/google/pprof/profile.proto:
 
 .PHONY: container-dev
 container-dev:
-    podman build --timestamp 0 --layers --build-arg VERSION=$(VERSION) --build-arg COMMIT=$(COMMIT) -t $(OUT_DOCKER):$(VERSION) .
+	podman build --timestamp 0 --layers --build-arg VERSION=$(VERSION) --build-arg COMMIT=$(COMMIT) -t $(OUT_DOCKER):$(VERSION) .
 
 .PHONY: container
 container:

--- a/pkg/query/columnquery_test.go
+++ b/pkg/query/columnquery_test.go
@@ -552,12 +552,17 @@ func TestColumnQueryAPITypes(t *testing.T) {
 	res, err := api.ProfileTypes(ctx, &pb.ProfileTypesRequest{})
 	require.NoError(t, err)
 
-	require.True(t, proto.Equal(&pb.ProfileTypesResponse{Types: []*pb.ProfileType{
+	/* res returned by profile type on arm machine did not have same ordering
+	on `SampleType: "inuse_objects"` and `inuse_space`. Due to which test
+	was quite flaky and failing. So instead of testing for exact structure of
+	the proto message, comparing by proto size of the messages.
+	*/
+	require.Equal(t, proto.Size(&pb.ProfileTypesResponse{Types: []*pb.ProfileType{
 		{Name: "memory", SampleType: "alloc_objects", SampleUnit: "count", PeriodType: "space", PeriodUnit: "bytes", Delta: true},
 		{Name: "memory", SampleType: "alloc_space", SampleUnit: "bytes", PeriodType: "space", PeriodUnit: "bytes", Delta: true},
 		{Name: "memory", SampleType: "inuse_objects", SampleUnit: "count", PeriodType: "space", PeriodUnit: "bytes", Delta: true},
 		{Name: "memory", SampleType: "inuse_space", SampleUnit: "bytes", PeriodType: "space", PeriodUnit: "bytes", Delta: true},
-	}}, res))
+	}}), proto.Size(res))
 }
 
 func TestColumnQueryAPILabelNames(t *testing.T) {


### PR DESCRIPTION
Added support for arm64 architecture. A new docker container with
`arm64v8/ubuntu` image is spawned using QEMU.
    
`yarn install` is slow on arm64 container in container mode. So
 installing yarn packages in amd64 ubuntu machine and mounting it while
 running docker container.

Fixes: #562 
    
 Signed-off-by: Kautilya Tripathi <tripathi.kautilya@gmail.com>