### PR TITLE
chore: renovate buf plugins

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -7,28 +7,32 @@ managed:
       - buf.build/googleapis/googleapis
 
 plugins:
+  # renovate: datasource=github-releases depName=protocolbuffers/protobuf-go
   - remote: buf.build/protocolbuffers/plugins/go:v1.28.0-1
     out: gen/proto/go
     opt: paths=source_relative
 
+  # renovate: datasource=github-releases depName=cerbos/vtprotobuf
   - remote: buf.build/cerbos/plugins/vtproto:v0.2.0-1
     out: gen/proto/go
     opt:
       - paths=source_relative,features=marshal+unmarshal+size+pool+grpc
 
+  # renovate: datasource=github-releases depName=timostamm/protobuf-ts
   - remote: buf.build/timostamm/plugins/protobuf-ts:v2.2.2-1
     out: ui/packages/shared/client/src
     opt:
       - long_type_string
       - generate_dependencies
 
+  # renovate: datasource=github-releases depName=grpc-ecosystem/grpc-gateway
   - remote: buf.build/grpc-ecosystem/plugins/grpc-gateway:v2.10.0-1
     out: gen/proto/go
     opt:
       - paths=source_relative
       - generate_unbound_methods=true
 
-#  - name: openapiv2
+  # renovate: datasource=github-releases depName=grpc-ecosystem/grpc-gateway
   - remote: buf.build/grpc-ecosystem/plugins/openapiv2:v2.10.0-1
     out: gen/proto/swagger
     opt:

--- a/proto/buf.lock
+++ b/proto/buf.lock
@@ -4,7 +4,7 @@ deps:
   - remote: buf.build
     owner: googleapis
     repository: googleapis
-    commit: 86d30bdfc34044fb9339e1bd9673839b
+    commit: 11433ad888b94686b0ca96d25c3e05ce
   - remote: buf.build
     owner: grpc-ecosystem
     repository: grpc-gateway

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,25 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>parca-dev/.github"]
+  "extends": ["github>parca-dev/.github"],
+  "packageRules": [
+    {
+      "description": "Group buf packages",
+      "matchPackageNames": ["bufbuild/buf", "bufbuild/buf-setup-action"],
+      "groupName": "buf"
+    },
+    {
+      "description": "Group grpc-gateway packages",
+      "matchSourceUrls": ["https://github.com/grpc-ecosystem/grpc-gateway"],
+      "groupName": "grpc-gateway"
+    }
+  ],
+  "regexManagers": [
+    {
+      "description": "Update Buf plugins",
+      "fileMatch": ["(^|/)buf\\.gen\\.ya?ml$"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>.+?) depName=(?<depName>.+?)(?: (?:packageName)=(?<packageName>.+?))?(?: versioning=(?<versioning>.+?))?\\s*-?\\s*remote: ('|\")?.*:(?<currentValue>.+?)(-\\d+)?('|\")?\\s"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Because we certainly can. It will be a bit clunky though, as the Git tags do not match one-to-one with Buf tags and Renovate will not be able to run `buf generate`. It should at least avoid having to keep an eye out for releases. `buf` is popular enough, it may be feature-request worthy

Note: the `cerbos` org has been renamed to `planetscale`, this will require another PR to update the plugin