### PR TITLE
ci/ui: Using a separate token for UI package publish

### DIFF
--- a/.github/workflows/ui-publish-components.yml
+++ b/.github/workflows/ui-publish-components.yml
@@ -33,11 +33,12 @@ jobs:
     if: ${{ needs.skip-check.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     env:
-      GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GH_PAT_UI }}
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
         with:
           fetch-depth: "0"
+          token: ${{ secrets.GH_PAT_UI }}
 
       - name: Pull all tags for Lerna semantic release
         run: |
@@ -70,4 +71,4 @@ jobs:
         working-directory: ui
         run: yarn publish:ci
         env:
-          GH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_PAT_UI }}


### PR DESCRIPTION
Possible solution to #1429.

The publish action fails while trying to push the tags and new publish commit to the repo as the main branch has push conditions, see: https://github.com/parca-dev/parca/runs/7536913694?check_suite_focus=true#step:8:26


As a first step trying, a PAT from admin user, so the push conditions are bypassed. 
