### PR TITLE
pkg/parcacol: Improve encodings and compression

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/improbable-eng/grpc-web v0.15.0
 	github.com/nanmu42/limitio v1.0.0
 	github.com/oklog/run v1.1.0
-	github.com/polarsignals/frostdb v0.0.0-20220724162312-2fcaa1aaa22a
+	github.com/polarsignals/frostdb v0.0.0-20220725071538-8afb5acc429f
 	github.com/prometheus/client_golang v1.12.2
 	github.com/prometheus/common v0.37.0
 	github.com/prometheus/prometheus v0.37.0

--- a/go.sum
+++ b/go.sum
@@ -880,8 +880,8 @@ github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6J
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/polarsignals/frostdb v0.0.0-20220724162312-2fcaa1aaa22a h1:FuKVAW4bUPSVf6eMnKNKsCyFC6FYeZS8pjnwtqQ1330=
-github.com/polarsignals/frostdb v0.0.0-20220724162312-2fcaa1aaa22a/go.mod h1:Sh+8dnx7Z5jKdjcMrBqxzIhSg/qwAOzvEzSd4+0lx4I=
+github.com/polarsignals/frostdb v0.0.0-20220725071538-8afb5acc429f h1:sOKe8prb6akHjBsju+FLlooWqgSCfpf5D3qcmuM9OEs=
+github.com/polarsignals/frostdb v0.0.0-20220725071538-8afb5acc429f/go.mod h1:Sh+8dnx7Z5jKdjcMrBqxzIhSg/qwAOzvEzSd4+0lx4I=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=

--- a/pkg/parcacol/ingest_test.go
+++ b/pkg/parcacol/ingest_test.go
@@ -1,0 +1,85 @@
+package parcacol
+
+import (
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/polarsignals/frostdb/dynparquet"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/segmentio/parquet-go"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
+
+	pprofpb "github.com/parca-dev/parca/gen/proto/go/google/pprof"
+	"github.com/parca-dev/parca/pkg/metastore"
+	"github.com/parca-dev/parca/pkg/metastoretest"
+)
+
+func MustReadAllGzip(t require.TestingT, filename string) []byte {
+	f, err := os.Open(filename)
+	require.NoError(t, err)
+	defer f.Close()
+
+	r, err := gzip.NewReader(f)
+	require.NoError(t, err)
+	content, err := ioutil.ReadAll(r)
+	require.NoError(t, err)
+	return content
+}
+
+func TestPprofToParquet(t *testing.T) {
+	logger := log.NewNopLogger()
+	reg := prometheus.NewRegistry()
+	tracer := trace.NewNoopTracerProvider().Tracer("")
+	ctx := context.Background()
+
+	schema, err := Schema()
+	require.NoError(t, err)
+
+	m := metastoretest.NewTestMetastore(
+		t,
+		logger,
+		reg,
+		tracer,
+	)
+	metastore := metastore.NewInProcessClient(m)
+
+	p := &pprofpb.Profile{}
+	require.NoError(t, p.UnmarshalVT(MustReadAllGzip(t, "../query/testdata/alloc_objects.pb.gz")))
+
+	nps, err := NewNormalizer(metastore).NormalizePprof(ctx, "memory", p, false)
+	require.NoError(t, err)
+
+	for i, np := range nps {
+		buf, err := NormalizedProfileToParquetBuffer(schema, labels.Labels{}, np)
+		require.NoError(t, err)
+
+		b, err := schema.SerializeBuffer(buf)
+		require.NoError(t, err)
+
+		serBuf, err := dynparquet.ReaderFromBytes(b)
+		require.NoError(t, err)
+
+		rows := serBuf.Reader()
+		rowBuf := []parquet.Row{{}}
+		for {
+			_, err := rows.ReadRows(rowBuf)
+			if err == io.EOF {
+				break
+			}
+			if err != io.EOF {
+				if err != nil {
+					require.NoError(t, os.WriteFile(fmt.Sprintf("test-%d.parquet", i), b, 0o777))
+				}
+				require.NoError(t, err)
+			}
+		}
+	}
+}

