### PR TITLE
ci: Disabling cancel-in-progress for Publish UI components workflow

### DIFF
--- a/.github/workflows/ui-publish-components.yml
+++ b/.github/workflows/ui-publish-components.yml
@@ -7,7 +7,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   skip-check:


### PR DESCRIPTION
Enabling cancel-in-progress for the publish UI component job is creating a bug where the actual publish of the package to npm is failing. Lerna pushes the updated git tags to GitHub before publishing to npm, which is triggering another run of the workflow and in turn cancelling the in-progress publishing to npm.
And the newly triggered run wouldn't publish it either, as it already has the git tags that indicate that the npm publishing is update to date. 

Disabling `cancel-in-progress` for this workflow would fix it. 