### PR TITLE
ci: fix version parsing for container builds

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -57,6 +57,8 @@ jobs:
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
+        with:
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # tag=v3.3.0


### PR DESCRIPTION
Fixes #1637 

I think by not specifying the fetch depth, the `checkout` action was calling `git fetch --no-tags`