### PR TITLE
pkg/query: Handle queries when no columns are found

### DIFF
--- a/pkg/parcacol/arrow.go
+++ b/pkg/parcacol/arrow.go
@@ -24,6 +24,15 @@ import (
 	"github.com/parca-dev/parca/pkg/profile"
 )
 
+type ErrMissingColumn struct {
+	column  string
+	columns int
+}
+
+func (e ErrMissingColumn) Error() string {
+	return fmt.Sprintf("expected column %s, got %d columns", e.column, e.columns)
+}
+
 func ArrowRecordToStacktraceSamples(
 	ctx context.Context,
 	m pb.MetastoreServiceClient,
@@ -34,13 +43,13 @@ func ArrowRecordToStacktraceSamples(
 	schema := ar.Schema()
 	indices := schema.FieldIndices("stacktrace")
 	if len(indices) != 1 {
-		return nil, fmt.Errorf("expected exactly one stacktrace column, got %d", len(indices))
+		return nil, ErrMissingColumn{column: "stacktrace", columns: len(indices)}
 	}
 	stacktraceColumn := ar.Column(indices[0]).(*array.Binary)
 
 	indices = schema.FieldIndices("sum(value)")
 	if len(indices) != 1 {
-		return nil, fmt.Errorf("expected exactly one value column, got %d", len(indices))
+		return nil, ErrMissingColumn{column: "value", columns: len(indices)}
 	}
 	valueColumn := ar.Column(indices[0]).(*array.Int64)
 

--- a/pkg/query/columnquery.go
+++ b/pkg/query/columnquery.go
@@ -563,6 +563,11 @@ func (q *ColumnQueryAPI) selectSingle(ctx context.Context, s *pb.SingleProfile) 
 	t := s.Time.AsTime()
 	p, err := q.findSingle(ctx, s.Query, t)
 	if err != nil {
+		// if the column cannot be found the timestamp is too far in the past and we don't have data
+		var colErr parcacol.ErrMissingColumn
+		if errors.As(err, &colErr) {
+			return nil, status.Error(codes.NotFound, "could not find profile at requested time and selectors")
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
This happens when the timestamp for the query is too old or simply doesn't exist. Parca should return NotFound and not Unknown gRPC codes.

Sending this against the release-0.12 branch so it can be in the proper release. 