### PR TITLE
ui: Add last 15min to DateTimeRangePicker

### DIFF
--- a/ui/packages/shared/components/src/DateTimeRangePicker/DateTimeRangePickerPanel/RelativeDatePicker/index.tsx
+++ b/ui/packages/shared/components/src/DateTimeRangePicker/DateTimeRangePickerPanel/RelativeDatePicker/index.tsx
@@ -20,6 +20,11 @@ interface RelativeDatePickerProps {
 
 const quickPresetRanges = [
   {
+    title: 'Last 15 min',
+    unit: UNITS.MINUTE,
+    value: 15,
+  },
+  {
     title: 'Last 1 hour',
     unit: UNITS.HOUR,
     value: 1,
@@ -44,19 +49,14 @@ const quickPresetRanges = [
     unit: UNITS.DAY,
     value: 1,
   },
-  {
-    title: 'Last 3 days',
-    unit: UNITS.DAY,
-    value: 3,
-  },
 ];
 
 const NOW = new RelativeDate(UNITS.MINUTE, 0);
 
 const RelativeDatePicker = ({range, onChange = () => null}: RelativeDatePickerProps) => {
   const date = range.from as RelativeDate;
-  const [unit, setUnit] = useState<UNIT_TYPE>(date.isRelative() ? date.unit : UNITS.HOUR);
-  const [value, setValue] = useState<number>(date.isRelative() ? date.value : 1);
+  const [unit, setUnit] = useState<UNIT_TYPE>(date.isRelative() ? date.unit : UNITS.MINUTE);
+  const [value, setValue] = useState<number>(date.isRelative() ? date.value : 15);
   return (
     <div className="p-4 w-[300px]">
       <div className="pb-2">


### PR DESCRIPTION
Also make 15min the default.

I've never used the 3 days time range, however I often find myself typing 5 or 10 min into the time range picker. 15min is probably totally fine, and thus went with that. 

It's more helpful for the deployments of Parca we currently have, until we have actual persistence and long term storage, then we should discuss the time ranges again.