### PR TITLE
fix: stop error on profile with no location id

### DIFF
--- a/pkg/parcacol/ingest.go
+++ b/pkg/parcacol/ingest.go
@@ -189,15 +189,14 @@ func validatePprofProfile(p *pprofproto.Profile) error {
 		if len(s.Value) != sampleLen {
 			return fmt.Errorf("mismatch: sample has %d values vs. %d types", len(s.Value), len(p.SampleType))
 		}
-		if len(s.LocationId) == 0 {
-			return fmt.Errorf("sample %d has no location ids", i)
-		}
-		for j, l := range s.LocationId {
-			if l == 0 {
-				return fmt.Errorf("location ids of stacktraces must be non-zero")
-			}
-			if l > locationsNum {
-				return fmt.Errorf("sample %d location number %d (%d) is out of range", i, j, l)
+		if len(s.LocationId) > 0 {
+			for j, l := range s.LocationId {
+				if l == 0 {
+					return fmt.Errorf("location ids of stacktraces must be non-zero")
+				}
+				if l > locationsNum {
+					return fmt.Errorf("sample %d location number %d (%d) is out of range", i, j, l)
+				}
 			}
 		}
 		for j, label := range s.Label {

--- a/pkg/parcacol/ingest.go
+++ b/pkg/parcacol/ingest.go
@@ -189,14 +189,12 @@ func validatePprofProfile(p *pprofproto.Profile) error {
 		if len(s.Value) != sampleLen {
 			return fmt.Errorf("mismatch: sample has %d values vs. %d types", len(s.Value), len(p.SampleType))
 		}
-		if len(s.LocationId) > 0 {
-			for j, l := range s.LocationId {
-				if l == 0 {
-					return fmt.Errorf("location ids of stacktraces must be non-zero")
-				}
-				if l > locationsNum {
-					return fmt.Errorf("sample %d location number %d (%d) is out of range", i, j, l)
-				}
+		for j, l := range s.LocationId {
+			if l == 0 {
+				return fmt.Errorf("location ids of stacktraces must be non-zero")
+			}
+			if l > locationsNum {
+				return fmt.Errorf("sample %d location number %d (%d) is out of range", i, j, l)
 			}
 		}
 		for j, label := range s.Label {


### PR DESCRIPTION
At present, when ingesting a profile that doesn't set a location id an error is logged. This stops that error from being logged.

This fix is simple, and the tests pass. I've just run the resultant binary in the situation where Parca was previously erroring every few seconds and things seem to be stable - perhaps there is some nuance I've missed elsewhere in the code, though?

Fixes #1264 