### PR TITLE
pkg/parcacol: Ensure process labels don't overlap with profile labels

### DIFF
--- a/pkg/parcacol/ingest_test.go
+++ b/pkg/parcacol/ingest_test.go
@@ -54,7 +54,7 @@ func TestPprofToParquet(t *testing.T) {
 	p := &pprofpb.Profile{}
 	require.NoError(t, p.UnmarshalVT(MustReadAllGzip(t, "../query/testdata/alloc_objects.pb.gz")))
 
-	nps, err := NewNormalizer(metastore).NormalizePprof(ctx, "memory", p, false)
+	nps, err := NewNormalizer(metastore).NormalizePprof(ctx, "memory", map[string]struct{}{}, p, false)
 	require.NoError(t, err)
 
 	for i, np := range nps {

--- a/pkg/parcacol/normalizer.go
+++ b/pkg/parcacol/normalizer.go
@@ -16,6 +16,7 @@ package parcacol
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	pprofpb "github.com/parca-dev/parca/gen/proto/go/google/pprof"
 	pb "github.com/parca-dev/parca/gen/proto/go/parca/metastore/v1alpha1"
@@ -36,7 +37,7 @@ func NewNormalizer(metastore pb.MetastoreServiceClient) *Normalizer {
 	}
 }
 
-func (n *Normalizer) NormalizePprof(ctx context.Context, name string, p *pprofpb.Profile, normalizedAddress bool) ([]*profile.NormalizedProfile, error) {
+func (n *Normalizer) NormalizePprof(ctx context.Context, name string, takenLabelNames map[string]struct{}, p *pprofpb.Profile, normalizedAddress bool) ([]*profile.NormalizedProfile, error) {
 	mappings, err := n.NormalizeMappings(ctx, p.Mapping, p.StringTable)
 	if err != nil {
 		return nil, fmt.Errorf("normalize mappings: %w", err)
@@ -76,9 +77,8 @@ func (n *Normalizer) NormalizePprof(ctx context.Context, name string, p *pprofpb
 	}
 
 	for i, sample := range p.Sample {
-		labels, numLabels := labelsFromSample(p.StringTable, sample.Label)
+		labels, numLabels := labelsFromSample(takenLabelNames, p.StringTable, sample.Label)
 		key := sampleKey(stacktraces[i].Id, labels, numLabels)
-
 		for j, value := range sample.Value {
 			if value == 0 {
 				continue
@@ -116,19 +116,39 @@ func sampleKey(stacktraceID string, labels map[string]string, numLabels map[stri
 	return key
 }
 
-func labelsFromSample(stringTable []string, plabels []*pprofpb.Label) (map[string]string, map[string]int64) {
-	// TODO: support num label units.
-	labels := map[string]string{}
-	numLabels := map[string]int64{}
-
+// TODO: support num label units.
+func labelsFromSample(takenLabelNames map[string]struct{}, stringTable []string, plabels []*pprofpb.Label) (map[string]string, map[string]int64) {
+	labels := map[string][]string{}
+	labelNames := []string{}
 	for _, label := range plabels {
-		key := stringTable[label.Key]
-		if label.Str != 0 {
-			if _, ok := labels[key]; !ok {
-				labels[key] = stringTable[label.Str]
-			}
+		if label.Str == 0 {
 			continue
 		}
+
+		key := stringTable[label.Key]
+		if _, ok := labels[key]; !ok {
+			labels[key] = []string{}
+			labelNames = append(labelNames, key)
+		}
+		labels[key] = append(labels[key], stringTable[label.Str])
+	}
+	sort.Strings(labelNames)
+
+	resLabels := map[string]string{}
+	for _, labelName := range labelNames {
+		resLabelName := labelName
+		if _, ok := takenLabelNames[resLabelName]; ok {
+			resLabelName = "exported_" + resLabelName
+		}
+		if _, ok := resLabels[resLabelName]; ok {
+			resLabelName = "exported_" + resLabelName
+		}
+		resLabels[resLabelName] = labels[labelName][0]
+	}
+
+	numLabels := map[string]int64{}
+	for _, label := range plabels {
+		key := stringTable[label.Key]
 		if label.Num != 0 {
 			if _, ok := numLabels[key]; !ok {
 				numLabels[key] = label.Num
@@ -136,7 +156,7 @@ func labelsFromSample(stringTable []string, plabels []*pprofpb.Label) (map[strin
 		}
 	}
 
-	return labels, numLabels
+	return resLabels, numLabels
 }
 
 type mappingNormalizationInfo struct {

--- a/pkg/parcacol/normalizer_test.go
+++ b/pkg/parcacol/normalizer_test.go
@@ -1,0 +1,64 @@
+package parcacol
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	pprofpb "github.com/parca-dev/parca/gen/proto/go/google/pprof"
+)
+
+func TestLabelsFromSample(t *testing.T) {
+	cases := []struct {
+		name            string
+		takenLabels     map[string]struct{}
+		stringTable     []string
+		samples         []*pprofpb.Label
+		resultLabels    map[string]string
+		resultNumLabels map[string]int64
+	}{{
+		name: "descending order",
+		takenLabels: map[string]struct{}{
+			"foo": {},
+		},
+		stringTable: []string{"", "foo", "bar", "exported_foo", "baz"},
+		samples: []*pprofpb.Label{{
+			Key: 1,
+			Str: 2,
+		}, {
+			Key: 3,
+			Str: 4,
+		}},
+		resultLabels: map[string]string{
+			"exported_foo":          "baz",
+			"exported_exported_foo": "bar",
+		},
+		resultNumLabels: map[string]int64{},
+	}, {
+		name: "ascending order",
+		takenLabels: map[string]struct{}{
+			"a": {},
+		},
+		stringTable: []string{"", "a", "bar", "exported_a", "baz"},
+		samples: []*pprofpb.Label{{
+			Key: 1,
+			Str: 2,
+		}, {
+			Key: 3,
+			Str: 4,
+		}},
+		resultLabels: map[string]string{
+			"exported_a":          "bar",
+			"exported_exported_a": "baz",
+		},
+		resultNumLabels: map[string]int64{},
+	}}
+
+	for _, c := range cases {
+		t.Run("", func(t *testing.T) {
+			labels, numLabels := labelsFromSample(c.takenLabels, c.stringTable, c.samples)
+			require.Equal(t, c.resultLabels, labels)
+			require.Equal(t, c.resultNumLabels, numLabels)
+		})
+	}
+}

--- a/pkg/query/flamegraph_flat_test.go
+++ b/pkg/query/flamegraph_flat_test.go
@@ -231,7 +231,7 @@ func testGenerateFlamegraphFromProfile(t *testing.T, l metastorepb.MetastoreServ
 	require.NoError(t, err)
 
 	normalizer := parcacol.NewNormalizer(l)
-	profiles, err := normalizer.NormalizePprof(ctx, "test", p, false)
+	profiles, err := normalizer.NormalizePprof(ctx, "test", map[string]struct{}{}, p, false)
 	require.NoError(t, err)
 
 	sp, err := parcacol.NewArrowToProfileConverter(tracer, l).SymbolizeNormalizedProfile(ctx, profiles[0])
@@ -289,7 +289,7 @@ func TestGenerateFlamegraphWithInlined(t *testing.T) {
 
 	metastore := metastore.NewInProcessClient(store)
 	normalizer := parcacol.NewNormalizer(metastore)
-	profiles, err := normalizer.NormalizePprof(ctx, "memory", p, false)
+	profiles, err := normalizer.NormalizePprof(ctx, "memory", map[string]struct{}{}, p, false)
 	require.NoError(t, err)
 
 	symbolizedProfile, err := parcacol.NewArrowToProfileConverter(tracer, metastore).SymbolizeNormalizedProfile(ctx, profiles[0])
@@ -437,7 +437,7 @@ func TestGenerateFlamegraphWithInlinedExisting(t *testing.T) {
 	require.NoError(t, err)
 
 	normalizer := parcacol.NewNormalizer(metastore)
-	profiles, err := normalizer.NormalizePprof(ctx, "", p, false)
+	profiles, err := normalizer.NormalizePprof(ctx, "", map[string]struct{}{}, p, false)
 	require.NoError(t, err)
 
 	symbolizedProfile, err := parcacol.NewArrowToProfileConverter(tracer, metastore).SymbolizeNormalizedProfile(ctx, profiles[0])

--- a/pkg/query/pprof_test.go
+++ b/pkg/query/pprof_test.go
@@ -60,7 +60,7 @@ func TestGenerateFlatPprof(t *testing.T) {
 	)
 	metastore := metastore.NewInProcessClient(l)
 	normalizer := parcacol.NewNormalizer(metastore)
-	profiles, err := normalizer.NormalizePprof(ctx, "memory", p, false)
+	profiles, err := normalizer.NormalizePprof(ctx, "memory", map[string]struct{}{}, p, false)
 	require.NoError(t, err)
 
 	symbolizedProfile, err := parcacol.NewArrowToProfileConverter(tracer, metastore).SymbolizeNormalizedProfile(ctx, profiles[0])

--- a/pkg/query/query_test.go
+++ b/pkg/query/query_test.go
@@ -80,7 +80,7 @@ func Benchmark_Query_Merge(b *testing.B) {
 			normalizer := parcacol.NewNormalizer(m)
 			ingester := parcacol.NewIngester(logger, normalizer, table, schema)
 
-			profiles, err := normalizer.NormalizePprof(ctx, "memory", p, false)
+			profiles, err := normalizer.NormalizePprof(ctx, "memory", map[string]struct{}{}, p, false)
 			require.NoError(b, err)
 
 			for j := 0; j < n; j++ {

--- a/pkg/query/top_test.go
+++ b/pkg/query/top_test.go
@@ -47,7 +47,7 @@ func TestGenerateTopTable(t *testing.T) {
 	)
 	metastore := metastore.NewInProcessClient(l)
 	normalizer := parcacol.NewNormalizer(metastore)
-	profiles, err := normalizer.NormalizePprof(ctx, "memory", p, false)
+	profiles, err := normalizer.NormalizePprof(ctx, "memory", map[string]struct{}{}, p, false)
 	require.NoError(t, err)
 
 	tracer := trace.NewNoopTracerProvider().Tracer("")
@@ -187,7 +187,7 @@ func TestGenerateDiffTopTable(t *testing.T) {
 	)
 	metastore := metastore.NewInProcessClient(l)
 	normalizer := parcacol.NewNormalizer(metastore)
-	profiles, err := normalizer.NormalizePprof(ctx, "memory", p1, false)
+	profiles, err := normalizer.NormalizePprof(ctx, "memory", map[string]struct{}{}, p1, false)
 	require.NoError(t, err)
 
 	p2 := profiles[0]


### PR DESCRIPTION
This is important for future work where we introduce the ability to
query samples by profile labels. In order to keep the same query
language we just force labels never to conflict so we always search by
process and profile labels at the same time.