### PR TITLE
ci: fix Go arm64 download for new minor releases

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -110,8 +110,8 @@ jobs:
       shell: docker exec buildpack-deps bash -e {0}
       run: |
         GO_VERSION="$(<.go-version)"
-        wget --directory-prefix=/tmp "https://dl.google.com/go/go${GO_VERSION}.linux-${{ matrix.arch }}.tar.gz"
-        tar -C /usr/local/ -xzf "/tmp/go${GO_VERSION}.linux-${{ matrix.arch }}.tar.gz"
+        wget --directory-prefix=/tmp "https://dl.google.com/go/go${GO_VERSION%.0}.linux-${{ matrix.arch }}.tar.gz"
+        tar -C /usr/local/ -xzf "/tmp/go${GO_VERSION%.0}.linux-${{ matrix.arch }}.tar.gz"
         export PATH="${PATH}:/usr/local/go/bin"
         go version
 


### PR DESCRIPTION
This should trim the `.0` from new minor releases. The download link is:

```
https://dl.google.com/go/go1.19.linux-arm64.tar.gz
```

Not:

```
https://dl.google.com/go/go1.19.0.linux-arm64.tar.gz
```

It would too simple otherwise