### PR TITLE
ci: fix pre-commit on main branch

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -50,6 +50,8 @@ jobs:
           declare -a EXTRA_ARGS=()
           if [[ "${GITHUB_EVENT_NAME}" == 'pull_request' ]]; then
             EXTRA_ARGS=(--from-ref "origin/${GITHUB_BASE_REF}" --to-ref "${GITHUB_SHA}")
+          else
+            EXTRA_ARGS=(--from-ref "${GITHUB_SHA}^" --to-ref "${GITHUB_SHA}")
           fi
 
           pre-commit run --show-diff-on-failure --color=always "${EXTRA_ARGS[@]}"


### PR DESCRIPTION
I noticed `pre-commit` skips all hooks on the `main` branch. There, we want to check the last commit (assuming the merged PR has been squashed)