### PR TITLE
build: fix silent container build failure and lint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,24 @@
-ARG GOLANG_BASE
-ARG RUNNER_BASE
-
-FROM ${GOLANG_BASE} as builder
+FROM docker.io/golang:1.18.2-alpine3.15@sha256:e6b729ae22a2f7b6afcc237f7b9da3a27151ecbdcd109f7ab63a42e52e750262 AS builder
 RUN mkdir /.cache && chown nobody:nogroup /.cache && touch -t 202101010000.00 /.cache
+
+ARG GRPC_HEALTH_PROBE_VERSION=v0.4.11
 
 WORKDIR /app
 
-RUN go install github.com/grpc-ecosystem/grpc-health-probe@latest
+RUN go install "github.com/grpc-ecosystem/grpc-health-probe@${GRPC_HEALTH_PROBE_VERSION}"
 # Predicatable path for copying over to final image
-RUN if [ "$(go env GOHOSTARCH)" != "$(go env GOARCH)" ]; then mv "$(go env GOPATH)/bin/$(go env GOOS)_$(go env GOARCH)/grpc-health-probe" "$(go env GOPATH)/bin/grpc-health-probe"; fi
+RUN if [ "$(go env GOHOSTARCH)" != "$(go env GOARCH)" ]; then \
+        mv "$(go env GOPATH)/bin/$(go env GOOS)_$(go env GOARCH)/grpc-health-probe" "$(go env GOPATH)/bin/grpc-health-probe"; \
+    fi
 
 COPY ./dist /app/dist
-RUN if [ "amd64" = "$(go env GOARCH)" ]; then cp "dist/parca_$(go env GOOS)_$(go env GOARCH)_$(go env GOAMD64)/parca" parca; else cp "dist/parca_$(go env GOOS)_$(go env GOARCH)/parca" parca; fi
+RUN if [ "amd64" = "$(go env GOARCH)" ]; then \
+        cp "dist/parca_$(go env GOOS)_$(go env GOARCH)_$(go env GOAMD64)/parca" parca; \
+    else \
+        cp "dist/parca_$(go env GOOS)_$(go env GOARCH)/parca" parca; \
+    fi
 
-FROM ${RUNNER_BASE} as runner
+FROM docker.io/alpine:3.15.4@sha256:4edbd2beb5f78b1014028f4fbb99f3237d9561100b6881aabbf5acce2c4f9454 AS runner
 
 USER nobody
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:18.3.0-alpine3.15 AS ui-deps
+FROM docker.io/node:18.3.0-alpine3.15@sha256:7ab82182ec72ea2042e29f40fd2d7badf3023302928600803e2c158be85aee94 AS ui-deps
 
 WORKDIR /app
 
@@ -7,7 +7,7 @@ COPY ui/packages/app/web/package.json ./packages/app/web/package.json
 COPY ui/package.json ui/yarn.lock ./
 RUN yarn workspace @parca/web install --frozen-lockfile
 
-FROM node:18.3.0-alpine3.15 AS ui-builder
+FROM docker.io/node:18.3.0-alpine3.15@sha256:7ab82182ec72ea2042e29f40fd2d7badf3023302928600803e2c158be85aee94 AS ui-builder
 
 WORKDIR /app
 
@@ -15,13 +15,18 @@ COPY ui .
 COPY --from=ui-deps /app/node_modules ./node_modules
 RUN yarn workspace @parca/web build
 
-FROM golang:1.18.3-alpine3.15 AS builder
+FROM docker.io/golang:1.18.2-alpine3.15@sha256:e6b729ae22a2f7b6afcc237f7b9da3a27151ecbdcd109f7ab63a42e52e750262 AS builder
+
+ARG DLV_VERSION=v1.8.2
+ARG GRPC_HEALTH_PROBE_VERSION=v0.4.11
 
 WORKDIR /app
 
+# hadolint ignore=DL3018
 RUN apk update && apk add --no-cache build-base
-RUN go install github.com/go-delve/delve/cmd/dlv@v1.8.2
-RUN go install github.com/grpc-ecosystem/grpc-health-probe@latest
+RUN go install "github.com/go-delve/delve/cmd/dlv@${DLV_VERSION}"
+# hadolint ignore=DL3059
+RUN go install "github.com/grpc-ecosystem/grpc-health-probe@${GRPC_HEALTH_PROBE_VERSION}"
 
 COPY go.mod go.sum /app/
 RUN go mod download -modcacherw
@@ -36,7 +41,7 @@ COPY ./gen /app/gen
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -gcflags="all=-N -l" -o parca ./cmd/parca
 
-FROM golang:1.18.3-alpine3.15
+FROM docker.io/golang:1.18.2-alpine3.15@sha256:e6b729ae22a2f7b6afcc237f7b9da3a27151ecbdcd109f7ab63a42e52e750262
 
 COPY --from=builder /go/bin/dlv /
 COPY --from=builder /go/bin/grpc-health-probe /

