### PR TITLE
pkg/query: Fix comparing of two locations with only addresses

### DIFF
--- a/pkg/query/flamegraph_table.go
+++ b/pkg/query/flamegraph_table.go
@@ -426,8 +426,13 @@ func compareByNameTable(tables TableGetter, a, b *querypb.FlamegraphNode) bool {
 		return false
 	}
 
-	aFunction := tables.GetFunction(aLocation.Lines[a.Meta.LineIndex].FunctionIndex)
-	bFunction := tables.GetFunction(bLocation.Lines[b.Meta.LineIndex].FunctionIndex)
+	var aFunction, bFunction *metastorev1alpha1.Function
+	if uint32(len(aLocation.Lines)) > a.Meta.LineIndex {
+		aFunction = tables.GetFunction(aLocation.Lines[a.Meta.LineIndex].FunctionIndex)
+	}
+	if uint32(len(bLocation.Lines)) > b.Meta.LineIndex {
+		bFunction = tables.GetFunction(bLocation.Lines[b.Meta.LineIndex].FunctionIndex)
+	}
 
 	if aFunction != nil && bFunction == nil {
 		return false

--- a/pkg/query/flamegraph_table_test.go
+++ b/pkg/query/flamegraph_table_test.go
@@ -250,12 +250,16 @@ func TestGenerateFlamegraphTableMergeMappings(t *testing.T) {
 		}, {
 			MappingId: m2.Id,
 			Address:   0x5,
+		}, {
+			MappingId: m2.Id,
+			Address:   0x7,
 		}},
 	})
 	require.NoError(t, err)
 	l1 := lres.Locations[0]
 	l2 := lres.Locations[1]
 	l3 := lres.Locations[2]
+	l4 := lres.Locations[3]
 
 	sres, err := metastore.GetOrCreateStacktraces(ctx, &metastorepb.GetOrCreateStacktracesRequest{
 		Stacktraces: []*metastorepb.Stacktrace{{
@@ -264,12 +268,15 @@ func TestGenerateFlamegraphTableMergeMappings(t *testing.T) {
 			LocationIds: []string{l2.Id},
 		}, {
 			LocationIds: []string{l3.Id},
+		}, {
+			LocationIds: []string{l4.Id},
 		}},
 	})
 	require.NoError(t, err)
 	s1 := sres.Stacktraces[0]
 	s2 := sres.Stacktraces[1]
 	s3 := sres.Stacktraces[2]
+	s4 := sres.Stacktraces[3]
 
 	tracer := trace.NewNoopTracerProvider().Tracer("")
 
@@ -279,6 +286,9 @@ func TestGenerateFlamegraphTableMergeMappings(t *testing.T) {
 			Value:        2,
 		}, {
 			StacktraceID: s3.Id,
+			Value:        2,
+		}, {
+			StacktraceID: s4.Id,
 			Value:        2,
 		}, {
 			StacktraceID: s2.Id,
@@ -291,12 +301,12 @@ func TestGenerateFlamegraphTableMergeMappings(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, int32(2), fg.Height)
-	require.Equal(t, int64(5), fg.Total)
+	require.Equal(t, int64(7), fg.Total)
 
 	// Check if tables and thus deduplication was correct and deterministic
 
 	require.Equal(t, []string{"", "a", "1", "b"}, fg.StringTable)
-	require.Equal(t, 3, len(fg.Locations))
+	require.Equal(t, 4, len(fg.Locations))
 
 	require.Equal(t, uint32(1), fg.Locations[0].MappingIndex)
 	require.Equal(t, 1, len(fg.Locations[0].Lines))
@@ -307,10 +317,14 @@ func TestGenerateFlamegraphTableMergeMappings(t *testing.T) {
 	require.Equal(t, 0, len(fg.Locations[1].Lines))
 	require.Equal(t, uint64(0x5), fg.Locations[1].Address)
 
-	require.Equal(t, uint32(0), fg.Locations[2].MappingIndex)
-	require.Equal(t, 1, len(fg.Locations[2].Lines))
-	require.Equal(t, uint64(0x8), fg.Locations[2].Address)
-	require.Equal(t, uint32(1), fg.Locations[2].Lines[0].FunctionIndex)
+	require.Equal(t, uint32(2), fg.Locations[2].MappingIndex)
+	require.Equal(t, 0, len(fg.Locations[2].Lines))
+	require.Equal(t, uint64(0x7), fg.Locations[2].Address)
+
+	require.Equal(t, uint32(0), fg.Locations[3].MappingIndex)
+	require.Equal(t, 1, len(fg.Locations[3].Lines))
+	require.Equal(t, uint64(0x8), fg.Locations[3].Address)
+	require.Equal(t, uint32(1), fg.Locations[3].Lines[0].FunctionIndex)
 
 	require.Equal(t, []*metastorepb.Mapping{
 		{BuildIdStringIndex: 0, FileStringIndex: 1},
@@ -323,27 +337,37 @@ func TestGenerateFlamegraphTableMergeMappings(t *testing.T) {
 	// Check the recursive flamegraph that references the tables above.
 
 	expected := &pb.FlamegraphRootNode{
-		Cumulative: 5,
+		Cumulative: 7,
 		Children: []*pb.FlamegraphNode{{
 			Cumulative: 2,
 			Meta: &pb.FlamegraphNodeMeta{
 				LocationIndex: 2,
 			},
 		}, {
-			Cumulative: 3,
+			Cumulative: 2,
 			Meta: &pb.FlamegraphNodeMeta{
 				LocationIndex: 3,
+			},
+		}, {
+			Cumulative: 3,
+			Meta: &pb.FlamegraphNodeMeta{
+				LocationIndex: 4,
 				LineIndex:     0,
 			},
 		}},
 	}
-	require.Equal(t, int64(5), fg.Root.Cumulative)
-	require.Equal(t, 2, len(fg.Root.Children))
+	require.Equal(t, int64(7), fg.Root.Cumulative)
+	require.Equal(t, 3, len(fg.Root.Children))
+
 	require.Equal(t, int64(2), fg.Root.Children[0].Cumulative)
 	require.Equal(t, uint32(2), fg.Root.Children[0].Meta.LocationIndex)
-	require.Equal(t, int64(3), fg.Root.Children[1].Cumulative)
+
+	require.Equal(t, int64(2), fg.Root.Children[1].Cumulative)
 	require.Equal(t, uint32(3), fg.Root.Children[1].Meta.LocationIndex)
-	require.Equal(t, uint32(0), fg.Root.Children[1].Meta.LineIndex)
+
+	require.Equal(t, int64(3), fg.Root.Children[2].Cumulative)
+	require.Equal(t, uint32(4), fg.Root.Children[2].Meta.LocationIndex)
+	require.Equal(t, uint32(0), fg.Root.Children[2].Meta.LineIndex)
 	require.True(t, proto.Equal(expected, fg.Root))
 }
 


### PR DESCRIPTION
Previously there was a panic, when two locations were being compared that had no lines.