### PR TITLE
Ignore io.EOF errors when checking dwarf from objstore

### DIFF
--- a/pkg/debuginfo/store.go
+++ b/pkg/debuginfo/store.go
@@ -212,7 +212,7 @@ func (s *Store) Upload(stream debuginfopb.DebugInfoService_UploadServer) error {
 		}
 
 		hasDWARF, err := elfutils.HasDWARF(objFile)
-		if err != nil {
+		if err != nil && !errors.Is(err, io.EOF) {
 			return status.Error(codes.Internal, err.Error())
 		}
 		if hasDWARF {


### PR DESCRIPTION
Instead, we will ask the client to upload their debuginfo once more.