### PR TITLE
Fix storage docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 * [**eBPF Profiler**](https://www.parca.dev/docs/parca-agent): A single profiler, using eBPF, automatically discovering targets from Kubernetes or systemd across the entire infrastructure with very low overhead. Supports C, C++, Rust, Go, and more!
 * **[Open Standards](https://www.parca.dev/docs/concepts/#pprof)**: Both producing pprof formatted profiles with the eBPF based profiler, and ingesting any pprof formatted profiles allowing for wide language adoption and interoperability with existing tooling.
 
-* [**Optimized Storage & Querying**](https://www.parca.dev/docs/storage/): Efficiently storing profiling data while retaining raw data and allowing slicing and dicing of data through a label-based search. Aggregate profiling data infrastructure wide, view single profiles in time or compare on any dimension.
+* [**Optimized Storage & Querying**](https://www.parca.dev/docs/storage): Efficiently storing profiling data while retaining raw data and allowing slicing and dicing of data through a label-based search. Aggregate profiling data infrastructure wide, view single profiles in time or compare on any dimension.
 
 ## Why?
 * **Save Money**: Many organizations have 20-30% of resources wasted with easily optimized code paths. The Parca Agent aims to lower the entry bar by requiring 0 instrumentation for the whole infrastructure. Deploy in your infrastructure and get started!


### PR DESCRIPTION
Fixes the broken link reported in https://github.com/parca-dev/parca/issues/1070

This is probably not the correct fix, however I'm not familiar with the docs engine you are using so I was not able to provide a fix there instead. 