### PR TITLE
Add Debuginfo metadata

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -5,4 +5,4 @@ go install github.com/campoy/embedmd@latest
 
 go install mvdan.cc/gofumpt@latest
 
-go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.0
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2

--- a/pkg/debuginfo/metadata.go
+++ b/pkg/debuginfo/metadata.go
@@ -1,0 +1,165 @@
+// Copyright 2022 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package debuginfo
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"path"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/thanos-io/objstore"
+)
+
+var (
+	logger                                     log.Logger
+	ErrDebugInfoMetadataShouldExist            = errors.New("debug info metadata should exist")
+	ErrDebugInfoMetadataExpectedStateUploading = errors.New("debug info metadata state should be uploading")
+)
+
+type metadataState int64
+
+const (
+	// There was an unexpected error. The error will be filled in in the return
+	// value
+	metadataStateError metadataState = iota
+	// There's no debug info metadata. This could mean that an older Parca version
+	// uploaded the debug info files, but there's not record of the metadata, yet.
+	metadataStateEmpty
+	// The debug info file is being uploaded.
+	metadataStateUploading
+	// The debug info file is fully uploaded.
+	metadataStateUploaded
+)
+
+func setMetadataLogger(l log.Logger) {
+	logger = log.With(l, "component", "debuginfo-metadata")
+}
+
+func (m metadataState) String() string {
+	d := map[metadataState]string{
+		metadataStateError:     "METADATA_STATE_ERROR",
+		metadataStateEmpty:     "METADATA_STATE_EMTPY",
+		metadataStateUploading: "METADATA_STATE_UPLOADING",
+		metadataStateUploaded:  "METADATA_STATE_UPLOADED",
+	}
+
+	val, ok := d[m]
+	if !ok {
+		return "<not found>"
+	}
+	return val
+}
+
+type DebugInfoMetadata struct {
+	State            metadataState `json:"state"`
+	StartedUploadAt  int64         `json:"started_upload_at"`
+	FinishedUploadAt int64         `json:"finished_upload_at"`
+}
+
+func metadataUpdate(ctx context.Context, bucket objstore.Bucket, buildID string, state metadataState) error {
+	level.Debug(logger).Log("msg", "Attempting state update to", "state", state)
+
+	switch state {
+	case metadataStateUploading:
+		_, err := bucket.Get(ctx, metadataPath(buildID))
+		// The metadata file should not exist yet. Not erroring here because there's
+		// room for a race condition.
+		if err == nil {
+			level.Info(logger).Log("msg", "There should not be a metadata file")
+			return nil
+		}
+
+		if !bucket.IsObjNotFoundErr(err) {
+			level.Error(logger).Log("msg", "Expected IsObjNotFoundErr but got", "err", err)
+			return err
+		}
+
+		// Let's write the metadata.
+		metadataBytes, _ := json.MarshalIndent(&DebugInfoMetadata{
+			State:           metadataStateUploading,
+			StartedUploadAt: time.Now().Unix(),
+		}, "", "\t")
+		r := bytes.NewReader(metadataBytes)
+		if err := bucket.Upload(ctx, metadataPath(buildID), r); err != nil {
+			level.Error(logger).Log("msg", "Creating the metadata file failed", "err", err)
+			return err
+		}
+
+	case metadataStateUploaded:
+		r, err := bucket.Get(ctx, metadataPath(buildID))
+		if err != nil {
+			level.Error(logger).Log("msg", "Expected metadata file", "err", err)
+			return ErrDebugInfoMetadataShouldExist
+		}
+		buf := new(bytes.Buffer)
+		_, err = buf.ReadFrom(r)
+		if err != nil {
+			level.Error(logger).Log("msg", "ReadFrom failed", "err", err)
+			return err
+		}
+
+		metaData := &DebugInfoMetadata{}
+
+		if err := json.Unmarshal(buf.Bytes(), metaData); err != nil {
+			level.Error(logger).Log("msg", "Parsing JSON metadata failed", "err", err)
+			return err
+		}
+
+		// There's a small window where a race could happen.
+		if metaData.State == metadataStateUploaded {
+			return nil
+		}
+
+		if metaData.State != metadataStateUploading {
+			return ErrDebugInfoMetadataExpectedStateUploading
+		}
+
+		metaData.State = metadataStateUploaded
+		metaData.FinishedUploadAt = time.Now().Unix()
+
+		metadataBytes, _ := json.MarshalIndent(&metaData, "", "\t")
+		newData := bytes.NewReader(metadataBytes)
+
+		if err := bucket.Upload(ctx, metadataPath(buildID), newData); err != nil {
+			return err
+		}
+
+	}
+	return nil
+}
+
+func fetchMetadataState(ctx context.Context, bucket objstore.Bucket, buildID string) (metadataState, error) {
+	r, err := bucket.Get(ctx, metadataPath(buildID))
+	if err != nil {
+		return metadataStateEmpty, nil
+	}
+
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(r)
+
+	metaData := &DebugInfoMetadata{}
+	if err := json.Unmarshal(buf.Bytes(), metaData); err != nil {
+		return metadataStateError, err
+	}
+	return metaData.State, nil
+}
+
+func metadataPath(buildID string) string {
+	return path.Join(buildID, "metadata")
+}

