### PR TITLE
Shutdown persistence

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -149,9 +149,9 @@ jobs:
           curl ${CURL_OPTS[@]} http://localhost:7070/
           curl ${CURL_OPTS[@]} http://localhost:7070/metrics
 
-      - name: Configure snap - storage-persistence
+      - name: Configure snap - enable-persistence 
         run: |
-          sudo snap set parca storage-persist=true
+          sudo snap set parca enable-persistence=true
           sudo snap restart parca
 
           # Set some options to allow retries while Parca comes back up

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -149,7 +149,7 @@ jobs:
           curl ${CURL_OPTS[@]} http://localhost:7070/
           curl ${CURL_OPTS[@]} http://localhost:7070/metrics
 
-      - name: Configure snap - enable-persistence 
+      - name: Configure snap - enable-persistence
         run: |
           sudo snap set parca enable-persistence=true
           sudo snap restart parca

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ Flags:
   -h, --help                       Show context-sensitive help.
       --config-path="parca.yaml"
                                    Path to config file.
-      --mode="all"                 Scraper only runs a scraper that sends to a
-                                   remote gRPC endpoint. All runs all
+      --mode="all"                 Scraper only runs a scraper that sends
+                                   to a remote gRPC endpoint. All runs all
                                    components.
       --log-level="info"           log level.
       --port=":7070"               Port string for server
@@ -114,9 +114,9 @@ Flags:
       --storage-path="data"        Path to storage directory.
       --storage-enable-wal         Enables write ahead log for profile storage.
       --symbolizer-demangle-mode="simple"
-                                   Mode to demangle C++ symbols. Default mode is
-                                   simplified: no parameters, no templates, no
-                                   return type
+                                   Mode to demangle C++ symbols. Default mode
+                                   is simplified: no parameters, no templates,
+                                   no return type
       --symbolizer-number-of-tries=3
                                    Number of tries to attempt to symbolize an
                                    unsybolized location

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ Flags:
   -h, --help                       Show context-sensitive help.
       --config-path="parca.yaml"
                                    Path to config file.
-      --mode="all"                 Scraper only runs a scraper that sends
-                                   to a remote gRPC endpoint. All runs all
+      --mode="all"                 Scraper only runs a scraper that sends to a
+                                   remote gRPC endpoint. All runs all
                                    components.
       --log-level="info"           log level.
       --port=":7070"               Port string for server
@@ -100,8 +100,8 @@ Flags:
       --mutex-profile-fraction=0
                                    Fraction of mutex profile samples to collect.
       --block-profile-rate=0       Sample rate for block profile.
-      --storage-in-memory          Use in-memory storage, without write-ahead
-                                   log or persistent metastore.
+      --enable-persistence         Turn on persistent storage for the metastore
+                                   and profile storage.
       --storage-debug-value-log    Log every value written to the database into
                                    a separate file. This is only for debugging
                                    purposes to produce data to replay situations
@@ -112,17 +112,15 @@ Flags:
                                    Amount of memory to use for active storage.
                                    Defaults to 512MB.
       --storage-path="data"        Path to storage directory.
-      --storage-persist            Persist storage to the configured object
-                                   storage.
+      --storage-enable-wal         Enables write ahead log for profile storage.
       --symbolizer-demangle-mode="simple"
-                                   Mode to demangle C++ symbols. Default mode
-                                   is simplified: no parameters, no templates,
-                                   no return type
+                                   Mode to demangle C++ symbols. Default mode is
+                                   simplified: no parameters, no templates, no
+                                   return type
       --symbolizer-number-of-tries=3
                                    Number of tries to attempt to symbolize an
                                    unsybolized location
-      --metastore="badgerinmemory"
-                                   Which metastore implementation to use
+      --metastore="badger"         Which metastore implementation to use
       --profile-share-server="api.pprof.me:443"
                                    gRPC address to send share profile requests
                                    to.

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/improbable-eng/grpc-web v0.15.0
 	github.com/nanmu42/limitio v1.0.0
 	github.com/oklog/run v1.1.0
-	github.com/polarsignals/frostdb v0.0.0-20220808170940-27b5980a4fbe
+	github.com/polarsignals/frostdb v0.0.0-20220811073159-2f68e10c0065
 	github.com/prometheus/client_golang v1.12.2
 	github.com/prometheus/common v0.37.0
 	github.com/prometheus/prometheus v0.37.0

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/improbable-eng/grpc-web v0.15.0
 	github.com/nanmu42/limitio v1.0.0
 	github.com/oklog/run v1.1.0
