### PR TITLE
removes deprecated flags since switch to arcticdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,6 @@ Flags:
       --mutex-profile-fraction=0
                                    Fraction of mutex profile samples to collect.
       --block-profile-rate=0       Sample rate for block profile.
-      --storage-tsdb-retention-time=6h
-                                   How long to retain samples in storage.
-      --storage="tsdb"             Storage type to use.
       --storage-debug-value-log    Log every value written to the database into
                                    a separate file. This is only for debugging
                                    purposes to produce data to replay situations

--- a/pkg/parca/parca.go
+++ b/pkg/parca/parca.go
@@ -82,13 +82,9 @@ type Flags struct {
 	MutexProfileFraction int `default:"0" help:"Fraction of mutex profile samples to collect."`
 	BlockProfileRate     int `default:"0" help:"Sample rate for block profile."`
 
-	StorageTSDBRetentionTime    time.Duration `default:"6h" help:"How long to retain samples in storage."`
-	StorageTSDBExpensiveMetrics bool          `default:"false" help:"Enable really heavy metrics. Only do this for debugging as the metrics are slowing Parca down by a lot." hidden:"true"`
-
-	Storage              string `default:"tsdb" enum:"columnstore,tsdb" help:"Storage type to use."`
-	StorageDebugValueLog bool   `default:"false" help:"Log every value written to the database into a separate file. This is only for debugging purposes to produce data to replay situations in tests."`
-	StorageGranuleSize   int    `default:"8196" help:"Granule size for storage."`
-	StorageActiveMemory  int64  `default:"536870912" help:"Amount of memory to use for active storage. Defaults to 512MB."`
+	StorageDebugValueLog bool  `default:"false" help:"Log every value written to the database into a separate file. This is only for debugging purposes to produce data to replay situations in tests."`
+	StorageGranuleSize   int   `default:"8196" help:"Granule size for storage."`
+	StorageActiveMemory  int64 `default:"536870912" help:"Amount of memory to use for active storage. Defaults to 512MB."`
 
 	SymbolizerDemangleMode  string `default:"simple" help:"Mode to demangle C++ symbols. Default mode is simplified: no parameters, no templates, no return type" enum:"simple,full,none,templates"`
 	SymbolizerNumberOfTries int    `default:"3" help:"Number of tries to attempt to symbolize an unsybolized location"`


### PR DESCRIPTION
These flags are no longer valid since we've moved to arcticdb as the only option.