### PR TITLE
pkg/parcacol: Fix potential schema inconsistencies

### DIFF
--- a/pkg/parcacol/ingest.go
+++ b/pkg/parcacol/ingest.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -64,6 +65,8 @@ func separateNameFromLabels(ls labels.Labels) (string, labels.Labels, error) {
 	if name == "" {
 		return "", nil, ErrMissingNameLabel
 	}
+
+	sort.Sort(out)
 
 	return name, out, nil
 }


### PR DESCRIPTION
Dynamic label names were not sorted, causing merging of them to create
unknown behavior and potentially cause inconsistent schemas.