### PR TITLE
Create an initial ADOPTERS.md

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,33 @@
+<!--
+
+Inspired by https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/main/ADOPTERS.md
+
+Insert your entry using this template keeping the list alphabetically sorted:
+
+## <Company/Organization Name>
+
+https://our-link.com/
+
+Environments: AWS, Azure, Google Cloud, Bare Metal, etc
+
+Uses [Parca Agent](https://github.com/parca-dev/parca-agent): Yes | No
+
+Details (optional):
+- Languages: C, C++, Elixir, Go, Java, JavaScript, .NET, Python, Ruby, Rust
+
+-->
+
+This document tracks people and use cases for Parca in production. By creating a list of production use cases we hope to build a community of advisors that we can reach out to with experience using Parca on various operation environments and cluster sizes. The Parca development team may reach out periodically to check-in on how Parca is working in the field and update this list.
+
+Go ahead and [add your organization](https://github.dev/parca-dev/parca/edit/main/ADOPTERS.md) alphabetically to the list.
+
+## Polar Signals
+
+[polarsignals.com](https://www.polarsignals.com/)
+
+Environment: Google Cloud
+
+Uses [Parca Agent](https://github.com/parca-dev/parca-agent): Yes
+
+Details:
+- Languages: Go, JavaScript (TypeScript)


### PR DESCRIPTION
Let me know what you think of this first draft.
This is intentionally very simple.

Once we have a handful of users on this list, we can still think about adding those companies with logos to the parca.dev website eventually. :slightly_smiling_face: 