### PR TITLE
pkg/query: Fix locations with no lines

### DIFF
--- a/pkg/query/flamegraph_table.go
+++ b/pkg/query/flamegraph_table.go
@@ -272,6 +272,13 @@ func (c *tableConverter) AddFunction(f *metastorev1alpha1.Function) uint32 {
 // has multiple inlined functions it creates multiple nodes for each inlined
 // function.
 func tableLocationToTreeNodes(location *metastorev1alpha1.Location, locationIndex uint32) []*querypb.FlamegraphNode {
+	if len(location.Lines) == 0 {
+		return []*querypb.FlamegraphNode{{
+			Meta: &querypb.FlamegraphNodeMeta{
+				LocationIndex: locationIndex,
+			},
+		}}
+	}
 	nodes := make([]*querypb.FlamegraphNode, len(location.Lines))
 	for i := range location.Lines {
 		nodes[i] = &querypb.FlamegraphNode{
@@ -410,8 +417,8 @@ func compareByNameTable(tables TableGetter, a, b *querypb.FlamegraphNode) bool {
 		return false
 	}
 
-	aFunction := tables.GetFunction(aLocation.Lines[0].FunctionIndex)
-	bFunction := tables.GetFunction(bLocation.Lines[0].FunctionIndex)
+	aFunction := tables.GetFunction(aLocation.Lines[a.Meta.LineIndex].FunctionIndex)
+	bFunction := tables.GetFunction(bLocation.Lines[b.Meta.LineIndex].FunctionIndex)
 
 	if aFunction != nil && bFunction == nil {
 		return false
@@ -434,12 +441,12 @@ func equalsByNameTable(tables TableGetter, a, b *querypb.FlamegraphNode) bool {
 	if aLocation == nil || bLocation == nil {
 		return false
 	}
-	if len(aLocation.Lines) < 1 || len(bLocation.Lines) < 1 {
+	if a.Meta.LineIndex >= uint32(len(aLocation.Lines)) || b.Meta.LineIndex >= uint32(len(bLocation.Lines)) {
 		return false
 	}
 
-	aFunction := tables.GetFunction(aLocation.Lines[0].FunctionIndex)
-	bFunction := tables.GetFunction(bLocation.Lines[0].FunctionIndex)
+	aFunction := tables.GetFunction(aLocation.Lines[a.Meta.LineIndex].FunctionIndex)
+	bFunction := tables.GetFunction(bLocation.Lines[b.Meta.LineIndex].FunctionIndex)
 
 	if aFunction != nil && bFunction == nil {
 		return false

--- a/pkg/query/flamegraph_table_test.go
+++ b/pkg/query/flamegraph_table_test.go
@@ -245,22 +245,29 @@ func TestGenerateFlamegraphTableMergeMappings(t *testing.T) {
 			Lines: []*metastorepb.Line{{
 				FunctionId: f1.Id,
 			}},
+		}, {
+			MappingId: m2.Id,
+			Address:   0x5,
 		}},
 	})
 	require.NoError(t, err)
 	l1 := lres.Locations[0]
 	l2 := lres.Locations[1]
+	l3 := lres.Locations[2]
 
 	sres, err := metastore.GetOrCreateStacktraces(ctx, &metastorepb.GetOrCreateStacktracesRequest{
 		Stacktraces: []*metastorepb.Stacktrace{{
 			LocationIds: []string{l1.Id},
 		}, {
 			LocationIds: []string{l2.Id},
+		}, {
+			LocationIds: []string{l3.Id},
 		}},
 	})
 	require.NoError(t, err)
 	s1 := sres.Stacktraces[0]
 	s2 := sres.Stacktraces[1]
+	s3 := sres.Stacktraces[2]
 
 	tracer := trace.NewNoopTracerProvider().Tracer("")
 
@@ -271,6 +278,9 @@ func TestGenerateFlamegraphTableMergeMappings(t *testing.T) {
 		}, {
 			StacktraceID: s2.Id,
 			Value:        1,
+		}, {
+			StacktraceID: s3.Id,
+			Value:        2,
 		}},
 	})
 	require.NoError(t, err)
@@ -279,18 +289,25 @@ func TestGenerateFlamegraphTableMergeMappings(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, int32(2), fg.Height)
-	require.Equal(t, int64(3), fg.Total)
+	require.Equal(t, int64(5), fg.Total)
 
 	// Check if tables and thus deduplication was correct and deterministic
 
 	require.Equal(t, []string{"", "a", "1", "b"}, fg.StringTable)
-	require.Equal(t, 2, len(fg.Locations))
+	require.Equal(t, 3, len(fg.Locations))
+
 	require.Equal(t, uint32(1), fg.Locations[0].MappingIndex)
 	require.Equal(t, 1, len(fg.Locations[0].Lines))
 	require.Equal(t, uint32(1), fg.Locations[0].Lines[0].FunctionIndex)
+
 	require.Equal(t, uint32(0), fg.Locations[1].MappingIndex)
 	require.Equal(t, 1, len(fg.Locations[1].Lines))
 	require.Equal(t, uint32(1), fg.Locations[1].Lines[0].FunctionIndex)
+
+	require.Equal(t, uint32(2), fg.Locations[2].MappingIndex)
+	require.Equal(t, 0, len(fg.Locations[2].Lines))
+	require.Equal(t, uint64(0x5), fg.Locations[2].Address)
+
 	require.Equal(t, []*metastorepb.Mapping{
 		{BuildIdStringIndex: 0, FileStringIndex: 1},
 		{BuildIdStringIndex: 0, FileStringIndex: 3},
@@ -302,19 +319,26 @@ func TestGenerateFlamegraphTableMergeMappings(t *testing.T) {
 	// Check the recursive flamegraph that references the tables above.
 
 	expected := &pb.FlamegraphRootNode{
-		Cumulative: 3,
+		Cumulative: 5,
 		Children: []*pb.FlamegraphNode{{
 			Cumulative: 3,
 			Meta: &pb.FlamegraphNodeMeta{
 				LocationIndex: 2,
 				LineIndex:     0,
 			},
+		}, {
+			Cumulative: 2,
+			Meta: &pb.FlamegraphNodeMeta{
+				LocationIndex: 3,
+			},
 		}},
 	}
-	require.Equal(t, int64(3), fg.Root.Cumulative)
-	require.Equal(t, 1, len(fg.Root.Children))
+	require.Equal(t, int64(5), fg.Root.Cumulative)
+	require.Equal(t, 2, len(fg.Root.Children))
 	require.Equal(t, int64(3), fg.Root.Children[0].Cumulative)
 	require.Equal(t, uint32(2), fg.Root.Children[0].Meta.LocationIndex)
+	require.Equal(t, int64(2), fg.Root.Children[1].Cumulative)
+	require.Equal(t, uint32(3), fg.Root.Children[1].Meta.LocationIndex)
 	require.True(t, proto.Equal(expected, fg.Root))
 }
 


### PR DESCRIPTION
Previously we were skipping locations that had no lines in the response.