### PR TITLE
Don't use a path prefix when in development mode

### DIFF
--- a/ui/packages/app/web/src/components/ui/Navbar.tsx
+++ b/ui/packages/app/web/src/components/ui/Navbar.tsx
@@ -17,9 +17,11 @@ import {Parca, ParcaSmall} from '@parca/icons';
 import cx from 'classnames';
 import DarkModeToggle from './DarkModeToggle';
 
+const pathPrefix = process.env.NODE_ENV === 'development' ? '' : window.PATH_PREFIX;
+
 const links: {[path: string]: {label: string; href: string; external: boolean}} = {
-  '/': {label: 'Profiles', href: `${window.PATH_PREFIX}/`, external: false},
-  '/targets': {label: 'Targets', href: `${window.PATH_PREFIX}/targets`, external: false},
+  '/': {label: 'Profiles', href: `${pathPrefix}/`, external: false},
+  '/targets': {label: 'Targets', href: `${pathPrefix}/targets`, external: false},
   '/help': {label: 'Help', href: 'https://parca.dev/docs/overview', external: true},
 };
 const Navbar = () => {


### PR DESCRIPTION
Noticed a bug where the links in the Navbar were not working correctly in development mode (localhost:3000). The `window.PATH_PREFIX` returns a value of `{{.PathPrefix}}` in dev mode, even though it wasn't explicitly given a value. 

That meant the navbar links were pointing to invalid URLs. This is probably related to this [change](https://github.com/parca-dev/parca/pull/1679).