### PR TITLE
pkg/debuginfo: Ignore bad magic numbers if all zeros

### DIFF
--- a/pkg/debuginfo/store.go
+++ b/pkg/debuginfo/store.go
@@ -15,6 +15,7 @@ package debuginfo
 
 import (
 	"context"
+	"debug/elf"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -213,7 +214,15 @@ func (s *Store) Upload(stream debuginfopb.DebugInfoService_UploadServer) error {
 
 		hasDWARF, err := elfutils.HasDWARF(objFile)
 		if err != nil && !errors.Is(err, io.EOF) {
-			return status.Error(codes.Internal, err.Error())
+			var fe *elf.FormatError
+			if errors.As(err, &fe) {
+				// Ignore bad magic number if all zero
+				if !strings.Contains(fe.Error(), "bad magic number '[0 0 0 0]'") {
+					return status.Error(codes.Internal, err.Error())
+				}
+			} else {
+				return status.Error(codes.Internal, err.Error())
+			}
 		}
 		if hasDWARF {
 			// We probably have the best version.


### PR DESCRIPTION
If the error isn't a `io.EOF` there are cases where reading the ELF magic numbers returns `[0 0 0 0]` and we should simply ignore that file too and ask the client to upload new information. 

It's probably more of a workaround than a real fix. Hopefully, the changes #1136 improve things, so Parca doesn't even need to read those files in the first place?

Check out the [error rate dropping](
https://demo.pyrra.dev/prometheus/graph?g0.expr=sum%20by(grpc_code)%20(rate(grpc_server_handled_total%7Bgrpc_code%3D~%22Aborted%7CUnavailable%7CInternal%7CUnknown%7CUnimplemented%7CDataLoss%22%2Cgrpc_method%3D%22Upload%22%2Cgrpc_service%3D%22parca.debuginfo.v1alpha1.DebugInfoService%22%7D%5B1h%5D))%20%2F%20scalar(sum(rate(grpc_server_handled_total%7Bgrpc_method%3D%22Upload%22%2Cgrpc_service%3D%22parca.debuginfo.v1alpha1.DebugInfoService%22%7D%5B1h%5D)))%20%3E%200&g0.tab=0&g0.stacked=1&g0.show_exemplars=0&g0.range_input=1d&g0.end_input=2022-06-13%2000%3A00%3A00&g0.moment_input=2022-06-13%2000%3A00%3A00) with this fix.