### PR TITLE
ci(proto-gen): remove on.pull_request.paths

### DIFF
--- a/.github/workflows/proto-gen.yaml
+++ b/.github/workflows/proto-gen.yaml
@@ -2,11 +2,6 @@ name: proto-gen
 
 on:
   pull_request:
-    paths:
-      - .github/workflows/proto-gen.yaml
-      - proto/**
-      - buf.gen.yaml
-      - buf.work.yaml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}


### PR DESCRIPTION
A leftover from before `fkirc/skip-duplicate-actions` and it prevents it from working