### PR TITLE
fix(deploy): fix object_storage config

### DIFF
--- a/deploy/lib/parca/parca.libsonnet
+++ b/deploy/lib/parca/parca.libsonnet
@@ -10,14 +10,12 @@ local defaults = {
   replicas: error 'must provide replicas',
 
   config: {
-    debug_info: {
+    object_storage: {
       bucket: {
         type: 'FILESYSTEM',
-        config: { directory: './tmp' },
-      },
-      cache: {
-        type: 'FILESYSTEM',
-        config: { directory: './tmp' },
+        config: {
+          directory: './data',
+        },
       },
     },
   },


### PR DESCRIPTION
Follow up to #1403

Fixes:

```
level=error name=parca ts=2022-10-26T19:09:58.15050786Z caller=parca.go:138 msg="failed to read config" path=/var/parca/parca.yaml
level=error name=parca ts=2022-10-26T19:09:58.15054876Z caller=main.go:59 msg="Program exited with error" err="parsing YAML file /var/parca/parca.yaml: yaml: unmarshal errors:\n  line 1: field debug_info not found in type config.Config"
```

It was reported on Discord as well: https://discord.com/channels/877547706334199818/877547706334199821/1032955935255187498