### PR TITLE
fix: no proper filtering target

### DIFF
--- a/pkg/scrape/target.go
+++ b/pkg/scrape/target.go
@@ -363,7 +363,7 @@ func targetsFromGroup(tg *targetgroup.Group, cfg *config.ScrapeConfig) ([]*Targe
 			if err != nil {
 				return nil, fmt.Errorf("instance %d in group %s: %s", i, tg, err)
 			}
-			if lbls != nil || origLabels != nil {
+			if lbls != nil || len(origLabels) > 0 {
 				params := cfg.Params
 				if params == nil {
 					params = url.Values{}


### PR DESCRIPTION
https://github.com/parca-dev/parca/blob/01aed4dc2428996f7cd7c7a8f5837688cffd1715/pkg/scrape/target.go#L366

because origLabels always not nil, all target will be added.