--- a/pkg/debuginfo/metadata_test.go
+++ b/pkg/debuginfo/metadata_test.go
@@ -86,12 +86,12 @@ func TestMetadata_MarshalJSON(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			m:    metadata{State: metadataStateEmpty},
-			want: `{"state":"METADATA_STATE_EMPTY","started_upload_at":0,"finished_upload_at":0}`,
+			m:    metadata{State: metadataStateUnknown},
+			want: `{"state":"METADATA_STATE_UNKNOWN","started_upload_at":0,"finished_upload_at":0}`,
 		},
 		{
-			m:    metadata{State: metadataStateError},
-			want: `{"state":"METADATA_STATE_ERROR","started_upload_at":0,"finished_upload_at":0}`,
+			m:    metadata{State: metadataStateEmpty},
+			want: `{"state":"METADATA_STATE_EMPTY","started_upload_at":0,"finished_upload_at":0}`,
 		},
 		{
 			m:    metadata{State: metadataStateUploading},
@@ -125,12 +125,12 @@ func TestMetadata_UnmarshalJSON(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			b:    []byte(`{"state":"METADATA_STATE_EMPTY","started_upload_at":0,"finished_upload_at":0}`),
-			want: metadata{State: metadataStateEmpty},
+			b:    []byte(`{"state":"METADATA_STATE_UNKNOWN","started_upload_at":0,"finished_upload_at":0}`),
+			want: metadata{State: metadataStateUnknown},
 		},
 		{
-			b:    []byte(`{"state":"METADATA_STATE_ERROR","started_upload_at":0,"finished_upload_at":0}`),
-			want: metadata{State: metadataStateError},
+			b:    []byte(`{"state":"METADATA_STATE_EMPTY","started_upload_at":0,"finished_upload_at":0}`),
+			want: metadata{State: metadataStateEmpty},
 		},
 		{
 			b:    []byte(`{"state":"METADATA_STATE_UPLOADING","started_upload_at":0,"finished_upload_at":0}`),

--- a/pkg/debuginfo/metadata_test.go
+++ b/pkg/debuginfo/metadata_test.go
@@ -1,0 +1,78 @@
+// Copyright 2021 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package debuginfo
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/parca-dev/parca/pkg/symbol"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/objstore/client"
+	"github.com/thanos-io/objstore/filesystem"
+)
+
+func TestMetadata(t *testing.T) {
+	dir, err := ioutil.TempDir("", "parca-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	cacheDir, err := ioutil.TempDir("", "parca-test-cache")
+	require.NoError(t, err)
+	defer os.RemoveAll(cacheDir)
+
+	logger := log.NewNopLogger()
+	sym, err := symbol.NewSymbolizer(logger)
+	require.NoError(t, err)
+
+	cfg := &Config{
+		Bucket: &client.BucketConfig{
+			Type: client.FILESYSTEM,
+			Config: filesystem.Config{
+				Directory: dir,
+			},
+		},
+		Cache: &CacheConfig{
+			Type: FILESYSTEM,
+			Config: &FilesystemCacheConfig{
+				Directory: cacheDir,
+			},
+		},
+	}
+
+	store, err := NewStore(
+		logger,
+		sym,
+		cfg,
+		NopDebugInfodClient{},
+	)
+	require.NoError(t, err)
+
+	// Test that the initial state should be empty.
+	setMetadataLogger(logger)
+	state, err := fetchMetadataState(context.Background(), store.bucket, "fake-build-id")
+	require.NoError(t, err)
+	require.Equal(t, metadataStateEmpty, state)
+
+	// Updating the state should be written to blob storage.
+	err = metadataUpdate(context.Background(), store.bucket, "fake-build-id", metadataStateUploading)
+	require.NoError(t, err)
+
+	state, err = fetchMetadataState(context.Background(), store.bucket, "fake-build-id")
+	require.NoError(t, err)
+	require.Equal(t, metadataStateUploading, state)
+}

--- a/pkg/debuginfo/metadata_test.go
+++ b/pkg/debuginfo/metadata_test.go
@@ -20,10 +20,11 @@ import (
 	"testing"
 
 	"github.com/go-kit/log"
-	"github.com/parca-dev/parca/pkg/symbol"
 	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/objstore/client"
 	"github.com/thanos-io/objstore/filesystem"
+
+	"github.com/parca-dev/parca/pkg/symbol"
 )
 
 func TestMetadata(t *testing.T) {
@@ -63,16 +64,15 @@ func TestMetadata(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test that the initial state should be empty.
-	setMetadataLogger(logger)
-	state, err := fetchMetadataState(context.Background(), store.bucket, "fake-build-id")
+	state, err := store.metadataManager.fetch(context.Background(), "fake-build-id")
 	require.NoError(t, err)
 	require.Equal(t, metadataStateEmpty, state)
 
 	// Updating the state should be written to blob storage.
-	err = metadataUpdate(context.Background(), store.bucket, "fake-build-id", metadataStateUploading)
+	err = store.metadataManager.update(context.Background(), "fake-build-id", metadataStateUploading)
 	require.NoError(t, err)
 
-	state, err = fetchMetadataState(context.Background(), store.bucket, "fake-build-id")
+	state, err = store.metadataManager.fetch(context.Background(), "fake-build-id")
 	require.NoError(t, err)
 	require.Equal(t, metadataStateUploading, state)
 }


### PR DESCRIPTION
At the moment, debug files are uploaded to our gRPC server by [streaming](https://github.com/parca-dev/parca/blob/2af5503bba08b709eaf07a3b83b18c9bc29cd262/pkg/debuginfo/reader.go#L34) its chunks. [Once we receive all the chunks](https://github.com/parca-dev/parca/blob/e0c7d0cf16275d30591a93a373c292683efab360/pkg/debuginfo/client.go#L54), we write the whole file in blob storage.

Right now there's no metadata associated with said debug files. Adding metadata to the uploads would allow us, among other things, to:
- debug issues more easily, as we can add extra data to uploads
- add new features in the future (such as different debug formats), and many more

Another welcomed effect is that, while this doesn't eliminate Upload() race conditions, it heavily reduces their likelihood. 

Imagine two concurrent uploads for the same debug info. While this might seem unlikely, when profiling several hosts, or profiling all the processes in a machine (this is how this issue surfaced) this is something that happens often.

```
(time) -----------------------------------------> (requests)

|    Upload()
|    check if file exists in blob storage = false  Upload()
|    read all chunks [slow critical section]       check if file exists in blob storage = false            
|    write the file in blob storage                read all chunks [slow critical section]
|                                                        write the file in blob storage (again!)
|
v

```

The reason for the diminished race window is that the critical section becomes smaller. Before this PR, the critical section is relatively slow as it has to read all the chunks and read a file that could be hundreds of MBs to blob storage.

With this PR, the critical section is smaller, as we just need to read a small file and parse the JSON, which is significantly faster.

In order to make sure that previously running parca-agent instances that might have already uploaded debug info files, we don't error if we don't find the metadata file, and just log this event. In another PR, if we think it's necessary we can 'backfill' the metadata for previously uploaded debug files.

## Test plan

Wrote some basic tests:
```shell
[javierhonduco@localhost-live parca]$ go test -v github.com/parca-dev/parca/pkg/debuginfo
=== RUN   TestHTTPDebugInfodClient_request
=== RUN   TestHTTPDebugInfodClient_request/success
=== CONT  TestHTTPDebugInfodClient_request
    debuginfod_test.go:40: <nil>
--- PASS: TestHTTPDebugInfodClient_request (0.35s)
    --- PASS: TestHTTPDebugInfodClient_request/success (0.01s)
=== RUN   TestMetadata
--- PASS: TestMetadata (0.00s)
=== RUN   TestStore
--- PASS: TestStore (0.00s)
PASS
ok  	github.com/parca-dev/parca/pkg/debuginfo	0.371s
```

And ran `parca` and `parca-agent` side to side with no issues for several hours, without issues


With the following structure created:
```shell
[javierhonduco@localhost-live parca]$ tree tmp/
tmp/
├── 618d3581ff908f8b3bd57c8ba53324903a6c24e4
│   ├── debuginfo
│   └── metadata
├── b23b4013416032e081da00934207e154233bcda7
│   ├── debuginfo
│   └── metadata
├── c8e7be08e00f53b66489178db08f7c49e0b123c0
│   ├── debuginfo
│   └── metadata
└── cf014e05d88e8b0168baf3b6d51ae070ff9fdd7a
    ├── debuginfo
    └── metadata
[...]
```

And the right contents in the file:
```shell
[javierhonduco@localhost-live parca]$ cat tmp/618d3581ff908f8b3bd57c8ba53324903a6c24e4/metadata
{
        "state": "METADATA_STATE_UPLOADED",
        "started_upload_at": 1654686039,
        "finished_upload_at": 1654686039
}
```

_Note_: This is **not** a fix for https://github.com/parca-dev/parca/issues/1097, but it's something that was developed while debugging it