### PR TITLE
ci: ensure workflows run on Go/Node updates

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -31,10 +31,12 @@ jobs:
         paths: |-
           [
             "**.go",
+            ".github/workflows/build-test.yml",
+            ".go-version",
+            ".node-version",
             "go.mod",
             "go.sum",
-            "ui/**",
-            ".github/workflows/build-test.yml"
+            "ui/**"
           ]
         skip_after_successful_duplicate: false
 

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -27,13 +27,15 @@ jobs:
           do_not_skip: '["schedule", "workflow_dispatch"]'
           paths: |-
             [
-               "**.go",
-               "go.mod",
-               "go.sum",
-               "Dockerfile*",
-               ".dockerignore",
-               "ui/**",
-               ".github/workflows/container.yml"
+              "**.go",
+              ".dockerignore",
+              ".github/workflows/container.yml",
+              ".go-version",
+              ".node-version",
+              "Dockerfile*",
+              "go.mod",
+              "go.sum",
+              "ui/**"
             ]
           skip_after_successful_duplicate: false
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,10 +23,12 @@ jobs:
           do_not_skip: '["schedule", "workflow_dispatch"]'
           paths: |-
             [
-               "**.go",
-               "go.mod",
-               "go.sum",
-               ".github/workflows/docs.yml"
+              "**.go",
+              ".github/workflows/docs.yml",
+              ".go-version",
+              ".node-version",
+              "go.mod",
+              "go.sum"
             ]
           skip_after_successful_duplicate: false
 

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -29,8 +29,10 @@ jobs:
           paths: |-
             [
               "**.go",
+              ".github/workflows/go-lint.yml",
+              ".go-version",
               ".golangci.yml",
-              ".github/workflows/go-lint.yml"
+              ".node-version"
             ]
           skip_after_successful_duplicate: false
 

--- a/.github/workflows/jsonnet.yml
+++ b/.github/workflows/jsonnet.yml
@@ -23,10 +23,11 @@ jobs:
           do_not_skip: '["schedule", "workflow_dispatch"]'
           paths: |-
             [
-              "deploy/**",
               "*.jsonnet",
               "*.libsonnet",
-              ".github/workflows/jsonnet.yml"
+              ".github/workflows/jsonnet.yml",
+              ".go-version",
+              "deploy/**"
             ]
           skip_after_successful_duplicate: false
 

--- a/.github/workflows/proto-gen.yaml
+++ b/.github/workflows/proto-gen.yaml
@@ -26,9 +26,10 @@ jobs:
           paths: |-
             [
               ".github/workflows/proto-gen.yaml",
-              "proto/**",
+              ".go-version",
               "buf.gen.yaml",
-              "buf.work.yaml"
+              "buf.work.yaml",
+              "proto/**"
             ]
           skip_after_successful_duplicate: false
 

--- a/.github/workflows/proto-pr.yaml
+++ b/.github/workflows/proto-pr.yaml
@@ -21,9 +21,10 @@ jobs:
           paths: |-
             [
               ".github/workflows/proto-pr.yaml",
-              "proto/**",
+              ".go-version",
               "buf.gen.yaml",
-              "buf.work.yaml"
+              "buf.work.yaml",
+              "proto/**"
             ]
           skip_after_successful_duplicate: false
 

--- a/.github/workflows/proto-push.yaml
+++ b/.github/workflows/proto-push.yaml
@@ -22,9 +22,10 @@ jobs:
           paths: |-
             [
               ".github/workflows/proto-push.yaml",
-              "proto/**",
+              ".go-version",
               "buf.gen.yaml",
-              "buf.work.yaml"
+              "buf.work.yaml",
+              "proto/**"
             ]
           skip_after_successful_duplicate: false
 

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -31,13 +31,15 @@ jobs:
           paths: |-
             [
               "**.go",
+              ".github/workflows/release-dry-run.yml",
+              ".go-version",
+              ".node-version",
+              "cmd/**",
+              "gen/**",
               "go.mod",
               "go.sum",
-              "ui/**",
-              "cmd/**",
               "pkg/**",
-              "gen/**",
-              ".github/workflows/release-dry-run.yml"
+              "ui/**"
             ]
           skip_after_successful_duplicate: false
 

--- a/.github/workflows/ui-publish-components.yml
+++ b/.github/workflows/ui-publish-components.yml
@@ -22,7 +22,8 @@ jobs:
           do_not_skip: '["schedule", "workflow_dispatch"]'
           paths: |-
             [
-              "ui/**",
+              ".node-version",
+              "ui/**"
             ]
           skip_after_successful_duplicate: false
 

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -23,8 +23,9 @@ jobs:
           do_not_skip: '["schedule", "workflow_dispatch"]'
           paths: |-
             [
-              "ui/**",
-              ".github/workflows/ui.yml"
+              ".github/workflows/ui.yml",
+              ".node-version",
+              "ui/**"
             ]
           skip_after_successful_duplicate: false
 

--- a/proto/buf.lock
+++ b/proto/buf.lock
@@ -4,7 +4,7 @@ deps:
   - remote: buf.build
     owner: googleapis
     repository: googleapis
-    commit: bf27b3d87ed2431aa83ea765e5098a9e
+    commit: 0173a713ae734ba4ad55a7f32f63326d
   - remote: buf.build
     owner: grpc-ecosystem
     repository: grpc-gateway


### PR DESCRIPTION
This adds `.go-version` and `.node-version` files to path filters. I noticed checks were skipped in #1317

I also felt the need to sort them.