### PR TITLE
ci: disable setup actions on arm64

### DIFF
--- a/.github/workflows/go-build-test.yml
+++ b/.github/workflows/go-build-test.yml
@@ -36,6 +36,7 @@ jobs:
     - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
 
     - name: Set up Go
+      if: ${{ matrix.arch == 'amd64' }}
       uses: actions/setup-go@b22fbbc2921299758641fab08929b4ac52b32923 # tag=v3.2.0
       with:
         go-version-file: .go-version
@@ -43,6 +44,7 @@ jobs:
         cache: true
 
     - name: Set up Node.js
+      if: ${{ matrix.arch == 'amd64' }}
       uses: actions/setup-node@eeb10cff27034e7acf239c5d29f62154018672fd # tag=v3.3.0
       with:
         node-version-file: .node-version


### PR DESCRIPTION
Fixes:

```
/home/runner/.cache/go-build
Error: There are no cache folders on the disk
```