### PR TITLE
Gate avx2 instructions support for parquet-go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,10 @@ else
 endif
 VERSION ?= $(if $(RELEASE_TAG),$(RELEASE_TAG),$(shell $(CMD_GIT) describe --tags 2>/dev/null || echo '$(BRANCH)$(COMMIT)'))
 OUT_DOCKER ?= ghcr.io/parca-dev/parca
+HAVE_AVX2 := $(shell grep avx2 /proc/cpuinfo)
+ifneq ($(.SHELLSTATUS),0)
+	GO_BUILD_TAGS := -tags purego
+endif
 
 .PHONY: build
 build: ui/build go/bin
@@ -34,7 +38,7 @@ go/deps:
 .PHONY: go/bin
 go/bin: go/deps
 	mkdir -p ./bin
-	go build -o bin/ ./cmd/parca
+	go build $(GO_BUILD_TAGS) -o bin/ ./cmd/parca
 
 .PHONY: format
 format: go/fmt proto/format check-license


### PR DESCRIPTION
Some CPUs / hypervisors don't have avx2 support. This PR gates using
this feature in the parquet-go library during compilation depending
on whether the CPU has this feature

Thanks, @achille-roussel for the hint! (https://github.com/segmentio/parquet-go/issues/189#issuecomment-1147093453) 😄 

This is a remediation for: https://github.com/parca-dev/parca/issues/1062

## Test plan 

- With no avx2 support
```shell
$ make 
[...]
go build -tags purego -o bin/ ./cmd/parca
```

Ran the binary for several minutes with parca-agent sending profiles without any issues

- With avx2 support
```shell
$ make 
[...]
go build  -o bin/ ./cmd/parca
```

@jorgelbg could you please confirm if this fixes the issue for you as well? Thanks!
