### PR TITLE
actions: Fix build and push job for arm64

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -41,8 +41,8 @@ jobs:
       # To build multi-arch images, see also: https://github.com/redhat-actions/buildah-build#multi-arch-builds
       - name: Install qemu dependency
         run: |
-          sudo apt-get update
-          sudo apt-get install -y qemu-user-static
+          sudo apt-get update -y
+          sudo apt-get install -y binfmt-support qemu-user-static
 
       - name: Build container
         run: make container

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /app
 COPY ui/packages/shared ./packages/shared
 COPY ui/packages/app/web/package.json ./packages/app/web/package.json
 COPY ui/package.json ui/yarn.lock ./
-RUN yarn workspace @parca/web install --frozen-lockfile
+RUN yarn workspace @parca/web install --frozen-lockfile --network-timeout 100000
 
 # Rebuild the source code only when needed
 FROM ${NODE_BUILDER_BASE} AS ui-builder

--- a/scripts/make-containers.sh
+++ b/scripts/make-containers.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set +x
+set +eox pipefail
 
 VERSION="$1"
 COMMIT="$2"

--- a/scripts/make-containers.sh
+++ b/scripts/make-containers.sh
@@ -23,7 +23,7 @@ DOCKER_NODE_ALPINE_SHAS=(
 # SHA order is respectively ('amd64' 'arm64')
 # this image is what docker.io/alpine:3.15.4 on May 11 2022.
 # Here is how to obtain the digests:
-# for r in amd64 arm64v8 arm32v6 arm32v7 i386; do docker pull $r/alpine:3.15.4 | grep Digest; done
+# for r in amd64 arm64v8; do docker pull $r/alpine:3.15.4 | grep Digest; done
 DOCKER_ALPINE_SHAS=(
     'docker.io/alpine@sha256:a777c9c66ba177ccfea23f2a216ff6721e78a662cd17019488c417135299cd89'
     'docker.io/alpine@sha256:f3bec467166fd0e38f83ff32fb82447f5e89b5abd13264a04454c75e11f1cdc6'


### PR DESCRIPTION
To run arm64 arch, QEMU is used. `qemu binfmt-support` packages are
required qemu dependency.

While building container images for arm64 the network is slow due to
container in container mode and yarn install fails if the packages are
big as default retry timeourt is 30sec. Increasing it fixes the issue.

Signed-off-by: Kautilya Tripathi <tripathi.kautilya@gmail.com>