### PR TITLE
ci: disable skip_after_successful_duplicate

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -36,6 +36,7 @@ jobs:
             "ui/**",
             ".github/workflows/build-test.yml"
           ]
+        skip_after_successful_duplicate: false
 
     - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
       if: ${{ steps.skip-check.outputs.should_skip != 'true' }}

--- a/.github/workflows/codeql-analysis-go.yml
+++ b/.github/workflows/codeql-analysis-go.yml
@@ -41,6 +41,7 @@ jobs:
               "go.mod",
               "go.sum"
             ]
+          skip_after_successful_duplicate: false
 
   analyze:
     name: Analyze

--- a/.github/workflows/codeql-analysis-js.yml
+++ b/.github/workflows/codeql-analysis-js.yml
@@ -39,6 +39,7 @@ jobs:
             [
               "ui/**"
             ]
+          skip_after_successful_duplicate: false
 
   analyze:
     name: Analyze

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -24,7 +24,7 @@ jobs:
       - id: skip-check
         uses: fkirc/skip-duplicate-actions@9d116fa7e55f295019cfab7e3ab72b478bcf7fdd # tag=v4.0.0
         with:
-          do_not_skip: '["schedule", "workflow_dispatch", "push"]' # We don't want to skip on push as pull requests don't publish the image, they just test-build them. Deduplicating this is incorrect as the workflow run was not actually identical.
+          do_not_skip: '["schedule", "workflow_dispatch"]'
           paths: |-
             [
                "**.go",
@@ -35,6 +35,7 @@ jobs:
                "ui/**",
                ".github/workflows/container.yml"
             ]
+          skip_after_successful_duplicate: false
 
   build-container:
     name: Container build and push (when merged)

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,6 +28,7 @@ jobs:
                "go.sum",
                ".github/workflows/docs.yml"
             ]
+          skip_after_successful_duplicate: false
 
   docs:
     needs: skip-check

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -32,6 +32,7 @@ jobs:
               ".golangci.yml",
               ".github/workflows/go-lint.yml"
             ]
+          skip_after_successful_duplicate: false
 
   lint:
     name: Go Lint

--- a/.github/workflows/jsonnet.yml
+++ b/.github/workflows/jsonnet.yml
@@ -28,6 +28,7 @@ jobs:
               "*.libsonnet",
               ".github/workflows/jsonnet.yml"
             ]
+          skip_after_successful_duplicate: false
 
   build:
     name: Jsonnet Build

--- a/.github/workflows/proto-gen.yaml
+++ b/.github/workflows/proto-gen.yaml
@@ -30,6 +30,7 @@ jobs:
               "buf.gen.yaml",
               "buf.work.yaml"
             ]
+          skip_after_successful_duplicate: false
 
   build:
     name: Proto Generate

--- a/.github/workflows/proto-pr.yaml
+++ b/.github/workflows/proto-pr.yaml
@@ -25,6 +25,7 @@ jobs:
               "buf.gen.yaml",
               "buf.work.yaml"
             ]
+          skip_after_successful_duplicate: false
 
   build:
     name: Proto PR Checks

--- a/.github/workflows/proto-push.yaml
+++ b/.github/workflows/proto-push.yaml
@@ -26,6 +26,7 @@ jobs:
               "buf.gen.yaml",
               "buf.work.yaml"
             ]
+          skip_after_successful_duplicate: false
 
   build:
     name: Proto Push

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -39,6 +39,7 @@ jobs:
               "gen/**",
               ".github/workflows/release-dry-run.yml"
             ]
+          skip_after_successful_duplicate: false
 
   goreleaser:
     name: Release (Dry Run)

--- a/.github/workflows/ui-publish-components.yml
+++ b/.github/workflows/ui-publish-components.yml
@@ -24,6 +24,7 @@ jobs:
             [
               "ui/**",
             ]
+          skip_after_successful_duplicate: false
 
   publish-ui-components:
     name: Publish UI components to NPM

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -26,6 +26,8 @@ jobs:
               "ui/**",
               ".github/workflows/ui.yml"
             ]
+          skip_after_successful_duplicate: false
+
   test:
     name: UI Test and Lint
     needs: skip-check


### PR DESCRIPTION
Follow up to #1303 

I did not intend to use the skip duplicate feature, I think we are only interested in path filtering for now.

https://github.com/fkirc/skip-duplicate-actions#skip_after_successful_duplicate