-	github.com/polarsignals/frostdb v0.0.0-20220803072135-ec26eb354ead
+	github.com/polarsignals/frostdb v0.0.0-20220808170940-27b5980a4fbe
 	github.com/prometheus/client_golang v1.12.2
 	github.com/prometheus/common v0.37.0
 	github.com/prometheus/prometheus v0.37.0

--- a/go.sum
+++ b/go.sum
@@ -880,8 +880,8 @@ github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6J
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/polarsignals/frostdb v0.0.0-20220803072135-ec26eb354ead h1:IdsvLAzydLRE/2NJe0UNotE0zsr6RIdkvDKu7EpI6EM=
-github.com/polarsignals/frostdb v0.0.0-20220803072135-ec26eb354ead/go.mod h1:lWmn8P/AX43XlaPfnURHFp+gDjRsUdM4zyMZvCDuN1M=
+github.com/polarsignals/frostdb v0.0.0-20220808170940-27b5980a4fbe h1:dLktQYbb5z+qXB3MyZ8xgxifgeO/q2P5LXo9qJIGcFA=
+github.com/polarsignals/frostdb v0.0.0-20220808170940-27b5980a4fbe/go.mod h1:pAYbFxj4Tkqo1uqmv+MO7qvDd+SOZnFxzsUoLqAbLLo=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=

--- a/go.sum
+++ b/go.sum
@@ -882,6 +882,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/polarsignals/frostdb v0.0.0-20220808170940-27b5980a4fbe h1:dLktQYbb5z+qXB3MyZ8xgxifgeO/q2P5LXo9qJIGcFA=
 github.com/polarsignals/frostdb v0.0.0-20220808170940-27b5980a4fbe/go.mod h1:pAYbFxj4Tkqo1uqmv+MO7qvDd+SOZnFxzsUoLqAbLLo=
+github.com/polarsignals/frostdb v0.0.0-20220811073159-2f68e10c0065 h1:Q9cplS14JxWdeLXb//d9WBLSSkWQJ37aND9mh8adtcs=
+github.com/polarsignals/frostdb v0.0.0-20220811073159-2f68e10c0065/go.mod h1:pAYbFxj4Tkqo1uqmv+MO7qvDd+SOZnFxzsUoLqAbLLo=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=

--- a/go.sum
+++ b/go.sum
@@ -880,8 +880,6 @@ github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6J
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/polarsignals/frostdb v0.0.0-20220808170940-27b5980a4fbe h1:dLktQYbb5z+qXB3MyZ8xgxifgeO/q2P5LXo9qJIGcFA=
-github.com/polarsignals/frostdb v0.0.0-20220808170940-27b5980a4fbe/go.mod h1:pAYbFxj4Tkqo1uqmv+MO7qvDd+SOZnFxzsUoLqAbLLo=
 github.com/polarsignals/frostdb v0.0.0-20220811073159-2f68e10c0065 h1:Q9cplS14JxWdeLXb//d9WBLSSkWQJ37aND9mh8adtcs=
 github.com/polarsignals/frostdb v0.0.0-20220811073159-2f68e10c0065/go.mod h1:pAYbFxj4Tkqo1uqmv+MO7qvDd+SOZnFxzsUoLqAbLLo=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=

