### PR TITLE
Better error handling when db result is empty

### DIFF
--- a/pkg/query/columnquery.go
+++ b/pkg/query/columnquery.go
@@ -283,6 +283,12 @@ func (q *ColumnQueryAPI) QueryRange(ctx context.Context, req *pb.QueryRangeReque
 	if err != nil {
 		return nil, err
 	}
+	if ar.NumRows() == 0 {
+		return nil, status.Error(
+			codes.NotFound,
+			"No data found for the query, try a different query or time range or no data has been written to be queried yet.",
+		)
+	}
 
 	timestampColumnIndex := 0
 	timestampColumnFound := false

--- a/pkg/query/columnquery_test.go
+++ b/pkg/query/columnquery_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -85,7 +87,10 @@ func TestColumnQueryAPIQueryRangeEmpty(t *testing.T) {
 		Start: timestamppb.New(timestamp.Time(0)),
 		End:   timestamppb.New(timestamp.Time(9223372036854775807)),
 	})
-	require.ErrorIs(t, err, ErrTimestampColumnNotFound)
+	require.ErrorIs(t, err, status.Error(
+		codes.NotFound,
+		"No data found for the query, try a different query or time range or no data has been written to be queried yet.",
+	))
 }
 
 func TestColumnQueryAPIQueryRange(t *testing.T) {


### PR DESCRIPTION
In https://github.com/parca-dev/parca/issues/1121 @brancz suggested to change `timestamp column not found` error to be handled differently.
I am not sure how exactly it should be handled, so at least here is a test case to start a conversation :)