### PR TITLE
debuginfo: DWARF inlined function symbolization fixes

### DIFF
--- a/pkg/symbol/elfutils/debuginfofile.go
+++ b/pkg/symbol/elfutils/debuginfofile.go
@@ -18,10 +18,11 @@ import (
 	"debug/elf"
 	"errors"
 	"fmt"
-	"github.com/go-delve/delve/pkg/dwarf/godwarf"
-	"github.com/go-delve/delve/pkg/dwarf/reader"
 	"io"
 	"sort"
+
+	"github.com/go-delve/delve/pkg/dwarf/godwarf"
+	"github.com/go-delve/delve/pkg/dwarf/reader"
 
 	pb "github.com/parca-dev/parca/gen/proto/go/parca/metastore/v1alpha1"
 	"github.com/parca-dev/parca/pkg/profile"

--- a/pkg/symbol/elfutils/debuginfofile.go
+++ b/pkg/symbol/elfutils/debuginfofile.go
@@ -85,7 +85,6 @@ func (f *debugInfoFile) buildAbstractSubprograms() error {
 		if entry == nil {
 			break
 		}
-
 		if entry.Tag == dwarf.TagSubprogram {
 			for _, field := range entry.Field {
 				if field.Attr == dwarf.AttrInline {

--- a/pkg/symbolizer/symbolizer_test.go
+++ b/pkg/symbolizer/symbolizer_test.go
@@ -109,18 +109,18 @@ func TestSymbolizer(t *testing.T) {
 
 	require.Equal(t, fres.Functions[0].Id, lres.Locations[0].Lines[0].FunctionId)
 	require.Equal(t, "/home/brancz/src/github.com/polarsignals/pprof-labels-example/main.go", fres.Functions[0].Filename)
-	require.Equal(t, "main.main", fres.Functions[0].Name)
-	require.Equal(t, int64(7), lres.Locations[0].Lines[0].Line) // llvm-addr2line gives 10
+	require.Equal(t, "main.iterate", fres.Functions[0].Name)
+	require.Equal(t, int64(27), lres.Locations[0].Lines[0].Line) // llvm-addr2line gives 10
 
 	require.Equal(t, fres.Functions[1].Id, lres.Locations[0].Lines[1].FunctionId)
 	require.Equal(t, "/home/brancz/src/github.com/polarsignals/pprof-labels-example/main.go", fres.Functions[1].Filename)
-	require.Equal(t, "main.iterate", fres.Functions[1].Name)
-	require.Equal(t, int64(27), lres.Locations[0].Lines[1].Line)
+	require.Equal(t, "main.iteratePerTenant", fres.Functions[1].Name)
+	require.Equal(t, int64(23), lres.Locations[0].Lines[1].Line)
 
 	require.Equal(t, fres.Functions[2].Id, lres.Locations[0].Lines[2].FunctionId)
 	require.Equal(t, "/home/brancz/src/github.com/polarsignals/pprof-labels-example/main.go", fres.Functions[2].Filename)
-	require.Equal(t, "main.iteratePerTenant", fres.Functions[2].Name)
-	require.Equal(t, int64(23), lres.Locations[0].Lines[2].Line)
+	require.Equal(t, "main.main", fres.Functions[2].Name)
+	require.Equal(t, int64(7), lres.Locations[0].Lines[2].Line)
 }
 
 func findIndexWithAddress(locs []*pb.Location, address uint64) int {
@@ -172,14 +172,14 @@ func TestRealSymbolizer(t *testing.T) {
 	require.Equal(t, 3, len(fres.Functions))
 
 	require.Equal(t, "/home/brancz/src/github.com/polarsignals/pprof-labels-example/main.go", fres.Functions[0].Filename)
-	require.Equal(t, "main.main", fres.Functions[0].Name)
-	require.Equal(t, int64(7), lres.Locations[0].Lines[0].Line) // llvm-addr2line gives 10
+	require.Equal(t, "main.iterate", fres.Functions[0].Name)
+	require.Equal(t, int64(27), lres.Locations[0].Lines[0].Line) // llvm-addr2line gives 10
 	require.Equal(t, "/home/brancz/src/github.com/polarsignals/pprof-labels-example/main.go", fres.Functions[1].Filename)
-	require.Equal(t, "main.iterate", fres.Functions[1].Name)
-	require.Equal(t, int64(27), lres.Locations[0].Lines[1].Line)
+	require.Equal(t, "main.iteratePerTenant", fres.Functions[1].Name)
+	require.Equal(t, int64(23), lres.Locations[0].Lines[1].Line)
 	require.Equal(t, "/home/brancz/src/github.com/polarsignals/pprof-labels-example/main.go", fres.Functions[2].Filename)
-	require.Equal(t, "main.iteratePerTenant", fres.Functions[2].Name)
-	require.Equal(t, int64(23), lres.Locations[0].Lines[2].Line)
+	require.Equal(t, "main.main", fres.Functions[2].Name)
+	require.Equal(t, int64(7), lres.Locations[0].Lines[2].Line)
 }
 
 func TestRealSymbolizerDwarfAndSymbols(t *testing.T) {


### PR DESCRIPTION
#### what i do 

use pprof raw get address:

```
1951: 0xfe1475 M=1 google.golang.org/grpc/metadata.Join /home/gitlab-runner/go/pkg/mod/google.golang.org/grpc@v1.48.0/metadata/metadata.go:141 s=0
             google.golang.org/grpc/metadata.MD.Copy /home/gitlab-runner/go/pkg/mod/google.golang.org/grpc@v1.48.0/metadata/metadata.go:92 s=0
             go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc.UnaryServerInterceptor.func1 /home/gitlab-runner/go/pkg/mod/go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.33.0/interceptor.go:304 s=0
```

use parca to tran address:

```
package main

import (
	"debug/elf"
	"log"
	"os"
	"strconv"

	parcadwarf "github.com/parca-dev/parca/pkg/symbol/addr2line"
	"github.com/parca-dev/parca/pkg/symbol/demangle"
)

func main() {
	f, _ := elf.Open(os.Args[1])
	debug, _ := parcadwarf.DWARF(nil, f, demangle.NewDemangler("simple", false))
	pc, _ := strconv.ParseUint(os.Args[2], 16, 64)
	log.Println(debug.PCToLines(pc))
}
```

command:

```
./dwarf/dwarf /home/data/server/otel-collector/data/otelcol-contrib  fe1475
[{297 name:"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc.UnaryServerInterceptor.func1" filename:"/home/gitlab-runner/go/pkg/mod/go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.33.0/interceptor.go"} {138 name:"?" filename:"/home/gitlab-runner/go/pkg/mod/google.golang.org/grpc@v1.48.0/metadata/metadata.go"} {92 name:"?" filename:"/home/gitlab-runner/go/pkg/mod/google.golang.org/grpc@v1.48.0/metadata/metadata.go"}]
```

#### problem

compared with parca output with pprof raw, it have two problem:

- wrong line order compared with pprof.
- could not get inline function name from other compile unit.

#### what things this commit did

- the first commit fix first problem.
- the second commit fix the second problem, it range over all compile unit to build abstractSubprograms.