### PR TITLE
Fix flamegraph span sorting

### DIFF
--- a/pkg/query/flamegraph_table.go
+++ b/pkg/query/flamegraph_table.go
@@ -410,10 +410,19 @@ func compareByNameTable(tables TableGetter, a, b *querypb.FlamegraphNode) bool {
 	aLocation := tables.GetLocation(a.Meta.LocationIndex)
 	bLocation := tables.GetLocation(b.Meta.LocationIndex)
 
-	if aLocation == nil || bLocation == nil {
+	if aLocation == nil && bLocation != nil {
+		return true
+	}
+	if aLocation != nil && bLocation == nil {
 		return false
 	}
-	if len(aLocation.Lines) < 1 || len(bLocation.Lines) < 1 {
+	if aLocation == nil && bLocation == nil {
+		return false
+	}
+	if len(aLocation.Lines) == 0 && len(bLocation.Lines) > 0 {
+		return true
+	}
+	if len(aLocation.Lines) > 0 && len(bLocation.Lines) == 0 {
 		return false
 	}
 


### PR DESCRIPTION
Previously spans with locations that have no lines were incorrectly compared to locations with lines, which caused two locations that have the same lines to potentially not be sorted to be next to each other, causing merging not to work as expected.