### PR TITLE
chore(renovate): fix grpc-health-probe

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,9 @@ ARG TARGETOS=linux
 ARG TARGETARCH=amd64
 ARG TARGETVARIANT=v1
 
-# renovate: datasource=github-releases depName=github.com/grpc-ecosystem/grpc-health-probe
+# renovate: datasource=github-releases depName=grpc-ecosystem/grpc-health-probe
 ARG GRPC_HEALTH_PROBE_VERSION=v0.4.11
-RUN wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-${TARGETOS}-${TARGETARCH} && \
+RUN wget -qO/bin/grpc_health_probe "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-${TARGETOS}-${TARGETARCH}" && \
     chmod +x /bin/grpc_health_probe
 
 WORKDIR /app

--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,11 @@
       "description": "Group grpc-gateway packages",
       "matchSourceUrls": ["https://github.com/grpc-ecosystem/grpc-gateway"],
       "groupName": "grpc-gateway"
+    },
+    {
+      "description": "Group grpc-health-probe packages",
+      "matchSourceUrls": ["https://github.com/grpc-ecosystem/grpc-health-probe"],
+      "groupName": "grpc-health-probe"
     }
   ],
   "regexManagers": [


### PR DESCRIPTION
> Renovate failed to look up the following dependencies: `github.com/grpc-ecosystem/grpc-health-probe`.

I changed the datasource from Go modules to GitHub Releases, but forgot to update the dep name.

And the dev dockerfiles still use the Go module, so better group the updates