### PR TITLE
parca.yaml: replace object_storage with debug_info

### DIFF
--- a/parca.yaml
+++ b/parca.yaml
@@ -1,4 +1,4 @@
-object_storage:
+debug_info:
   bucket:
     type: "FILESYSTEM"
     config:


### PR DESCRIPTION
Currently, the example parca.yaml uses `object_storage` while `debug_info` seems more correct. This fixes it