### PR TITLE
chore(pre-commit): add buf generate hook

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -22,8 +22,6 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    permissions:
-      contents: write
     steps:
       - name: Check if pre-commit should run on all files
         id: run-all-files

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -96,6 +96,6 @@ jobs:
 
           pre-commit run --show-diff-on-failure --color=always "${EXTRA_ARGS[@]}"
 
-      - name: Apply automatic fixes
+      - name: 'pre-commit-ci-lite: Apply automatic fixes'
         uses: pre-commit-ci/lite-action@50143aaf27e2c42e75a5e06185a471d9582e89df # v1.0.0
         if: always()

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -98,4 +98,4 @@ jobs:
 
       - name: Apply automatic fixes
         uses: pre-commit-ci/lite-action@50143aaf27e2c42e75a5e06185a471d9582e89df # v1.0.0
-        if: github.event_name == 'pull_request' && always()
+        if: always()

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,11 @@ repos:
   - repo: https://github.com/bufbuild/buf
     rev: v1.9.0
     hooks:
+      # Hijack an existing hook ID to run buf generate
+      # It also mean running `pre-commit run buf-format` will run both format and generate
+      - id: buf-format
+        name: buf generate
+        entry: make proto/generate
       - id: buf-lint
       - id: buf-format
       - id: buf-breaking

--- a/proto/buf.lock
+++ b/proto/buf.lock
@@ -4,7 +4,7 @@ deps:
   - remote: buf.build
     owner: googleapis
     repository: googleapis
-    commit: 783e4b5374fa488ab068d08af9658438
+    commit: 5abafbf55b5c4c07ad5fb06d2599560f
   - remote: buf.build
     owner: grpc-ecosystem
     repository: grpc-gateway


### PR DESCRIPTION
With #2162, fixes can be apply automatically, so hopefully this would fix Renovate PRs (and unless they need rebasing they should be able to merge automatically too) :grin:

I'll see if I can add a `buf-generate` hook upstream to avoid hacking another.