### PR TITLE
dev: update jsonnet version to 635d04f

### DIFF
--- a/env-jsonnet.sh
+++ b/env-jsonnet.sh
@@ -6,7 +6,7 @@ GOJSONTOYAML_VERSION='v0.1.0'
 go install "github.com/brancz/gojsontoyaml@${GOJSONTOYAML_VERSION}"
 
 # renovate: datasource=go depName=github.com/google/go-jsonnet
-JSONNET_VERSION='v0.18.0'
+JSONNET_VERSION='635d04f'
 go install "github.com/google/go-jsonnet/cmd/jsonnet@${JSONNET_VERSION}"
 go install "github.com/google/go-jsonnet/cmd/jsonnetfmt@${JSONNET_VERSION}"
 


### PR DESCRIPTION
This commit fixes make dev/setup failing due to an older version of golang.org/x/sys in github.com/google/go-jsonnet. The version was bumped in https://github.com/google/go-jsonnet/pull/633.