--- a/Dockerfile.go.dev
+++ b/Dockerfile.go.dev
@@ -1,11 +1,16 @@
 # Designed to only used by Tilt to iterate faster on the API.
-FROM golang:1.18.3-alpine3.15 AS builder
+FROM docker.io/golang:1.18.2-alpine3.15@sha256:e6b729ae22a2f7b6afcc237f7b9da3a27151ecbdcd109f7ab63a42e52e750262 AS builder
+
+ARG DLV_VERSION=v1.8.2
+ARG GRPC_HEALTH_PROBE_VERSION=v0.4.11
 
 WORKDIR /app
 
+# hadolint ignore=DL3018
 RUN apk update && apk add --no-cache build-base
-RUN go install github.com/go-delve/delve/cmd/dlv@v1.8.2
-RUN go install github.com/grpc-ecosystem/grpc-health-probe@latest
+RUN go install "github.com/go-delve/delve/cmd/dlv@${DLV_VERSION}"
+# hadolint ignore=DL3059
+RUN go install "github.com/grpc-ecosystem/grpc-health-probe@${GRPC_HEALTH_PROBE_VERSION}"
 
 COPY go.mod go.sum /app/
 RUN go mod download -modcacherw
@@ -13,7 +18,7 @@ RUN go mod download -modcacherw
 # Create a dummy ui package to convience go compiler.
 RUN mkdir -p /app/ui/packages/app/web/build && \
     touch /app/ui/packages/app/web/build/index.html && \
-    echo $'package ui\n \
+    printf 'package ui\n \
     import "embed"\n\
     //go:embed packages/app/web/build\n\
     var FS embed.FS\n'\
@@ -27,7 +32,7 @@ COPY ./gen /app/gen
 # goreleaser build --single-target
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -gcflags="all=-N -l" -o parca ./cmd/parca
 
-FROM golang:1.18.3-alpine3.15
+FROM docker.io/golang:1.18.2-alpine3.15@sha256:e6b729ae22a2f7b6afcc237f7b9da3a27151ecbdcd109f7ab63a42e52e750262
 
 COPY --from=builder /go/bin/dlv /
 COPY --from=builder /go/bin/grpc-health-probe /

--- a/scripts/make-containers.sh
+++ b/scripts/make-containers.sh
@@ -1,34 +1,13 @@
 #!/usr/bin/env bash
-set +eox pipefail
+set -euo pipefail
 
-MANIFEST="$1"
-ARCHS=('amd64' 'arm64')
+MANIFEST="${1?Image name must be provided}"
+PLATFORMS=('linux/amd64' 'linux/arm64')
 
-# SHA order is respectively ('amd64' 'arm64')
-# this image is what docker.io/golang:1.18.2-alpine3.15 on May 12 2022
-DOCKER_GOLANG_ALPINE_SHAS=(
-    'docker.io/golang@sha256:3765360960a954c24b215518a41b0bf8e9e2fe3bd142b6f782fa56f8e00b8d21'
-    'docker.io/golang@sha256:394c1e739574aac2b389c628d0a199316164c3ed9d821c06ebe4ad3f133ed1f9'
-)
-
-# SHA order is respectively ('amd64' 'arm64')
-# this image is what docker.io/alpine:3.15.4 on May 11 2022.
-# Here is how to obtain the digests:
-# for r in amd64 arm64v8; do docker pull $r/alpine:3.15.4 | grep Digest; done
-DOCKER_ALPINE_SHAS=(
-    'docker.io/alpine@sha256:a777c9c66ba177ccfea23f2a216ff6721e78a662cd17019488c417135299cd89'
-    'docker.io/alpine@sha256:f3bec467166fd0e38f83ff32fb82447f5e89b5abd13264a04454c75e11f1cdc6'
-)
-
-for i in "${!ARCHS[@]}"; do
-    ARCH=${ARCHS[$i]}
-    DOCKER_GOLANG_ALPINE_SHA=${DOCKER_GOLANG_ALPINE_SHAS[$i]}
-    DOCKER_ALPINE_SHA=${DOCKER_ALPINE_SHAS[$i]}
-    echo "Building manifest for $MANIFEST with arch \"$ARCH\""
+for platform in "${PLATFORMS[@]}"; do
+    printf 'Building manifest for %s with platform "%s"\n' "${MANIFEST}" "${platform}"
     podman build \
-        --build-arg GOLANG_BASE="$DOCKER_GOLANG_ALPINE_SHA" \
-        --build-arg RUNNER_BASE="$DOCKER_ALPINE_SHA" \
-        --arch "$ARCH" \
+        --platform "${platform}" \
         --timestamp 0 \
-        --manifest "$MANIFEST" .; \
+        --manifest "${MANIFEST}" .
 done


### PR DESCRIPTION
Same changes as parca-dev/parca-agent#465 +:

* Pin `grpc-health-probe` version for reproducible builds
* Use `podman build` with `--platform` instead of `--arch`, so global `BUILD*`/`TARGET*` args are set and cache behaves properly

I do not know a way to backtrack a manifest list from a digest since the tag has moved, so base images have been updated