### PR TITLE
pkg/parcacol: Create a pprof ingester that converts to row directly

### DIFF
--- a/pkg/parca/parca.go
+++ b/pkg/parca/parca.go
@@ -64,8 +64,9 @@ import (
 )
 
 const (
-	symbolizationInterval = 10 * time.Second
-	flagModeScraperOnly   = "scraper-only"
+	symbolizationInterval   = 10 * time.Second
+	flagModeScraperOnly     = "scraper-only"
+	metaStoreBadgerInMemory = "badgerinmemory"
 )
 
 type Flags struct {
@@ -139,15 +140,16 @@ func Run(ctx context.Context, logger log.Logger, reg *prometheus.Registry, flags
 
 	var mStr metastore.ProfileMetaStore
 	switch flags.Metastore {
-	case "badgerinmemory":
+	case metaStoreBadgerInMemory:
 		mStr = metastore.NewBadgerMetastore(
 			logger,
 			reg,
-			tracerProvider.Tracer("badgerinmemory"),
+			tracerProvider.Tracer(metaStoreBadgerInMemory),
 			metastore.NewRandomUUIDGenerator(),
 		)
 	default:
-		level.Error(logger).Log("msg", "unknown metastore implementation", "chosen", flags.Metastore)
+		err := fmt.Errorf("unknown metastore implementation: %s", flags.Metastore)
+		level.Error(logger).Log("msg", "failed to initialize metastore", "err", err)
 		return err
 	}
 

--- a/pkg/parca/parca_test.go
+++ b/pkg/parca/parca_test.go
@@ -52,12 +52,20 @@ import (
 )
 
 func benchmarkSetup(ctx context.Context, b *testing.B) (pb.ProfileStoreServiceClient, <-chan struct{}) {
+	addr := ":7077"
+
 	logger := log.NewNopLogger()
 	reg := prometheus.NewRegistry()
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		err := Run(ctx, logger, reg, &Flags{ConfigPath: "testdata/parca.yaml", Port: ":9090"}, "test-version")
+		err := Run(ctx, logger, reg, &Flags{
+			ConfigPath:          "testdata/parca.yaml",
+			Port:                addr,
+			Metastore:           metaStoreBadgerInMemory,
+			StorageGranuleSize:  8 * 1024,
+			StorageActiveMemory: 512 * 1024 * 1024,
+		}, "test-version")
 		if !errors.Is(err, context.Canceled) {
 			require.NoError(b, err)
 		}
@@ -66,14 +74,19 @@ func benchmarkSetup(ctx context.Context, b *testing.B) (pb.ProfileStoreServiceCl
 	var conn grpc.ClientConnInterface
 	err := backoff.Retry(func() error {
 		var err error
-		conn, err = grpc.Dial(":9090", grpc.WithTransportCredentials(insecure.NewCredentials()))
+		conn, err = grpc.Dial(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 		if err != nil {
+			// b.Logf("failed to connect to parca: %v", err)
 			return err
 		}
 
 		client := pb.NewProfileStoreServiceClient(conn)
 		_, err = client.WriteRaw(ctx, &pb.WriteRawRequest{})
-		return err
+		if err != nil {
+			// b.Logf("failed to connect to write raw profile: %v", err)
+			return err
+		}
+		return nil
 	}, backoff.NewConstantBackOff(time.Second))
 	require.NoError(b, err)
 
@@ -81,7 +94,9 @@ func benchmarkSetup(ctx context.Context, b *testing.B) (pb.ProfileStoreServiceCl
 	return client, done
 }
 
-func Benchmark_Parca_WriteRaw(b *testing.B) {
+// go test -bench=Benchmark_WriteRaw --count=3 --benchtime=100x -benchmem -memprofile ./pkg/parca/writeraw-memory.pb.gz -cpuprofile ./pkg/parca/writeraw-cpu.pb.gz ./pkg/parca | tee ./pkg/parca/writeraw.txt
+
+func Benchmark_WriteRaw(b *testing.B) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -90,7 +105,8 @@ func Benchmark_Parca_WriteRaw(b *testing.B) {
 	f, err := ioutil.ReadFile("testdata/alloc_objects.pb.gz")
 	require.NoError(b, err)
 
-	// Benchamrk section
+	// Benchmark section
+	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, err := client.WriteRaw(ctx, &pb.WriteRawRequest{
@@ -98,6 +114,10 @@ func Benchmark_Parca_WriteRaw(b *testing.B) {
 				{
 					Labels: &pb.LabelSet{
 						Labels: []*pb.Label{
+							{
+								Name:  labels.MetricName,
+								Value: "allocs",
+							},
 							{
 								Name:  "test",
 								Value: b.Name(),

--- a/pkg/parca/parca_test.go
+++ b/pkg/parca/parca_test.go
@@ -341,13 +341,8 @@ func TestConsistency(t *testing.T) {
 
 	p1 = p1.Compact()
 
-	p, err := parcaprofile.FromPprof(ctx, logger, m, p1, 0, false)
-	require.NoError(t, err)
-
-	_, err = parcacol.InsertProfileIntoTable(ctx, logger, table, labels.Labels{{
-		Name:  "__name__",
-		Value: "memory",
-	}}, p)
+	ingester := parcacol.NewIngester(logger, m, table)
+	err = ingester.Ingest(ctx, labels.Labels{{Name: "__name__", Value: "memory"}}, p1, false)
 	require.NoError(t, err)
 
 	table.Sync()

--- a/pkg/parca/testdata/parca.yaml
+++ b/pkg/parca/testdata/parca.yaml
@@ -3,3 +3,7 @@ debug_info:
     type: "FILESYSTEM"
     config:
       directory: "./tmp"
+  cache:
+    type: "FILESYSTEM"
+    config:
+      directory: "./tmp"

--- a/pkg/parcacol/ingest.go
+++ b/pkg/parcacol/ingest.go
@@ -1,3 +1,16 @@
+// Copyright 2022 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package parcacol
 
 import (

--- a/pkg/parcacol/ingest.go
+++ b/pkg/parcacol/ingest.go
@@ -1,0 +1,555 @@
+package parcacol
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/google/pprof/profile"
+	"github.com/google/uuid"
+	"github.com/polarsignals/arcticdb/dynparquet"
+	"github.com/prometheus/prometheus/model/labels"
+
+	pb "github.com/parca-dev/parca/gen/proto/go/parca/metastore/v1alpha1"
+	"github.com/parca-dev/parca/pkg/metastore"
+)
+
+type Table interface {
+	Schema() *dynparquet.Schema
+	InsertBuffer(context.Context, *dynparquet.Buffer) (tx uint64, err error)
+}
+
+type Ingester struct {
+	logger    log.Logger
+	table     Table
+	metaStore metastore.ProfileMetaStore // Swap with local interface
+}
+
+func NewIngester(logger log.Logger, metaStore metastore.ProfileMetaStore, table Table) *Ingester {
+	return &Ingester{logger: logger, metaStore: metaStore, table: table}
+}
+
+var ErrMissingNameLabel = errors.New("missing __name__ label")
+
+func (ing Ingester) Ingest(ctx context.Context, inLs labels.Labels, p *profile.Profile, normalized bool) error {
+	// We need to extract the name from the labels into a separate column.
+	// The labels are the same excluding the __name__.
+	var name string
+	ls := make(labels.Labels, 0, len(inLs))
+	for _, l := range inLs {
+		if l.Name == labels.MetricName {
+			name = l.Value
+		} else {
+			ls = append(ls, l)
+		}
+	}
+	if name == "" {
+		return ErrMissingNameLabel
+	}
+	sort.Sort(ls)
+
+	for i := range p.SampleType {
+		pn := &profileNormalizer{
+			logger:    ing.logger,
+			metaStore: ing.metaStore,
+
+			samples:       make(map[string]*Sample, len(p.Sample)),
+			locationsByID: make(map[uint64]*metastore.Location, len(p.Location)),
+			functionsByID: make(map[uint64]*pb.Function, len(p.Function)),
+			mappingsByID:  make(map[uint64]mapInfo, len(p.Mapping)),
+		}
+
+		if p.TimeNanos == 0 {
+			return errors.New("timestamp must not be zero")
+		}
+		if len(p.Sample) == 0 {
+			// Ignore profiles with no samples
+			continue
+		}
+
+		// meta data that all samples share
+		meta := sampleMeta{
+			Name:       name,
+			Labels:     ls,
+			SampleType: p.SampleType[i].Type,
+			SampleUnit: p.SampleType[i].Unit,
+			PeriodType: p.PeriodType.Type,
+			PeriodUnit: p.PeriodType.Unit,
+			Duration:   p.DurationNanos,
+			Period:     p.Period,
+			Timestamp:  p.TimeNanos / time.Millisecond.Nanoseconds(),
+		}
+
+		samples := make(Samples, 0, len(p.Sample))
+		for _, s := range p.Sample {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+				if isZeroSample(s) {
+					continue
+				}
+
+				// TODO: This is semantically incorrect, it is valid to have no
+				// locations in pprof. This needs to be fixed once we remove the
+				// stacktrace UUIDs since location IDs are going to be saved directly
+				// in the columnstore.
+				if len(s.Location) == 0 {
+					continue
+				}
+
+				sample, _, err := pn.mapSample(ctx, s, meta, i, normalized)
+				if err != nil {
+					return err
+				}
+
+				samples = append(samples, sample)
+			}
+		}
+
+		buffer, err := samples.ToBuffer(Schema())
+		if err != nil {
+			return fmt.Errorf("failed to convert samples to buffer: %w", err)
+		}
+
+		buffer.Sort()
+
+		// This is necessary because sorting a buffer makes concurrent reading not
+		// safe as the internal pages are cyclically sorted at read time. Cloning
+		// executes the cyclic sort once and makes the resulting buffer safe for
+		// concurrent reading as it no longer has to perform the cyclic sorting at
+		// read time. This should probably be improved in the parquet library.
+		buffer, err = buffer.Clone()
+		if err != nil {
+			return err
+		}
+
+		_, err = ing.table.InsertBuffer(ctx, buffer)
+		if err != nil {
+			return fmt.Errorf("failed to insert buffer: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func isZeroSample(s *profile.Sample) bool {
+	for _, v := range s.Value {
+		if v != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+type profileNormalizer struct {
+	logger    log.Logger
+	metaStore metastore.ProfileMetaStore
+
+	samples map[string]*Sample
+	// Memoization tables within a profile.
+	locationsByID map[uint64]*metastore.Location
+	functionsByID map[uint64]*pb.Function
+	mappingsByID  map[uint64]mapInfo
+}
+
+type mapInfo struct {
+	m      *pb.Mapping
+	offset int64
+}
+
+type sampleMeta struct {
+	Name       string
+	Labels     labels.Labels
+	SampleType string
+	SampleUnit string
+	PeriodType string
+	PeriodUnit string
+	Period     int64
+	Duration   int64
+	Timestamp  int64
+}
+
+func (pn *profileNormalizer) mapSample(ctx context.Context, s *profile.Sample, meta sampleMeta, index int, normalized bool) (*Sample, bool, error) {
+	sn := &sampleNormalizer{
+		Location: make([]*metastore.Location, len(s.Location)),
+		Label:    make(map[string]string, len(s.Label)),
+		NumLabel: make(map[string]int64, len(s.NumLabel)),
+		NumUnit:  make(map[string]string, len(s.NumLabel)),
+	}
+
+	var err error
+	for i, l := range s.Location {
+		select {
+		case <-ctx.Done():
+			return nil, false, ctx.Err()
+		default:
+			sn.Location[i], err = pn.mapLocation(ctx, l, normalized)
+			if err != nil {
+				return nil, false, err
+			}
+		}
+	}
+	for k, v := range s.Label {
+		if len(v) == 1 {
+			sn.Label[k] = v[0]
+		}
+	}
+	for k, v := range s.NumLabel {
+		if len(v) == 1 {
+			sn.NumLabel[k] = v[0]
+		}
+		u := s.NumUnit[k]
+		if len(u) == 1 {
+			sn.NumUnit[k] = u[0]
+		}
+	}
+
+	// Check memoization table. Must be done on the remapped location to
+	// account for the remapped mapping. Add current values to the
+	// existing sample.
+	k := makeStacktraceKey(sn)
+
+	stacktraceUUID, err := pn.metaStore.GetStacktraceByKey(ctx, k)
+	if err != nil && err != metastore.ErrStacktraceNotFound {
+		return nil, false, err
+	}
+
+	if stacktraceUUID == uuid.Nil {
+		pbs := &pb.Sample{}
+		pbs.LocationIds = make([][]byte, 0, len(sn.Location))
+		for _, l := range sn.Location {
+			pbs.LocationIds = append(pbs.LocationIds, l.ID[:])
+		}
+
+		pbs.Labels = make(map[string]*pb.SampleLabel, len(sn.Label))
+		for l, strings := range sn.Label {
+			pbs.Labels[l] = &pb.SampleLabel{Labels: []string{strings}}
+		}
+
+		pbs.NumLabels = make(map[string]*pb.SampleNumLabel, len(sn.NumLabel))
+		for l, int64s := range sn.NumLabel {
+			pbs.NumLabels[l] = &pb.SampleNumLabel{NumLabels: []int64{int64s}}
+		}
+
+		pbs.NumUnits = make(map[string]*pb.SampleNumUnit, len(sn.NumUnit))
+		for l, strings := range sn.NumUnit {
+			pbs.NumUnits[l] = &pb.SampleNumUnit{Units: []string{strings}}
+		}
+
+		stacktraceUUID, err = pn.metaStore.CreateStacktrace(ctx, k, pbs)
+		if err != nil {
+			return nil, false, err
+		}
+	}
+
+	sa, found := pn.samples[string(stacktraceUUID[:])]
+	if found {
+		sa.Value += s.Value[index]
+		return sa, false, nil
+	}
+
+	pn.samples[string(stacktraceUUID[:])] = &Sample{
+		Name:       meta.Name,
+		Labels:     meta.Labels,
+		Duration:   meta.Duration,
+		Period:     meta.Period,
+		PeriodType: meta.PeriodType,
+		PeriodUnit: meta.PeriodUnit,
+		SampleType: meta.SampleType,
+		SampleUnit: meta.SampleUnit,
+		Timestamp:  meta.Timestamp,
+
+		Stacktrace:     stacktraceUUID[:],
+		PprofLabels:    sn.Label,
+		PprofNumLabels: sn.NumLabel,
+		Value:          s.Value[index],
+	}
+
+	return pn.samples[string(stacktraceUUID[:])], true, nil
+}
+
+type sampleNormalizer struct {
+	Location []*metastore.Location
+	Label    map[string]string
+	NumLabel map[string]int64
+	NumUnit  map[string]string
+}
+
+func (pn *profileNormalizer) mapLocation(ctx context.Context, src *profile.Location, normalized bool) (*metastore.Location, error) {
+	if src == nil {
+		return nil, nil
+	}
+
+	if l, ok := pn.locationsByID[src.ID]; ok {
+		return l, nil
+	}
+
+	mi, err := pn.mapMapping(ctx, src.Mapping)
+	if err != nil {
+		return nil, err
+	}
+
+	var addr uint64
+	if !normalized {
+		addr = uint64(int64(src.Address) + mi.offset)
+	} else {
+		addr = src.Address
+	}
+
+	l := &metastore.Location{
+		Mapping:  mi.m,
+		Address:  addr,
+		Lines:    make([]metastore.LocationLine, len(src.Line)),
+		IsFolded: src.IsFolded,
+	}
+	for i, ln := range src.Line {
+		l.Lines[i], err = pn.mapLine(ctx, ln)
+		if err != nil {
+			return nil, err
+		}
+	}
+	// Check memoization table. Must be done on the remapped location to
+	// account for the remapped mapping ID.
+	loc, err := metastore.GetLocationByKey(ctx, pn.metaStore, l)
+	if err != nil && err != metastore.ErrLocationNotFound {
+		return nil, err
+	}
+	if loc != nil {
+		pn.locationsByID[src.ID] = loc
+		return loc, nil
+	}
+	pn.locationsByID[src.ID] = l
+
+	id, err := pn.metaStore.CreateLocation(ctx, l)
+	if err != nil {
+		return nil, err
+	}
+
+	l.ID, err = uuid.FromBytes(id)
+	if err != nil {
+		return nil, err
+	}
+
+	return l, nil
+}
+
+func (pn *profileNormalizer) mapMapping(ctx context.Context, src *profile.Mapping) (mapInfo, error) {
+	if src == nil {
+		return mapInfo{}, nil
+	}
+
+	if mi, ok := pn.mappingsByID[src.ID]; ok {
+		return mi, nil
+	}
+
+	// Check memoization tables.
+	m, err := pn.metaStore.GetMappingByKey(ctx, &pb.Mapping{
+		Start:   src.Start,
+		Limit:   src.Limit,
+		Offset:  src.Offset,
+		File:    src.File,
+		BuildId: src.BuildID,
+	})
+	if err != nil && err != metastore.ErrMappingNotFound {
+		return mapInfo{}, err
+	}
+	if m != nil {
+		// NOTICE: We only store a single version of a mapping.
+		// Which means the m.Start actually correct for a single process.
+		// For a multi-process shared library, this will always be wrong.
+		// And storing the mapping for each process will be very expensive.
+		// Which is why the client sending the profiling data can choose to normalize the addresses for each process.
+		// In a future iteration of the wire format, the computed base address for each mapping should be included
+		// to prevent this dilemma or forcing the client to be smart in one direction or the other.
+		mi := mapInfo{m, int64(src.Start) - int64(m.Start)}
+		pn.mappingsByID[src.ID] = mi
+		return mi, nil
+	}
+	m = &pb.Mapping{
+		Start:           src.Start,
+		Limit:           src.Limit,
+		Offset:          src.Offset,
+		File:            src.File,
+		BuildId:         src.BuildID,
+		HasFunctions:    src.HasFunctions,
+		HasFilenames:    src.HasFilenames,
+		HasLineNumbers:  src.HasLineNumbers,
+		HasInlineFrames: src.HasInlineFrames,
+	}
+
+	// Update memoization tables.
+	id, err := pn.metaStore.CreateMapping(ctx, m)
+	if err != nil {
+		return mapInfo{}, err
+	}
+	m.Id = id
+	mi := mapInfo{m, 0}
+	pn.mappingsByID[src.ID] = mi
+	return mi, nil
+}
+
+func (pn *profileNormalizer) mapLine(ctx context.Context, src profile.Line) (metastore.LocationLine, error) {
+	f, err := pn.mapFunction(ctx, src.Function)
+	if err != nil {
+		return metastore.LocationLine{}, err
+	}
+
+	return metastore.LocationLine{
+		Function: f,
+		Line:     src.Line,
+	}, nil
+}
+
+func (pn *profileNormalizer) mapFunction(ctx context.Context, src *profile.Function) (*pb.Function, error) {
+	if src == nil {
+		return nil, nil
+	}
+	if f, ok := pn.functionsByID[src.ID]; ok {
+		return f, nil
+	}
+	f, err := pn.metaStore.GetFunctionByKey(ctx, &pb.Function{
+		Name:       src.Name,
+		SystemName: src.SystemName,
+		Filename:   src.Filename,
+		StartLine:  src.StartLine,
+	})
+	if err != nil && err != metastore.ErrFunctionNotFound {
+		return nil, err
+	}
+	if f != nil {
+		pn.functionsByID[src.ID] = f
+		return f, nil
+	}
+	f = &pb.Function{
+		Name:       src.Name,
+		SystemName: src.SystemName,
+		Filename:   src.Filename,
+		StartLine:  src.StartLine,
+	}
+
+	id, err := pn.metaStore.CreateFunction(ctx, f)
+	if err != nil {
+		return nil, err
+	}
+	f.Id = id
+
+	pn.functionsByID[src.ID] = f
+	return f, nil
+}
+
+type stacktraceKey []byte
+
+// makeStacktraceKey generates stacktraceKey to be used as a key for maps.
+func makeStacktraceKey(sample *sampleNormalizer) stacktraceKey {
+	numLocations := len(sample.Location)
+	if numLocations == 0 {
+		return []byte{}
+	}
+
+	locationLength := (16 * numLocations) + (numLocations - 1)
+
+	labelsLength := 0
+	// TODO
+	//labelName := make([]string, 0, len(sample.Label))
+	//for l, vs := range sample.Label {
+	//	labelName = append(labelName, l)
+	//
+	//	labelsLength += len(l) + 2 // +2 for the quotes
+	//	for _, v := range vs {
+	//		labelsLength += len(v) + 2 // +2 for the quotes
+	//	}
+	//	labelsLength += len(vs) - 1 // spaces
+	//	labelsLength += 2           // square brackets
+	//}
+	//sort.Strings(labelName)
+
+	numLabelsLength := 0
+	// TODO
+	//numLabelNames := make([]string, 0, len(sample.NumLabel))
+	//for l, int64s := range sample.NumLabel {
+	//	numLabelNames = append(numLabelNames, l)
+	//
+	//	numLabelsLength += len(l) + 2      // +2 for the quotes
+	//	numLabelsLength += 2               // square brackets
+	//	numLabelsLength += 8 * len(int64s) // 8*8=64bit
+	//
+	//	if len(sample.NumUnit[l]) > 0 {
+	//		for i := range int64s {
+	//			numLabelsLength += len(sample.NumUnit[l][i]) + 2 // numUnit string +2 for quotes
+	//		}
+	//
+	//		numLabelsLength += 2               // square brackets
+	//		numLabelsLength += len(int64s) - 1 // spaces
+	//	}
+	//}
+	//sort.Strings(numLabelNames)
+
+	length := locationLength + labelsLength + numLabelsLength
+	key := make([]byte, 0, length)
+
+	for i, l := range sample.Location {
+		key = append(key, l.ID[:]...)
+		if i != len(sample.Location)-1 {
+			key = append(key, '|')
+		}
+	}
+
+	// TODO
+	//for i := 0; i < len(sample.Label); i++ {
+	//	l := labelName[i]
+	//	vs := sample.Label[l]
+	//	key = append(key, '"')
+	//	key = append(key, l...)
+	//	key = append(key, '"')
+	//
+	//	key = append(key, '[')
+	//	for i, v := range vs {
+	//		key = append(key, '"')
+	//		key = append(key, v...)
+	//		key = append(key, '"')
+	//		if i != len(vs)-1 {
+	//			key = append(key, ' ')
+	//		}
+	//	}
+	//	key = append(key, ']')
+	//}
+
+	// TODO
+	//for i := 0; i < len(sample.NumLabel); i++ {
+	//	l := numLabelNames[i]
+	//	int64s := sample.NumLabel[l]
+	//
+	//	key = append(key, '"')
+	//	key = append(key, l...)
+	//	key = append(key, '"')
+	//
+	//	key = append(key, '[')
+	//	for _, v := range int64s {
+	//		// Writing int64 to pre-allocated key by shifting per byte
+	//		for shift := 56; shift >= 0; shift -= 8 {
+	//			key = append(key, byte(v>>shift))
+	//		}
+	//	}
+	//	key = append(key, ']')
+	//
+	//	key = append(key, '[')
+	//	for i := range int64s {
+	//		if len(sample.NumUnit[l]) > 0 {
+	//			s := sample.NumUnit[l][i]
+	//			key = append(key, '"')
+	//			key = append(key, s...)
+	//			key = append(key, '"')
+	//			if i != len(int64s)-1 {
+	//				key = append(key, ' ')
+	//			}
+	//		}
+	//	}
+	//	key = append(key, ']')
+	//}
+
+	return key
+}

--- a/pkg/parcacol/ingest_test.go
+++ b/pkg/parcacol/ingest_test.go
@@ -1,3 +1,16 @@
+// Copyright 2022 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package parcacol
 
 import (

--- a/pkg/parcacol/ingest_test.go
+++ b/pkg/parcacol/ingest_test.go
@@ -1,0 +1,69 @@
+package parcacol
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/parca-dev/parca/pkg/metastore"
+)
+
+func TestMakeStacktraceKey(t *testing.T) {
+	g := metastore.NewLinearUUIDGenerator()
+
+	s := &SampleNormalizer{
+		Location: []*metastore.Location{{ID: g.New()}, {ID: g.New()}, {ID: g.New()}},
+		Label:    map[string]string{"foo": "bar", "bar": "baz"},
+		NumLabel: map[string]int64{"foo": 1},
+		NumUnit:  map[string]string{"foo": "cpu"},
+	}
+
+	k := []byte(MakeStacktraceKey(s))
+
+	require.Len(t, k, 94)
+
+	require.Equal(t,
+		[]byte{
+			0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
+			'|',
+			0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2,
+			'|',
+			0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x3,
+		},
+		k[0:50],
+	)
+
+	require.Equal(t,
+		[]byte(`"bar":"baz""foo":"bar"`),
+		k[50:72],
+	)
+
+	require.Equal(t,
+		[]byte{
+			'"', 'f', 'o', 'o', '"',
+			':', '{',
+			'"', 'c', 'p', 'u', '"',
+			':',
+			0, 0, 0, 0, 0, 0, 0, 1,
+			'}',
+		},
+		k[72:],
+	)
+}
+
+func BenchmarkMakeStacktraceKey(b *testing.B) {
+	g := metastore.NewLinearUUIDGenerator()
+	s := &SampleNormalizer{
+		Location: []*metastore.Location{{ID: g.New()}, {ID: g.New()}, {ID: g.New()}},
+		Label:    map[string]string{"foo": "bar"},
+		NumLabel: map[string]int64{"foo": 1},
+		NumUnit:  map[string]string{"foo": "cpu"},
+	}
+
+	b.ReportAllocs()
+	b.StartTimer()
+
+	for i := 0; i < b.N; i++ {
+		_ = MakeStacktraceKey(s)
+	}
+}

--- a/pkg/parcacol/parcacol.go
+++ b/pkg/parcacol/parcacol.go
@@ -27,11 +27,6 @@ import (
 	parcaprofile "github.com/parca-dev/parca/pkg/profile"
 )
 
-type Table interface {
-	Schema() *dynparquet.Schema
-	InsertBuffer(context.Context, *dynparquet.Buffer) (tx uint64, err error)
-}
-
 func InsertProfileIntoTable(ctx context.Context, logger log.Logger, table Table, ls labels.Labels, prof *parcaprofile.Profile) (int, error) {
 	if prof.Meta.Timestamp == 0 {
 		return 0, errors.New("timestamp must not be zero")
@@ -45,8 +40,6 @@ func InsertProfileIntoTable(ctx context.Context, logger log.Logger, table Table,
 	_, err = table.InsertBuffer(ctx, buf)
 	return len(prof.FlatSamples), err
 }
-
-var ErrMissingNameLabel = errors.New("missing __name__ label")
 
 func FlatProfileToBuffer(logger log.Logger, inLs labels.Labels, schema *dynparquet.Schema, prof *parcaprofile.Profile) (*dynparquet.Buffer, error) {
 	rows, err := FlatProfileToRows(inLs, prof)
@@ -108,7 +101,7 @@ func FlatProfileToRows(inLs labels.Labels, prof *parcaprofile.Profile) (Samples,
 			pprofNumLabels[name] = values[0]
 		}
 
-		rows = append(rows, Sample{
+		rows = append(rows, &Sample{
 			Name:           name,
 			SampleType:     prof.Meta.SampleType.Type,
 			SampleUnit:     prof.Meta.SampleType.Unit,

--- a/pkg/parcacol/sample.go
+++ b/pkg/parcacol/sample.go
@@ -40,7 +40,7 @@ type Sample struct {
 	Value          int64
 }
 
-type Samples []Sample
+type Samples []*Sample
 
 func (s Samples) ToBuffer(schema *dynparquet.Schema) (*dynparquet.Buffer, error) {
 	names := s.SampleLabelNames()

--- a/pkg/query/columnquery.go
+++ b/pkg/query/columnquery.go
@@ -674,6 +674,7 @@ func (q *ColumnQueryAPI) diffRequest(ctx context.Context, d *pb.DiffProfile, rep
 	// TODO: This is cheating a bit. This should be done with a sub-query in the columnstore.
 	diff := &profile.StacktraceSamples{}
 
+	// TODO: Use parcacol.Sample for comparing these
 	for i := range compare.Samples {
 		diff.Samples = append(diff.Samples, &profile.Sample{
 			Location:  compare.Samples[i].Location,

--- a/pkg/query/columnquery_test.go
+++ b/pkg/query/columnquery_test.go
@@ -603,6 +603,7 @@ func TestColumnQueryAPILabelNames(t *testing.T) {
 		Name:  "job",
 		Value: "default",
 	}}, p, false)
+	require.NoError(t, err)
 
 	api := NewColumnQueryAPI(
 		logger,
@@ -665,6 +666,7 @@ func TestColumnQueryAPILabelValues(t *testing.T) {
 		Name:  "job",
 		Value: "default",
 	}}, p, false)
+	require.NoError(t, err)
 
 	api := NewColumnQueryAPI(
 		logger,


### PR DESCRIPTION
WriteRaw requests have been the bottleneck in the last weeks as profiles have shown.
Since the migration to columnar storage we don't need the FlatProfiles anymore and now convert pprof profiles into columnar rows directly. 

```
name          old time/op    new time/op    delta
_WriteRaw-24     1.03s ± 2%     0.95s ± 3%   ~     (p=0.100 n=3+3)

name          old alloc/op   new alloc/op   delta
_WriteRaw-24    3.28GB ± 2%    2.97GB ± 4%   ~     (p=0.100 n=3+3)

name          old allocs/op  new allocs/op  delta
_WriteRaw-24     3.56M ± 0%     3.47M ± 0%   ~     (p=0.100 n=3+3)
```

Two things are missing for this to be merged:
- [x] Rebase for newer parquet-go changes
- [x] Add the pprof labels back to the StacktraceKey