### PR TITLE
ui: Use BigInt to represent 64 bit addresses

### DIFF
--- a/ui/packages/shared/profile/src/GraphTooltip/index.tsx
+++ b/ui/packages/shared/profile/src/GraphTooltip/index.tsx
@@ -103,10 +103,10 @@ const TooltipMetaInfo = ({
             <td className="w-4/5 break-all">
               <CopyToClipboard
                 onCopy={onCopy}
-                text={' 0x' + hoveringNode.meta.location.address.toString()}
+                text={hexifyAddress(hoveringNode.meta.location.address)}
               >
                 <button className="cursor-pointer">
-                  {' 0x' + hoveringNode.meta.location.address.toString()}
+                  {hexifyAddress(hoveringNode.meta.location.address)}
                 </button>
               </CopyToClipboard>
             </td>

--- a/ui/packages/shared/profile/src/utils.ts
+++ b/ui/packages/shared/profile/src/utils.ts
@@ -18,7 +18,7 @@ export const hexifyAddress = (address?: string): string => {
   if (address == null) {
     return '';
   }
-  return `0x${parseInt(address, 10).toString(16)}`;
+  return `0x${BigInt(address).toString(16)}`;
 };
 
 export const downloadPprof = async (


### PR DESCRIPTION
This is necessary as the maximum number that JS can represent is 2^53 [0].And show the addresses in the popover in hexadecimal.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt

- [0] https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER
## Test plan

<img width="466" alt="image" src="https://user-images.githubusercontent.com/959128/196749374-c927d64b-89b6-43a4-9246-0428572e1e56.png">


Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>