### PR TITLE
deps: update frostdb to cc2d28d

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/improbable-eng/grpc-web v0.15.0
 	github.com/nanmu42/limitio v1.0.0
 	github.com/oklog/run v1.1.0
-	github.com/polarsignals/frostdb v0.0.0-20221019131336-29b94b80433b
+	github.com/polarsignals/frostdb v0.0.0-20221024164824-cc2d28dee3a9
 	github.com/prometheus/client_golang v1.13.0
 	github.com/prometheus/common v0.37.0
 	github.com/prometheus/prometheus v0.38.0

--- a/go.sum
+++ b/go.sum
@@ -869,8 +869,8 @@ github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZ
 github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/polarsignals/frostdb v0.0.0-20221019131336-29b94b80433b h1:AXD/XY0L3FpO9/o5obDY6FadAU1zO0CgoaN1N0PmqHs=
-github.com/polarsignals/frostdb v0.0.0-20221019131336-29b94b80433b/go.mod h1:u6J/wOau+2AIwGw8X6bPeXkgXzjILiwYh0it4DQmcGM=
+github.com/polarsignals/frostdb v0.0.0-20221024164824-cc2d28dee3a9 h1:p5ULOq/WupU8u1ZDmJYKP7P2knmnA9oN2Mn8GphDZeI=
+github.com/polarsignals/frostdb v0.0.0-20221024164824-cc2d28dee3a9/go.mod h1:u6J/wOau+2AIwGw8X6bPeXkgXzjILiwYh0it4DQmcGM=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=


### PR DESCRIPTION
This commit includes leveled compaction which should improve parca memory/cpu usage and query latency spikes.