### PR TITLE
parca: cancel parcaserver application context when handling an interrupt

### DIFF
--- a/pkg/parca/parca.go
+++ b/pkg/parca/parca.go
@@ -584,35 +584,44 @@ func runScraper(
 		},
 	)
 
-	parcaserver := server.NewServer(reg, version)
-	gr.Add(
-		func() error {
-			return parcaserver.ListenAndServe(
-				ctx,
-				logger,
-				flags.Port,
-				flags.CORSAllowedOrigins,
-				flags.PathPrefix,
-				server.RegisterableFunc(func(ctx context.Context, srv *grpc.Server, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) error {
-					scrapepb.RegisterScrapeServiceServer(srv, m)
-					if err := scrapepb.RegisterScrapeServiceHandlerFromEndpoint(ctx, mux, endpoint, opts); err != nil {
-						return err
-					}
-					return nil
-				}),
-			)
-		},
-		func(_ error) {
-			ctx, cancel := context.WithTimeout(ctx, 30*time.Second) // TODO make this a graceful shutdown config setting
-			defer cancel()
+	{
+		parcaserver := server.NewServer(reg, version)
+		serveCtx, cancelServe := context.WithCancel(ctx)
+		gr.Add(
+			func() error {
+				return parcaserver.ListenAndServe(
+					serveCtx,
+					logger,
+					flags.Port,
+					flags.CORSAllowedOrigins,
+					flags.PathPrefix,
+					server.RegisterableFunc(func(ctx context.Context, srv *grpc.Server, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) error {
+						scrapepb.RegisterScrapeServiceServer(srv, m)
+						if err := scrapepb.RegisterScrapeServiceHandlerFromEndpoint(ctx, mux, endpoint, opts); err != nil {
+							return err
+						}
+						return nil
+					}),
+				)
+			},
+			func(_ error) {
+				level.Debug(logger).Log("msg", "server shutting down")
 
-			level.Debug(logger).Log("msg", "server shutting down")
-			err := parcaserver.Shutdown(ctx)
-			if err != nil && !errors.Is(err, context.Canceled) {
-				level.Error(logger).Log("msg", "error shutting down server", "err", err)
-			}
-		},
-	)
+				// Create a new context for the server shutdown with a deadline.
+				shutdownCtx, cancelShutdown := context.WithTimeout(ctx, 30*time.Second) // TODO make this a graceful shutdown config setting
+				defer cancelShutdown()
+
+				err := parcaserver.Shutdown(shutdownCtx)
+				// Cancels ListenAndServe after shutting down the connections.
+				// If the timeout was reached during shutdown, this should
+				// cancel any remaining live application code.
+				cancelServe()
+				if err != nil && !errors.Is(err, context.Canceled) {
+					level.Error(logger).Log("msg", "error shutting down server", "err", err)
+				}
+			},
+		)
+	}
 
 	level.Info(logger).Log("msg", "running Parca in scrape mode", "version", version)
 	if err := gr.Run(); err != nil {


### PR DESCRIPTION
Previously, the context that was used to call ListenAndServe was never cancelled.

cc @brancz 