### PR TITLE
ui: Truncate build Id text

### DIFF
--- a/ui/packages/shared/profile/src/GraphTooltip/index.tsx
+++ b/ui/packages/shared/profile/src/GraphTooltip/index.tsx
@@ -57,6 +57,8 @@ function generateGetBoundingClientRect(contextElement: Element, x = 0, y = 0): (
       bottom: domRect.y + y,
     } as DOMRect);
 }
+const testStr =
+  '304d6656486c444d49773247312d5656327545722f59313658417076684e62336978576a4b636f4b6b2f533239316f6a62742d53535a51544845454b6c5a2f67545a4a4b6d5f53456d667344712d38654a4c55';
 
 const TooltipMetaInfo = ({
   hoveringNode,
@@ -124,18 +126,16 @@ const TooltipMetaInfo = ({
           </td>
         </tr>
       )}
-      {hoveringNode.meta.mapping !== undefined && hoveringNode.meta.mapping.buildId !== '' && (
-        <tr>
-          <td className="w-1/5">Build Id</td>
-          <td className="w-4/5 break-all">
-            <CopyToClipboard onCopy={onCopy} text={hoveringNode.meta.mapping.buildId}>
-              <button className="cursor-pointer">
-                {truncateString(getLastItem(hoveringNode.meta.mapping.buildId) as string, 16)}
-              </button>
-            </CopyToClipboard>
-          </td>
-        </tr>
-      )}
+      {/* {hoveringNode.meta.mapping !== undefined && hoveringNode.meta.mapping.buildId !== '' && ( */}
+      <tr>
+        <td className="w-1/5">Build Id</td>
+        <td className="w-4/5 break-all">
+          <CopyToClipboard onCopy={onCopy} text={hoveringNode.meta.mapping.buildId}>
+            <button className="cursor-pointer">{truncateString(testStr, 16)}</button>
+          </CopyToClipboard>
+        </td>
+      </tr>
+      {/* )} */}
     </>
   );
 };

--- a/ui/packages/shared/profile/src/GraphTooltip/index.tsx
+++ b/ui/packages/shared/profile/src/GraphTooltip/index.tsx
@@ -18,7 +18,7 @@ import {usePopper} from 'react-popper';
 import {CallgraphNode, FlamegraphNode, FlamegraphRootNode} from '@parca/client';
 import {getLastItem, valueFormatter} from '@parca/functions';
 import useIsShiftDown from '@parca/components/src/hooks/useIsShiftDown';
-import {hexifyAddress} from '../';
+import {hexifyAddress, truncateString} from '../';
 
 interface GraphTooltipProps {
   x: number;
@@ -130,7 +130,7 @@ const TooltipMetaInfo = ({
           <td className="w-4/5 break-all">
             <CopyToClipboard onCopy={onCopy} text={hoveringNode.meta.mapping.buildId}>
               <button className="cursor-pointer">
-                {getLastItem(hoveringNode.meta.mapping.buildId)}
+                {truncateString(getLastItem(hoveringNode.meta.mapping.buildId) as string, 16)}
               </button>
             </CopyToClipboard>
           </td>

--- a/ui/packages/shared/profile/src/utils.ts
+++ b/ui/packages/shared/profile/src/utils.ts
@@ -42,3 +42,11 @@ export const downloadPprof = async (
   const blob = new Blob([response.report.pprof], {type: 'application/octet-stream'});
   return blob;
 };
+
+export const truncateString = (str: string, num: number) => {
+  if (str.length <= num) {
+    return str;
+  }
+
+  return str.slice(0, num) + '...';
+};

--- a/ui/packages/shared/profile/src/utils.ts
+++ b/ui/packages/shared/profile/src/utils.ts
@@ -43,7 +43,7 @@ export const downloadPprof = async (
   return blob;
 };
 
-export const truncateString = (str: string, num: number) => {
+export const truncateString = (str: string, num: number): string => {
   if (str.length <= num) {
     return str;
   }


### PR DESCRIPTION
This PR truncates the build Id to just 16 characters.
**Before**
<img width="1780" alt="image" src="https://user-images.githubusercontent.com/9016992/196417015-4caca23a-611b-4167-bd9f-5bf947e0ec81.png">

**After**
<img width="1800" alt="image" src="https://user-images.githubusercontent.com/9016992/196417182-f73122ca-9f6b-4934-9b2c-c4a49e2ac454.png">
