### PR TITLE
pkg/metastore,pkg/debuginfo bump retries and maxmsgsize

### DIFF
--- a/pkg/debuginfo/client.go
+++ b/pkg/debuginfo/client.go
@@ -34,8 +34,8 @@ const (
 	// uploaded and downloaded. AWS S3 has a minimum of 5MB for multi-part uploads
 	// and a maximum of 15MB, and a default of 8MB.
 	ChunkSize = 1024 * 1024 * 8
-	// MaxMsgSize is the maximum message size the server can receive or send. By default, it is 4MB.
-	MaxMsgSize = 1024 * 1024 * 32
+	// MaxMsgSize is the maximum message size the server can receive or send. By default, it is 64MB.
+	MaxMsgSize = 1024 * 1024 * 64
 )
 
 type Client struct {

--- a/pkg/metastore/badger.go
+++ b/pkg/metastore/badger.go
@@ -443,7 +443,7 @@ func (m *BadgerMetastore) GetOrCreateStacktraces(ctx context.Context, r *pb.GetO
 		stacktraceKeys = append(stacktraceKeys, MakeStacktraceKey(stacktrace))
 	}
 
-	const maxRetries = 2
+	const maxRetries = 100
 	var result retryableGetOrCreateStacktraces
 	var err error
 


### PR DESCRIPTION
Currently we hit limits with memory profiles in an application consuming a lot of memory. This seems to fix it.

Fixes #1397