--- a/pkg/parcacol/sample.go
+++ b/pkg/parcacol/sample.go
@@ -57,7 +57,8 @@ func NormalizedProfileToParquetBuffer(schema *dynparquet.Schema, ls labels.Label
 		}
 	}
 
-	return pb, nil
+	pb.Sort()
+	return pb.Clone()
 }
 
 func labelNames(ls labels.Labels) []string {

--- a/pkg/parcacol/schema.go
+++ b/pkg/parcacol/schema.go
@@ -43,7 +43,8 @@ func Schema() (*dynparquet.Schema, error) {
 			{
 				Name: ColumnDuration,
 				StorageLayout: &schemapb.StorageLayout{
-					Type: schemapb.StorageLayout_TYPE_INT64,
+					Type:     schemapb.StorageLayout_TYPE_INT64,
+					Encoding: schemapb.StorageLayout_ENCODING_RLE_DICTIONARY,
 				},
 				Dynamic: false,
 			}, {
@@ -64,7 +65,8 @@ func Schema() (*dynparquet.Schema, error) {
 			}, {
 				Name: ColumnPeriod,
 				StorageLayout: &schemapb.StorageLayout{
-					Type: schemapb.StorageLayout_TYPE_INT64,
+					Type:     schemapb.StorageLayout_TYPE_INT64,
+					Encoding: schemapb.StorageLayout_ENCODING_RLE_DICTIONARY,
 				},
 				Dynamic: false,
 			}, {
@@ -93,6 +95,7 @@ func Schema() (*dynparquet.Schema, error) {
 				Name: ColumnPprofNumLabels,
 				StorageLayout: &schemapb.StorageLayout{
 					Type:     schemapb.StorageLayout_TYPE_INT64,
+					Encoding: schemapb.StorageLayout_ENCODING_RLE_DICTIONARY,
 					Nullable: true,
 				},
 				Dynamic: true,
@@ -113,20 +116,25 @@ func Schema() (*dynparquet.Schema, error) {
 			}, {
 				Name: ColumnStacktrace,
 				StorageLayout: &schemapb.StorageLayout{
-					Type:     schemapb.StorageLayout_TYPE_STRING,
-					Encoding: schemapb.StorageLayout_ENCODING_RLE_DICTIONARY,
+					Type:        schemapb.StorageLayout_TYPE_STRING,
+					Encoding:    schemapb.StorageLayout_ENCODING_RLE_DICTIONARY,
+					Compression: schemapb.StorageLayout_COMPRESSION_ZSTD,
 				},
 				Dynamic: false,
 			}, {
 				Name: ColumnTimestamp,
 				StorageLayout: &schemapb.StorageLayout{
-					Type: schemapb.StorageLayout_TYPE_INT64,
+					Type:        schemapb.StorageLayout_TYPE_INT64,
+					Encoding:    schemapb.StorageLayout_ENCODING_DELTA_BINARY_PACKED,
+					Compression: schemapb.StorageLayout_COMPRESSION_ZSTD,
 				},
 				Dynamic: false,
 			}, {
 				Name: ColumnValue,
 				StorageLayout: &schemapb.StorageLayout{
-					Type: schemapb.StorageLayout_TYPE_INT64,
+					Type:        schemapb.StorageLayout_TYPE_INT64,
+					Encoding:    schemapb.StorageLayout_ENCODING_DELTA_BINARY_PACKED,
+					Compression: schemapb.StorageLayout_COMPRESSION_ZSTD,
 				},
 				Dynamic: false,
 			},


### PR DESCRIPTION
With these changes we have 13.2x better space efficiency, meaning 13.2x
less in-memory and on-disk usage by columnar data managed by FrostDB.

The majority of the improvements came from choosing better encodings for each column but compression ultimately pushed it over the double-digit.

Running the numbers on a couple of blocks and I'm seeing ~2.91bytes per sample including label metadata and I don't even think we have reached what we can with multiple of these columns.