### PR TITLE
Fix panic if QueryRange doesn't contain __name__

### DIFF
--- a/pkg/query/columnquery.go
+++ b/pkg/query/columnquery.go
@@ -195,10 +195,10 @@ func queryToFilterExprs(query string) ([]logicalplan.Expr, error) {
 		return nil, status.Error(codes.InvalidArgument, "failed to parse query")
 	}
 
-	sel := make([]*labels.Matcher, 0, len(parsedSelector)-1)
+	sel := make([]*labels.Matcher, 0, len(parsedSelector))
 	var nameLabel *labels.Matcher
 	for _, matcher := range parsedSelector {
-		if matcher.Name == "__name__" {
+		if matcher.Name == labels.MetricName {
 			nameLabel = matcher
 		} else {
 			sel = append(sel, matcher)


### PR DESCRIPTION
If a query does not contain a `__name__` label this code would have previously panicked.
Now there won't be a panic, but the error in line 208 would actually be returned.

Fixes #1134 