### PR TITLE
area/ui: Use batch to prevent multiple rerenders

### DIFF
--- a/ui/packages/shared/components/src/ProfileExplorer/index.tsx
+++ b/ui/packages/shared/components/src/ProfileExplorer/index.tsx
@@ -11,8 +11,9 @@ import {
   setSearchNodeString,
   store,
 } from '@parca/store';
-import {Provider} from 'react-redux';
+import {Provider, batch} from 'react-redux';
 import {DateTimeRange} from '../DateTimeRangePicker';
+import {useEffect} from 'react';
 
 export type NavigateFunction = (path: string, queryParams: any) => void;
 
@@ -75,11 +76,13 @@ const ProfileExplorerApp = ({
   if (queryParams && queryParams.expression_a) queryParams.expression_a = expression_a;
   if (queryParams && queryParams.expression_b) queryParams.expression_b = expression_b;
 
-  if (compare_a === 'true' && compare_b === 'true') {
-    dispatch(setCompare(true));
-  } else {
-    dispatch(setCompare(false));
-  }
+  useEffect(() => {
+    if (compare_a === 'true' && compare_b === 'true') {
+      dispatch(setCompare(true));
+    } else {
+      dispatch(setCompare(false));
+    }
+  }, [compare_a, compare_b]);
 
   const filterSuffix = (
     o: {[key: string]: string | string[] | undefined},
@@ -197,8 +200,11 @@ const ProfileExplorerApp = ({
         },
       };
 
-      dispatch(setCompare(!compareMode));
-      // dispatch(setSearchNodeString(undefined));
+      batch(() => {
+        dispatch(setCompare(!compareMode));
+        dispatch(setSearchNodeString(undefined));
+      });
+
       void navigateTo('/', compareQuery);
     };
 
@@ -297,8 +303,10 @@ const ProfileExplorerApp = ({
       newQueryParameters = swapQueryParameters(queryParams);
     }
 
-    dispatch(setCompare(!compareMode));
-    // dispatch(setSearchNodeString(undefined));
+    batch(() => {
+      dispatch(setCompare(!compareMode));
+      dispatch(setSearchNodeString(undefined));
+    });
 
     return navigateTo('/', {
       ...filterSuffix(newQueryParameters, '_b'),

--- a/ui/packages/shared/components/src/ProfileSelector/index.tsx
+++ b/ui/packages/shared/components/src/ProfileSelector/index.tsx
@@ -19,7 +19,6 @@ import {
 } from '../';
 import {CloseIcon} from '@parca/icons';
 import cx from 'classnames';
-import {setSearchNodeString, useAppDispatch} from '@parca/store';
 
 export interface QuerySelection {
   expression: string;
@@ -171,7 +170,6 @@ const ProfileSelector = ({
   comparing,
   onCompareProfile,
 }: ProfileSelectorProps): JSX.Element => {
-  const dispatch = useAppDispatch();
   const {
     loading: profileTypesLoading,
     data: profileTypesData,
@@ -238,7 +236,6 @@ const ProfileSelector = ({
   };
 
   const setQueryExpression = (): void => {
-    // dispatch(setSearchNodeString(undefined));
     setNewQueryExpression(query.toString(), false);
   };
 


### PR DESCRIPTION
This fixes the blank screen that occurs when you do a compare in the Polar Signals cloud product. 

The culprit here was having multiple dispatch events next to each other as that causes React to rerender multiple times. Using the [batch](https://redux.js.org/faq/performance/#how-can-i-reduce-the-number-of-store-update-events) fn fixes that.

I tested this by creating a [prerelease](https://www.npmjs.com/package/@parca/components/v/0.14.3-alpha.2) and using it in my local dev environment of the cloud app, and a working preview can be seen [here](https://cloud-app-git-temp-fix-compare-mode.vercel-preview.polarsignals.com/)