### PR TITLE
pkg/scrape: Allow profiles to be treated as already normalized

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -150,6 +150,10 @@ type ScrapeConfig struct {
 	// The URL scheme with which to fetch metrics from targets.
 	Scheme string `yaml:"scheme,omitempty"`
 
+	// NormalizedAddresses can be set to true if the addresses returned by the
+	// endpoints have already been normalized.
+	NormalizedAddresses bool `yaml:"normalized_addresses,omitempty"`
+
 	ProfilingConfig *ProfilingConfig `yaml:"profiling_config,omitempty"`
 
 	RelabelConfigs []*relabel.Config `yaml:"relabel_configs,omitempty"`


### PR DESCRIPTION
While this may be necessary for some pprof HTTP endpoints, we have encountered others now that are already normalized, in which case normalizing them again is incorrect.

This is save to be added like this without changing existing behavior, as the value defaults to false which is the currently used value before this patch.