### PR TITLE
pkg/debuginfo: Mark already existing metadata as uploaded

### DIFF
--- a/pkg/debuginfo/store.go
+++ b/pkg/debuginfo/store.go
@@ -214,6 +214,10 @@ func (s *Store) upload(ctx context.Context, buildID, hash string, r io.Reader) e
 		if hash != "" && metadataFile != nil {
 			if metadataFile.Hash == hash {
 				level.Debug(s.logger).Log("msg", "debug info already exists", "buildid", buildID)
+				if err := s.metadata.MarkAsUploaded(ctx, buildID, hash); err != nil {
+					err = fmt.Errorf("failed to update metadata after uploaded: %w", err)
+					return status.Error(codes.Internal, err.Error())
+				}
 				return status.Error(codes.AlreadyExists, "debuginfo already exists")
 			}
 		}
@@ -239,6 +243,10 @@ func (s *Store) upload(ctx context.Context, buildID, hash string, r io.Reader) e
 			level.Debug(s.logger).Log("msg", "failed to check for DWARF", "err", err)
 		}
 		if hasDWARF {
+			if err := s.metadata.MarkAsUploaded(ctx, buildID, hash); err != nil {
+				err = fmt.Errorf("failed to update metadata after uploaded: %w", err)
+				return status.Error(codes.Internal, err.Error())
+			}
 			return status.Error(codes.AlreadyExists, "debuginfo already exists")
 		}
 	}


### PR DESCRIPTION
There can be confusing circumstances, when for example debuginfos have already been uploaded in the past, but there was no metadata. Then the metadata will continue to not be created, while the debuginfo server acknowledges that it already knows about the debuginfos.

This ensures that if the debuginfo server realizes that it already has debuginfos, that it marks them as uploaded in the metadata.