### PR TITLE
feat: add metrics for debuginfo

### DIFF
--- a/pkg/debuginfo/metadata_test.go
+++ b/pkg/debuginfo/metadata_test.go
@@ -55,6 +55,7 @@ func TestMetadata(t *testing.T) {
 	store, err := NewStore(
 		tracer,
 		logger,
+		prometheus.NewRegistry(),
 		cacheDir,
 		NewObjectStoreMetadata(logger, bucket),
 		bucket,

--- a/pkg/debuginfo/store_test.go
+++ b/pkg/debuginfo/store_test.go
@@ -62,6 +62,7 @@ func TestStore(t *testing.T) {
 	s, err := NewStore(
 		tracer,
 		logger,
+		prometheus.NewRegistry(),
 		cacheDir,
 		NewObjectStoreMetadata(logger, bucket),
 		bucket,

--- a/pkg/parca/parca.go
+++ b/pkg/parca/parca.go
@@ -314,6 +314,7 @@ func Run(ctx context.Context, logger log.Logger, reg *prometheus.Registry, flags
 	dbgInfo, err := debuginfo.NewStore(
 		tracerProvider.Tracer("debuginfo"),
 		logger,
+		reg,
 		flags.DebuginfoCacheDir,
 		dbgInfoMetadata,
 		objstore.NewPrefixedBucket(bucket, "debuginfo"),

--- a/pkg/symbolizer/symbolizer_test.go
+++ b/pkg/symbolizer/symbolizer_test.go
@@ -457,6 +457,7 @@ func setup(t *testing.T) (*grpc.ClientConn, pb.MetastoreServiceClient, *Symboliz
 	dbgStr, err := debuginfo.NewStore(
 		tracer,
 		logger,
+		prometheus.NewRegistry(),
 		debugInfoCacheDir,
 		metadata,
 		bucket,


### PR DESCRIPTION
Hi Parca team,
I tried to fix #1275. Not sure I have covered everything mentioned in #1275. Please check and let me know if anything else to be added in this PR.

I have added metrics for..
1. errors and attempts for uploading debuginfo
2. errors and attempts for updating metadata
3. time taken for uploading debuginfo, updating metdata, and, exists check

I'm not sure what exactly I have to do for below metrics. Will you be able to guide me?
>Debuginfo Client metrics (will be exposed on Agent)

>Debuginfod Metrics


Fixes #1275 

Signed-off-by: shankeerthan-kasilingam <shankeerthan1995@gmail.com>