### PR TITLE
Fix elf based symbolization

### DIFF
--- a/pkg/symbol/addr2line/symtab_test.go
+++ b/pkg/symbol/addr2line/symtab_test.go
@@ -68,10 +68,18 @@ func TestSymtabLiner_PCToLines(t *testing.T) {
 			args: args{
 				addr: 4,
 			},
-			wantErr: true,
+			wantLines: []profile.LocationLine{
+				{
+					Function: &metastorev1alpha1.Function{
+						Name:     "bar",
+						Filename: "?",
+					},
+					Line: 0,
+				},
+			},
 		},
 		{
-			name: "matching symbols",
+			name: "first exact address",
 			fields: fields{
 				symbols: []elf.Symbol{
 					{
@@ -98,6 +106,74 @@ func TestSymtabLiner_PCToLines(t *testing.T) {
 				{
 					Function: &metastorev1alpha1.Function{
 						Name:     "foo",
+						Filename: "?",
+					},
+					Line: 0,
+				},
+			},
+		},
+		{
+			name: "first non exact address",
+			fields: fields{
+				symbols: []elf.Symbol{
+					{
+						Name:  "foo",
+						Value: 1,
+						Size:  3,
+					},
+					{
+						Name:  "bar",
+						Value: 10,
+						Size:  3,
+					},
+					{
+						Name:  "baz",
+						Value: 20,
+						Size:  3,
+					},
+				},
+			},
+			args: args{
+				addr: 3,
+			},
+			wantLines: []profile.LocationLine{
+				{
+					Function: &metastorev1alpha1.Function{
+						Name:     "foo",
+						Filename: "?",
+					},
+					Line: 0,
+				},
+			},
+		},
+		{
+			name: "last address",
+			fields: fields{
+				symbols: []elf.Symbol{
+					{
+						Name:  "foo",
+						Value: 1,
+						Size:  3,
+					},
+					{
+						Name:  "bar",
+						Value: 10,
+						Size:  3,
+					},
+					{
+						Name:  "baz",
+						Value: 20,
+						Size:  3,
+					},
+				},
+			},
+			args: args{
+				addr: 30,
+			},
+			wantLines: []profile.LocationLine{
+				{
+					Function: &metastorev1alpha1.Function{
+						Name:     "baz",
 						Filename: "?",
 					},
 					Line: 0,

--- a/pkg/symbol/addr2line/symtab_test.go
+++ b/pkg/symbol/addr2line/symtab_test.go
@@ -71,8 +71,9 @@ func TestSymtabLiner_PCToLines(t *testing.T) {
 			wantLines: []profile.LocationLine{
 				{
 					Function: &metastorev1alpha1.Function{
-						Name:     "bar",
-						Filename: "?",
+						Name:       "bar",
+						SystemName: "bar",
+						Filename:   "?",
 					},
 					Line: 0,
 				},
@@ -105,8 +106,9 @@ func TestSymtabLiner_PCToLines(t *testing.T) {
 			wantLines: []profile.LocationLine{
 				{
 					Function: &metastorev1alpha1.Function{
-						Name:     "foo",
-						Filename: "?",
+						Name:       "foo",
+						SystemName: "foo",
+						Filename:   "?",
 					},
 					Line: 0,
 				},
@@ -139,8 +141,9 @@ func TestSymtabLiner_PCToLines(t *testing.T) {
 			wantLines: []profile.LocationLine{
 				{
 					Function: &metastorev1alpha1.Function{
-						Name:     "foo",
-						Filename: "?",
+						Name:       "foo",
+						SystemName: "foo",
+						Filename:   "?",
 					},
 					Line: 0,
 				},
@@ -173,8 +176,34 @@ func TestSymtabLiner_PCToLines(t *testing.T) {
 			wantLines: []profile.LocationLine{
 				{
 					Function: &metastorev1alpha1.Function{
-						Name:     "baz",
-						Filename: "?",
+						Name:       "baz",
+						SystemName: "baz",
+						Filename:   "?",
+					},
+					Line: 0,
+				},
+			},
+		},
+		{
+			name: "C++ symbols are demangled",
+			fields: fields{
+				symbols: []elf.Symbol{
+					{
+						Name:  "_Z2b1v",
+						Value: 20,
+						Size:  3,
+					},
+				},
+			},
+			args: args{
+				addr: 20,
+			},
+			wantLines: []profile.LocationLine{
+				{
+					Function: &metastorev1alpha1.Function{
+						Name:       "b1()",
+						SystemName: "_Z2b1v",
+						Filename:   "?",
 					},
 					Line: 0,
 				},

--- a/pkg/symbol/symbol.go
+++ b/pkg/symbol/symbol.go
@@ -263,7 +263,8 @@ func (s *Symbolizer) newLiner(buildID, path string) (liner, error) {
 		level.Debug(logger).Log("msg", "failed to determine if binary has symbols", "err", err)
 	}
 	if hasSymbols {
-		lnr, err := addr2line.Symbols(logger, f)
+		lnr, err := addr2line.Symbols(logger, f, *s.demangler)
+
 		if err == nil {
 			level.Debug(logger).Log("msg", "using symtab liner to resolve symbols")
 			return lnr, nil


### PR DESCRIPTION
There were two issues:
- There was an off-by-one, which the first commit fixes + we were using the dynamic symbols, too, which I don't belive it's correct (but I will double check in a bit);
- Symbols were not demangled, which affects C++ and Rust

## Test plan

- Added some more unittests
- Cross checked against GNU's addr2line
- End-to-end visual checks below

**Before**
(note that symbols are not correct, and also, mangled)
<img width="928" alt="image" src="https://user-images.githubusercontent.com/959128/196694693-ca34b9cd-d45e-4d41-b442-5f7dffceeca9.png">

**After**:

<img width="1414" alt="image" src="https://user-images.githubusercontent.com/959128/196695031-fe6e560e-4468-4c4b-b9b0-3cbe732d4fd3.png">


Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>