### PR TITLE
chore: Disable problematic linters (caused by generics)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,6 @@
 run:
   deadline: 5m
+  go: '1.18'
 
 linters:
   enable:
@@ -9,6 +10,12 @@ linters:
     - goimports
     - revive
     - whitespace
+  disable:
+    # Until https://github.com/golangci/golangci-lint/issues/2859 is fixed
+    - staticcheck
+    - gosimple
+    - stylecheck
+    - unused
 
 issues:
   exclude-rules:


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

github.com/segmentio/parquet-go  uses generics