### PR TITLE
ci: ensure package index is up-to-date before installing qemu

### DIFF
--- a/.github/workflows/go-build-test.yml
+++ b/.github/workflows/go-build-test.yml
@@ -71,6 +71,7 @@ jobs:
       if: ${{ matrix.arch != 'x64' }}
       run: |
         # Install QEMU and it's dependencies.
+        sudo apt-get update -y
         sudo apt-get install qemu binfmt-support qemu-user-static
         docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 


### PR DESCRIPTION
Fixes

```
Ign:1 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 qemu amd64 1:4.2-3ubuntu6.21
Ign:2 http://azure.archive.ubuntu.com/ubuntu focal-updates/universe amd64 qemu-user-static amd64 1:4.2-3ubuntu6.21
Err:1 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 qemu amd64 1:4.2-3ubuntu6.21
  404  Not Found [IP: 40.81.13.82 80]
Err:2 http://azure.archive.ubuntu.com/ubuntu focal-updates/universe amd64 qemu-user-static amd64 1:4.2-3ubuntu6.21
  404  Not Found [IP: 40.81.13.82 80]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/q/qemu/qemu_4.2-3ubuntu6.21_amd64.deb  404  Not Found [IP: 40.81.13.82 80]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/universe/q/qemu/qemu-user-static_4.2-3ubuntu6.21_amd64.deb  404  Not Found [IP: 40.81.13.82 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code 100.
```