### PR TITLE
chore: Disable Go cache for non-project dependencies

### DIFF
--- a/.github/workflows/jsonnet.yml
+++ b/.github/workflows/jsonnet.yml
@@ -28,7 +28,6 @@ jobs:
         with:
           go-version-file: .go-version
           check-latest: true
-          cache: true
 
       - name: Set up Jsonnet
         run: ./env-jsonnet.sh

--- a/.github/workflows/proto-gen.yaml
+++ b/.github/workflows/proto-gen.yaml
@@ -20,7 +20,6 @@ jobs:
         with:
           go-version-file: .go-version
           check-latest: true
-          cache: true
 
       - uses: bufbuild/buf-setup-action@f6302b8734110a8557ffc49bb1b5ff7fae642400 # tag=v1.6.0
 

--- a/.github/workflows/proto-pr.yaml
+++ b/.github/workflows/proto-pr.yaml
@@ -20,7 +20,6 @@ jobs:
         with:
           go-version-file: .go-version
           check-latest: true
-          cache: true
 
       - uses: bufbuild/buf-setup-action@f6302b8734110a8557ffc49bb1b5ff7fae642400 # tag=v1.6.0
 

--- a/.github/workflows/proto-push.yaml
+++ b/.github/workflows/proto-push.yaml
@@ -21,7 +21,6 @@ jobs:
         with:
           go-version-file: .go-version
           check-latest: true
-          cache: true
 
       - uses: bufbuild/buf-setup-action@f6302b8734110a8557ffc49bb1b5ff7fae642400 # tag=v1.6.0
 


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

To prevent failures like https://github.com/parca-dev/parca/runs/7109360855?check_suite_focus=true