### PR TITLE
area/ui: Fix the Icicle graph bug for Firefox browsers

### DIFF
--- a/ui/packages/shared/profile/src/IcicleGraph.tsx
+++ b/ui/packages/shared/profile/src/IcicleGraph.tsx
@@ -521,8 +521,9 @@ export default function IcicleGraph({
       />
       <svg
         className="font-robotoMono"
+        width={width}
+        height={height}
         onMouseMove={onMouseMove}
-        viewBox={`0 0 ${width} ${height}`}
         preserveAspectRatio="xMinYMid"
         ref={svg}
       >


### PR DESCRIPTION
As spotted by @/kura on [Discord](https://discord.com/channels/877547706334199818/877547706334199821/981906552095146034), the Icicle graph seemed to not show up at all on Firefox browsers.

After investigating a bit, I modified the IcicleGraph's component `svg` element to get its width & height from the respective width and height property as opposed to using the `viewBox` property and that makes the graph show up now in the Firefox browser. I also did a test across different browsers to ensure it works.

<img width="1770" alt="Screenshot 2022-06-07 at 15 26 36" src="https://user-images.githubusercontent.com/9016992/172391853-f7caaa9d-f386-421b-9b57-ae7fbbeca13d.png">

Fixes #1130 