--- a/pkg/parca/parca.go
+++ b/pkg/parca/parca.go
@@ -433,6 +433,11 @@ func Run(ctx context.Context, logger log.Logger, reg *prometheus.Registry, flags
 			if err != nil && !errors.Is(err, context.Canceled) {
 				level.Error(logger).Log("msg", "error shutting down server", "err", err)
 			}
+
+			// Close the columnstore after the parcaserver has shutdown to ensure no more writes occur against it.
+			if err := col.Close(); err != nil {
+				level.Error(logger).Log("msg", "error closing columnstore", "err", err)
+			}
 		},
 	)
 	if err := gr.Run(); err != nil {

--- a/pkg/parca/parca.go
+++ b/pkg/parca/parca.go
@@ -70,9 +70,9 @@ import (
 )
 
 const (
-	symbolizationInterval   = 10 * time.Second
-	flagModeScraperOnly     = "scraper-only"
-	metaStoreBadgerInMemory = "badgerinmemory"
+	symbolizationInterval = 10 * time.Second
+	flagModeScraperOnly   = "scraper-only"
+	metaStoreBadger       = "badger"
 )
 
 type Flags struct {
@@ -88,18 +88,18 @@ type Flags struct {
 	MutexProfileFraction int `default:"0" help:"Fraction of mutex profile samples to collect."`
 	BlockProfileRate     int `default:"0" help:"Sample rate for block profile."`
 
-	StorageInMemory bool `default:"true" help:"Use in-memory storage, without write-ahead log or persistent metastore."`
+	EnablePersistence bool `default:"false" help:"Turn on persistent storage for the metastore and profile storage."`
 
 	StorageDebugValueLog bool   `default:"false" help:"Log every value written to the database into a separate file. This is only for debugging purposes to produce data to replay situations in tests."`
 	StorageGranuleSize   int    `default:"8196" help:"Granule size for storage."`
 	StorageActiveMemory  int64  `default:"536870912" help:"Amount of memory to use for active storage. Defaults to 512MB."`
 	StoragePath          string `default:"data" help:"Path to storage directory."`
-	StoragePersist       bool   `default:"false" help:"Persist storage to the configured object storage."`
+	StorageEnableWAL     bool   `default:"false" help:"Enables write ahead log for profile storage."`
 
 	SymbolizerDemangleMode  string `default:"simple" help:"Mode to demangle C++ symbols. Default mode is simplified: no parameters, no templates, no return type" enum:"simple,full,none,templates"`
 	SymbolizerNumberOfTries int    `default:"3" help:"Number of tries to attempt to symbolize an unsybolized location"`
 
-	Metastore string `default:"badgerinmemory" help:"Which metastore implementation to use" enum:"badgerinmemory"`
+	Metastore string `default:"badger" help:"Which metastore implementation to use" enum:"badger"`
 
 	ProfileShareServer string `default:"api.pprof.me:443" help:"gRPC address to send share profile requests to."`
 
@@ -159,25 +159,28 @@ func Run(ctx context.Context, logger log.Logger, reg *prometheus.Registry, flags
 		return err
 	}
 
-	badgerOptions := badger.DefaultOptions("").WithInMemory(true)
-	if !flags.StorageInMemory {
-		badgerOptions = badger.DefaultOptions(filepath.Join(flags.StoragePath, "metastore"))
-	}
-	badgerOptions = badgerOptions.WithLogger(&metastore.BadgerLogger{Logger: logger})
-
-	db, err := badger.Open(badgerOptions)
-	if err != nil {
-		level.Error(logger).Log("msg", "failed to open badger database for metastore", "err", err)
-		return err
-	}
-
 	var mStr metastorepb.MetastoreServiceServer
 	switch flags.Metastore {
-	case metaStoreBadgerInMemory:
+	case metaStoreBadger:
+		var badgerOptions badger.Options
+		switch flags.EnablePersistence {
+		case true:
+			badgerOptions = badger.DefaultOptions(filepath.Join(flags.StoragePath, "metastore"))
+		default:
+			badgerOptions = badger.DefaultOptions("").WithInMemory(true)
+		}
+
+		badgerOptions = badgerOptions.WithLogger(&metastore.BadgerLogger{Logger: logger})
+		db, err := badger.Open(badgerOptions)
+		if err != nil {
+			level.Error(logger).Log("msg", "failed to open badger database for metastore", "err", err)
+			return err
+		}
+
 		mStr = metastore.NewBadgerMetastore(
 			logger,
 			reg,
-			tracerProvider.Tracer(metaStoreBadgerInMemory),
+			tracerProvider.Tracer(metaStoreBadger),
 			db,
 		)
 	default:
@@ -193,16 +196,12 @@ func Run(ctx context.Context, logger log.Logger, reg *prometheus.Registry, flags
 		frostdb.WithActiveMemorySize(flags.StorageActiveMemory),
 	}
 
-	if flags.StoragePersist {
+	if flags.EnablePersistence {
 		frostdbOptions = append(frostdbOptions, frostdb.WithBucketStorage(objstore.NewPrefixedBucket(bucket, "blocks")))
 	}
 
-	if !flags.StorageInMemory {
-		frostdbOptions = append(
-			frostdbOptions,
-			frostdb.WithWAL(),
-			frostdb.WithStoragePath(flags.StoragePath),
-		)
+	if flags.StorageEnableWAL {
+		frostdbOptions = append(frostdbOptions, frostdb.WithWAL(), frostdb.WithStoragePath(flags.StoragePath))
 	}
 
 	col, err := frostdb.New(

--- a/pkg/parca/parca.go
+++ b/pkg/parca/parca.go
@@ -220,7 +220,7 @@ func Run(ctx context.Context, logger log.Logger, reg *prometheus.Registry, flags
 		return err
 	}
 
-	colDB, err := col.DB("parca")
+	colDB, err := col.DB(ctx, "parca")
 	if err != nil {
 		level.Error(logger).Log("msg", "failed to load database", "err", err)
 		return err

--- a/pkg/parca/parca_test.go
+++ b/pkg/parca/parca_test.go
@@ -72,8 +72,7 @@ func benchmarkSetup(ctx context.Context, b *testing.B) (pb.ProfileStoreServiceCl
 		err := Run(ctx, logger, reg, &Flags{
 			ConfigPath:          "testdata/parca.yaml",
 			Port:                addr,
-			Metastore:           metaStoreBadgerInMemory,
-			StorageInMemory:     true,
+			Metastore:           metaStoreBadger,
 			StorageGranuleSize:  8 * 1024,
 			StorageActiveMemory: 512 * 1024 * 1024,
 		}, "test-version")

--- a/pkg/parca/parca_test.go
+++ b/pkg/parca/parca_test.go
@@ -218,7 +218,7 @@ func replayDebugLog(ctx context.Context, t Testing) (querypb.QueryServiceServer,
 		reg,
 	)
 	require.NoError(t, err)
-	colDB, err := col.DB("parca")
+	colDB, err := col.DB(context.Background(), "parca")
 	require.NoError(t, err)
 
 	schema, err := parcacol.Schema()
@@ -356,7 +356,7 @@ func TestConsistency(t *testing.T) {
 		reg,
 	)
 	require.NoError(t, err)
-	colDB, err := col.DB("parca")
+	colDB, err := col.DB(context.Background(), "parca")
 	require.NoError(t, err)
 
 	schema, err := parcacol.Schema()

--- a/pkg/profilestore/profilestore_test.go
+++ b/pkg/profilestore/profilestore_test.go
@@ -43,7 +43,7 @@ func Test_LabelName_Invalid(t *testing.T) {
 		reg,
 	)
 	require.NoError(t, err)
-	colDB, err := col.DB("parca")
+	colDB, err := col.DB(context.Background(), "parca")
 	require.NoError(t, err)
 
 	schema, err := parcacol.Schema()

--- a/pkg/query/columnquery_test.go
+++ b/pkg/query/columnquery_test.go
@@ -68,7 +68,7 @@ func TestColumnQueryAPIQueryRangeEmpty(t *testing.T) {
 		reg,
 	)
 	require.NoError(t, err)
-	colDB, err := col.DB("parca")
+	colDB, err := col.DB(context.Background(), "parca")
 	require.NoError(t, err)
 
 	schema, err := parcacol.Schema()
@@ -147,7 +147,7 @@ func TestColumnQueryAPIQueryRange(t *testing.T) {
 		reg,
 	)
 	require.NoError(t, err)
-	colDB, err := col.DB("parca")
+	colDB, err := col.DB(context.Background(), "parca")
 	require.NoError(t, err)
 
 	schema, err := parcacol.Schema()
@@ -222,7 +222,7 @@ func TestColumnQueryAPIQuerySingle(t *testing.T) {
 		reg,
 	)
 	require.NoError(t, err)
-	colDB, err := col.DB("parca")
+	colDB, err := col.DB(context.Background(), "parca")
 	require.NoError(t, err)
 
 	schema, err := parcacol.Schema()
@@ -309,7 +309,7 @@ func TestColumnQueryAPIQueryFgprof(t *testing.T) {
 		reg,
 	)
 	require.NoError(t, err)
-	colDB, err := col.DB("parca")
+	colDB, err := col.DB(context.Background(), "parca")
 	require.NoError(t, err)
 
 	schema, err := parcacol.Schema()
@@ -379,7 +379,7 @@ func TestColumnQueryAPIQueryDiff(t *testing.T) {
 		reg,
 	)
 	require.NoError(t, err)
-	colDB, err := col.DB("parca")
+	colDB, err := col.DB(context.Background(), "parca")
 	require.NoError(t, err)
 
 	schema, err := parcacol.Schema()
@@ -632,7 +632,7 @@ func TestColumnQueryAPITypes(t *testing.T) {
 		reg,
 	)
 	require.NoError(t, err)
-	colDB, err := col.DB("parca")
+	colDB, err := col.DB(context.Background(), "parca")
 	require.NoError(t, err)
 
 	schema, err := parcacol.Schema()
@@ -709,7 +709,7 @@ func TestColumnQueryAPILabelNames(t *testing.T) {
 		reg,
 	)
 	require.NoError(t, err)
-	colDB, err := col.DB("parca")
+	colDB, err := col.DB(context.Background(), "parca")
 	require.NoError(t, err)
 
 	schema, err := parcacol.Schema()
@@ -775,7 +775,7 @@ func TestColumnQueryAPILabelValues(t *testing.T) {
 		reg,
 	)
 	require.NoError(t, err)
-	colDB, err := col.DB("parca")
+	colDB, err := col.DB(context.Background(), "parca")
 	require.NoError(t, err)
 
 	schema, err := parcacol.Schema()

--- a/pkg/query/query_test.go
+++ b/pkg/query/query_test.go
@@ -50,7 +50,7 @@ func Benchmark_Query_Merge(b *testing.B) {
 				reg,
 			)
 			require.NoError(b, err)
-			colDB, err := col.DB("parca")
+			colDB, err := col.DB(context.Background(), "parca")
 			require.NoError(b, err)
 
 			schema, err := parcacol.Schema()
@@ -144,7 +144,7 @@ func Benchmark_ProfileTypes(b *testing.B) {
 
 	require.NoError(b, col.ReplayWALs(ctx))
 
-	colDB, err := col.DB("parca")
+	colDB, err := col.DB(context.Background(), "parca")
 	require.NoError(b, err)
 
 	table, err := colDB.GetTable("stacktraces")

--- a/pkg/symbolizer/symbolizer_test.go
+++ b/pkg/symbolizer/symbolizer_test.go
@@ -419,7 +419,7 @@ func setup(t *testing.T) (*grpc.ClientConn, pb.MetastoreServiceClient, *Symboliz
 	)
 	require.NoError(t, err)
 
-	colDB, err := col.DB("parca")
+	colDB, err := col.DB(context.Background(), "parca")
 	require.NoError(t, err)
 
 	schema, err := parcacol.Schema()

--- a/snap/README.md
+++ b/snap/README.md
@@ -39,7 +39,7 @@ There are a small number of config options:
 | Name                    | Valid Options                    | Default     | Description                                                                                        |
 | :---------------------- | :------------------------------- | :---------- | :------------------------------------------------------------------------------------------------- |
 | `storage-active-memory` | Any `int`                        | `536870912` | Total bytes in memory used for active memory storage                                               |
-| `storage-persist`       | `true`, `false`                  | `false`     | Persist data to disk (experimental). Profiles will be saved in `/var/snap/parca/current/profiles/` |
+| `enable-persistence`    | `true`, `false`                  | `false`     | Persist data to disk (experimental). Profiles will be saved in `/var/snap/parca/current/profiles/` |
 | `log-level`             | `error`, `warn`, `info`, `debug` | `info`      | Log level for Parca                                                                                |
 | `port`                  | 1024 > `int` > 65534             | `7070`      | Port for Parca server to listen on                                                                 |
 

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -29,9 +29,9 @@ if [[ -z "$log_level" ]]; then
     snapctl set log-level=info
 fi
 
-storage_persist="$(snapctl get storage-persist)"
+storage_persist="$(snapctl get enable-persistence)"
 if [[ -z "$storage_persist" ]]; then
-    snapctl set storage-persist=false
+    snapctl set enable-persistence=false
 fi
 
 port="$(snapctl get port)"

--- a/snap/parca-wrapper
+++ b/snap/parca-wrapper
@@ -21,7 +21,7 @@ set -euo pipefail
 # Grab the config options
 storage_active_memory="$(snapctl get storage-active-memory)"
 log_level="$(snapctl get log-level)"
-storage_persist="$(snapctl get storage-persist)"
+storage_persist="$(snapctl get enable-persistence)"
 port="$(snapctl get port)"
 
 # Start building an array of command line options
@@ -35,13 +35,12 @@ opts=(
 # specified storage-persist=true
 if [[ "${storage_persist}" == "true" ]]; then
     opts+=(
-        "--storage-in-memory=false"
-        "--storage-persist"
+        "--enable-persistence=true"
         "--storage-path=${SNAP_DATA}/profiles"
     )
 else
     opts+=(
-        "--storage-in-memory=true"
+        "--enable-persistence=false"
         "--storage-active-memory=${storage_active_memory}"
     )
 fi


### PR DESCRIPTION
This allows you to shutdown Parca, and on restarts query the historical data. Can see below where I shutdown Parca and started it much later
![image](https://user-images.githubusercontent.com/8681572/184167702-c2ab95c3-1095-4952-91c9-b86f3e8dabd8.png)

 

- updates version of frostdb to support persistence
- enables a graceful shutdown of the database on exit to write blocks to bucket storage
- refactors the persistence related flags to be less confusing:

       1. To enable persistence you only need to provide the `--enable-persistence` flag
       2. `--storage-persist` and `--storage-in-memory` has been removed.
       3. To enable the WAL it is now `--storage-enable-wal`
       4.  The `--metastore` flag now only accepts `badger` and the above persistence flags will determine if it's in-memory or not

