### PR TITLE
Fix/debuginfofile

### DIFF
--- a/pkg/symbol/elfutils/debuginfofile.go
+++ b/pkg/symbol/elfutils/debuginfofile.go
@@ -67,7 +67,7 @@ func NewDebugInfoFile(f *elf.File, demangler *demangle.Demangler) (DebugInfoFile
 }
 
 // buildAbstractSubprograms will range over all compile unit, build abstractSubprograms
-// cause inline function will cover multi package
+// cause inline function will cover multi package.
 func (f *debugInfoFile) buildAbstractSubprograms() error {
 	er := f.debugData.Reader()
 	_, err := er.Next()

--- a/pkg/symbol/elfutils/debuginfofile.go
+++ b/pkg/symbol/elfutils/debuginfofile.go
@@ -176,7 +176,7 @@ func (f *debugInfoFile) SourceLines(addr uint64) ([]profile.LocationLine, error)
 }
 
 // moveLinesForwardOneStep move each LocationLine's line filed move forward one step
-// to get right line number
+// to get right line number.
 func moveLinesForwardOneStep(lines []profile.LocationLine) {
 	if len(lines) <= 1 {
 		return

--- a/pkg/symbol/elfutils/debuginfofile.go
+++ b/pkg/symbol/elfutils/debuginfofile.go
@@ -238,9 +238,9 @@ func (f *debugInfoFile) ensureLookUpTablesBuilt(cu *dwarf.Entry) error {
 		if err != nil {
 			break
 		}
-		if le.IsStmt {
-			f.lineEntries[cu.Offset] = append(f.lineEntries[cu.Offset], le)
-		}
+		// either addr2line or go tool addr2line
+		// do not check le.IsStmt
+		f.lineEntries[cu.Offset] = append(f.lineEntries[cu.Offset], le)
 	}
 
 	er := f.debugData.Reader()

--- a/pkg/symbol/elfutils/debuginfofile.go
+++ b/pkg/symbol/elfutils/debuginfofile.go
@@ -52,14 +52,50 @@ func NewDebugInfoFile(f *elf.File, demangler *demangle.Demangler) (DebugInfoFile
 		return nil, fmt.Errorf("failed to read DWARF data: %w", err)
 	}
 
-	return &debugInfoFile{
+	result := &debugInfoFile{
 		demangler: demangler,
 
 		debugData:           debugData,
 		lineEntries:         make(map[dwarf.Offset][]dwarf.LineEntry),
 		subprograms:         make(map[dwarf.Offset][]*godwarf.Tree),
 		abstractSubprograms: make(map[dwarf.Offset]*dwarf.Entry),
-	}, nil
+	}
+	if err = result.buildAbstractSubprograms(); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// buildAbstractSubprograms will range over all compile unit, build abstractSubprograms
+// cause inline function will cover multi package
+func (f *debugInfoFile) buildAbstractSubprograms() error {
+	er := f.debugData.Reader()
+	_, err := er.Next()
+	if err != nil {
+		return errors.New("failed to read entry")
+	}
+	for {
+		entry, err := er.Next()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			continue
+		}
+		if entry == nil {
+			break
+		}
+
+		if entry.Tag == dwarf.TagSubprogram {
+			for _, field := range entry.Field {
+				if field.Attr == dwarf.AttrInline {
+					f.abstractSubprograms[entry.Offset] = entry
+					break
+				}
+			}
+		}
+	}
+	return nil
 }
 
 // SourceLines returns the resolved source lines for a program counter (memory address).

--- a/pkg/symbolizer/addr2line.go
+++ b/pkg/symbolizer/addr2line.go
@@ -1,0 +1,218 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package symbolizer
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+const (
+	defaultAddr2line = "addr2line"
+
+	// addr2line may produce multiple lines of output. We
+	// use this sentinel to identify the end of the output.
+	sentinel = ^uint64(0)
+)
+
+// addr2Liner is a connection to an addr2line command for obtaining
+// address and line number information from a binary.
+// copy from github.com/google/pprof@v0.0.0-20221118152302-e6195bd50e26/internal/binutils/addr2liner.go:39
+type addr2Liner struct {
+	mu   sync.Mutex
+	rw   lineReaderWriter
+	base uint64
+}
+
+// lineReaderWriter is an interface to abstract the I/O to an addr2line
+// process. It writes a line of input to the job, and reads its output
+// one line at a time.
+type lineReaderWriter interface {
+	write(string) error
+	readLine() (string, error)
+	close()
+}
+
+type addr2LinerJob struct {
+	cmd *exec.Cmd
+	in  io.WriteCloser
+	out *bufio.Reader
+}
+
+func (a *addr2LinerJob) write(s string) error {
+	_, err := fmt.Fprint(a.in, s+"\n")
+	return err
+}
+
+func (a *addr2LinerJob) readLine() (string, error) {
+	s, err := a.out.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(s), nil
+}
+
+// close releases any resources used by the addr2liner object.
+func (a *addr2LinerJob) close() {
+	a.in.Close()
+	a.cmd.Wait()
+}
+
+// newAddr2liner starts the given addr2liner command reporting
+// information about the given executable file. If file is a shared
+// library, base should be the address at which it was mapped in the
+// program under consideration.
+func newAddr2Liner(cmd, file string, base uint64) (*addr2Liner, error) {
+	if cmd == "" {
+		cmd = defaultAddr2line
+	}
+
+	j := &addr2LinerJob{
+		cmd: exec.Command(cmd, "-aif", "-e", file),
+	}
+
+	var err error
+	if j.in, err = j.cmd.StdinPipe(); err != nil {
+		return nil, err
+	}
+
+	outPipe, err := j.cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+
+	j.out = bufio.NewReader(outPipe)
+	if err := j.cmd.Start(); err != nil {
+		return nil, err
+	}
+
+	a := &addr2Liner{
+		rw:   j,
+		base: base,
+	}
+
+	return a, nil
+}
+
+// readFrame parses the addr2line output for a single address. It
+// returns a populated plugin.Frame and whether it has reached the end of the
+// data.
+func (d *addr2Liner) readFrame() (Frame, bool) {
+	funcname, err := d.rw.readLine()
+	if err != nil {
+		return Frame{}, true
+	}
+	if strings.HasPrefix(funcname, "0x") {
+		// If addr2line returns a hex address we can assume it is the
+		// sentinel. Read and ignore next two lines of output from
+		// addr2line
+		d.rw.readLine()
+		d.rw.readLine()
+		return Frame{}, true
+	}
+
+	fileline, err := d.rw.readLine()
+	if err != nil {
+		return Frame{}, true
+	}
+
+	linenumber := 0
+
+	if funcname == "??" {
+		funcname = ""
+	}
+
+	if fileline == "??:0" {
+		fileline = ""
+	} else {
+		if i := strings.LastIndex(fileline, ":"); i >= 0 {
+			// Remove discriminator, if present
+			if disc := strings.Index(fileline, " (discriminator"); disc > 0 {
+				fileline = fileline[:disc]
+			}
+			// If we cannot parse a number after the last ":", keep it as
+			// part of the filename.
+			if line, err := strconv.Atoi(fileline[i+1:]); err == nil {
+				linenumber = line
+				fileline = fileline[:i]
+			}
+		}
+	}
+
+	return Frame{
+		Func: funcname,
+		File: fileline,
+		Line: linenumber}, false
+}
+
+func (d *addr2Liner) rawAddrInfo(addr uint64) ([]Frame, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if err := d.rw.write(fmt.Sprintf("%x", addr-d.base)); err != nil {
+		return nil, err
+	}
+
+	if err := d.rw.write(fmt.Sprintf("%x", sentinel)); err != nil {
+		return nil, err
+	}
+
+	resp, err := d.rw.readLine()
+	if err != nil {
+		return nil, err
+	}
+
+	if !strings.HasPrefix(resp, "0x") {
+		return nil, fmt.Errorf("unexpected addr2line output: %s", resp)
+	}
+
+	var stack []Frame
+	for {
+		frame, end := d.readFrame()
+		if end {
+			break
+		}
+
+		if frame != (Frame{}) {
+			stack = append(stack, frame)
+		}
+	}
+	return stack, err
+}
+
+// addrInfo returns the stack frame information for a specific program
+// address. It returns nil if the address could not be identified.
+func (d *addr2Liner) addrInfo(addr uint64) ([]Frame, error) {
+	stack, err := d.rawAddrInfo(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	return stack, nil
+}
+
+// A Frame describes a single line in a source file.
+// this struct is in internal package, so we copy it.
+// copy from github.com/google/pprof@v0.0.0-20221118152302-e6195bd50e26/internal/plugin/plugin.go:161.
+type Frame struct {
+	Func string // name of function
+	File string // source file name
+	Line int    // line in file
+}

--- a/pkg/symbolizer/addr2line.go
+++ b/pkg/symbolizer/addr2line.go
@@ -1,6 +1,8 @@
 // Copyright 2014 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
+// TODO: This license is not consistent with license used in the project.
+//       Delete the inconsistent license and above line and rerun pre-commit to insert a good license.
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
@@ -34,7 +36,7 @@ const (
 
 // addr2Liner is a connection to an addr2line command for obtaining
 // address and line number information from a binary.
-// copy from github.com/google/pprof@v0.0.0-20221118152302-e6195bd50e26/internal/binutils/addr2liner.go:39
+// copy from github.com/google/pprof@v0.0.0-20221118152302-e6195bd50e26/internal/binutils/addr2liner.go:39.
 type addr2Liner struct {
 	mu   sync.Mutex
 	rw   lineReaderWriter
@@ -159,7 +161,8 @@ func (d *addr2Liner) readFrame() (Frame, bool) {
 	return Frame{
 		Func: funcname,
 		File: fileline,
-		Line: linenumber}, false
+		Line: linenumber,
+	}, false
 }
 
 func (d *addr2Liner) rawAddrInfo(addr uint64) ([]Frame, error) {

--- a/pkg/symbolizer/symbolizer_test.go
+++ b/pkg/symbolizer/symbolizer_test.go
@@ -110,7 +110,7 @@ func TestSymbolizer(t *testing.T) {
 	require.Equal(t, fres.Functions[0].Id, lres.Locations[0].Lines[0].FunctionId)
 	require.Equal(t, "/home/brancz/src/github.com/polarsignals/pprof-labels-example/main.go", fres.Functions[0].Filename)
 	require.Equal(t, "main.iterate", fres.Functions[0].Name)
-	require.Equal(t, int64(27), lres.Locations[0].Lines[0].Line) // llvm-addr2line gives 10
+	require.Equal(t, int64(27), lres.Locations[0].Lines[0].Line)
 
 	require.Equal(t, fres.Functions[1].Id, lres.Locations[0].Lines[1].FunctionId)
 	require.Equal(t, "/home/brancz/src/github.com/polarsignals/pprof-labels-example/main.go", fres.Functions[1].Filename)
@@ -120,7 +120,7 @@ func TestSymbolizer(t *testing.T) {
 	require.Equal(t, fres.Functions[2].Id, lres.Locations[0].Lines[2].FunctionId)
 	require.Equal(t, "/home/brancz/src/github.com/polarsignals/pprof-labels-example/main.go", fres.Functions[2].Filename)
 	require.Equal(t, "main.main", fres.Functions[2].Name)
-	require.Equal(t, int64(7), lres.Locations[0].Lines[2].Line)
+	require.Equal(t, int64(10), lres.Locations[0].Lines[2].Line)
 }
 
 func findIndexWithAddress(locs []*pb.Location, address uint64) int {
@@ -173,13 +173,13 @@ func TestRealSymbolizer(t *testing.T) {
 
 	require.Equal(t, "/home/brancz/src/github.com/polarsignals/pprof-labels-example/main.go", fres.Functions[0].Filename)
 	require.Equal(t, "main.iterate", fres.Functions[0].Name)
-	require.Equal(t, int64(27), lres.Locations[0].Lines[0].Line) // llvm-addr2line gives 10
+	require.Equal(t, int64(27), lres.Locations[0].Lines[0].Line)
 	require.Equal(t, "/home/brancz/src/github.com/polarsignals/pprof-labels-example/main.go", fres.Functions[1].Filename)
 	require.Equal(t, "main.iteratePerTenant", fres.Functions[1].Name)
 	require.Equal(t, int64(23), lres.Locations[0].Lines[1].Line)
 	require.Equal(t, "/home/brancz/src/github.com/polarsignals/pprof-labels-example/main.go", fres.Functions[2].Filename)
 	require.Equal(t, "main.main", fres.Functions[2].Name)
-	require.Equal(t, int64(7), lres.Locations[0].Lines[2].Line)
+	require.Equal(t, int64(10), lres.Locations[0].Lines[2].Line)
 }
 
 func TestRealSymbolizerDwarfAndSymbols(t *testing.T) {
@@ -218,11 +218,11 @@ func TestRealSymbolizerDwarfAndSymbols(t *testing.T) {
 
 	require.Equal(t, "/home/kakkoyun/Workspace/PolarSignals/pprof-example-app-go/fib/fib.go", fres.Functions[0].Filename)
 	require.Equal(t, "github.com/polarsignals/pprof-example-app-go/fib.Fibonacci", fres.Functions[0].Name)
-	require.Equal(t, int64(5), lres.Locations[0].Lines[0].Line)
+	require.Equal(t, int64(13), lres.Locations[0].Lines[0].Line)
 
 	require.Equal(t, "/home/kakkoyun/Workspace/PolarSignals/pprof-example-app-go/main.go", fres.Functions[1].Filename)
 	require.Equal(t, "main.busyCPU", fres.Functions[1].Name)
-	require.Equal(t, int64(86), lres.Locations[1].Lines[0].Line)
+	require.Equal(t, int64(89), lres.Locations[1].Lines[0].Line)
 }
 
 func TestRealSymbolizerInliningDisabled(t *testing.T) {
@@ -268,11 +268,11 @@ func TestRealSymbolizerInliningDisabled(t *testing.T) {
 
 	require.Equal(t, "/home/kakkoyun/Workspace/PolarSignals/pprof-example-app-go/fib/fib.go", fres.Functions[0].Filename)
 	require.Equal(t, "github.com/polarsignals/pprof-example-app-go/fib.Fibonacci", fres.Functions[0].Name)
-	require.Equal(t, int64(5), lres.Locations[0].Lines[0].Line)
+	require.Equal(t, int64(13), lres.Locations[0].Lines[0].Line)
 
 	require.Equal(t, "/home/kakkoyun/Workspace/PolarSignals/pprof-example-app-go/main.go", fres.Functions[1].Filename)
 	require.Equal(t, "main.busyCPU", fres.Functions[1].Name)
-	require.Equal(t, int64(86), lres.Locations[1].Lines[0].Line)
+	require.Equal(t, int64(89), lres.Locations[1].Lines[0].Line)
 }
 
 func TestRealSymbolizerWithoutDWARF(t *testing.T) {

--- a/pkg/symbolizer/symbolizer_test.go
+++ b/pkg/symbolizer/symbolizer_test.go
@@ -109,18 +109,18 @@ func TestSymbolizer(t *testing.T) {
 
 	require.Equal(t, fres.Functions[0].Id, lres.Locations[0].Lines[0].FunctionId)
 	require.Equal(t, "/home/brancz/src/github.com/polarsignals/pprof-labels-example/main.go", fres.Functions[0].Filename)
-	require.Equal(t, "main.main", fres.Functions[0].Name)
-	require.Equal(t, int64(7), lres.Locations[0].Lines[0].Line) // llvm-addr2line gives 10
+	require.Equal(t, "main.iterate", fres.Functions[0].Name)
+	require.Equal(t, int64(27), lres.Locations[0].Lines[0].Line) // llvm-addr2line gives 10
 
 	require.Equal(t, fres.Functions[1].Id, lres.Locations[0].Lines[1].FunctionId)
 	require.Equal(t, "/home/brancz/src/github.com/polarsignals/pprof-labels-example/main.go", fres.Functions[1].Filename)
-	require.Equal(t, "main.iterate", fres.Functions[1].Name)
-	require.Equal(t, int64(27), lres.Locations[0].Lines[1].Line)
+	require.Equal(t, "main.iteratePerTenant", fres.Functions[1].Name)
+	require.Equal(t, int64(23), lres.Locations[0].Lines[1].Line)
 
 	require.Equal(t, fres.Functions[2].Id, lres.Locations[0].Lines[2].FunctionId)
 	require.Equal(t, "/home/brancz/src/github.com/polarsignals/pprof-labels-example/main.go", fres.Functions[2].Filename)
-	require.Equal(t, "main.iteratePerTenant", fres.Functions[2].Name)
-	require.Equal(t, int64(23), lres.Locations[0].Lines[2].Line)
+	require.Equal(t, "main.main", fres.Functions[2].Name)
+	require.Equal(t, int64(7), lres.Locations[0].Lines[2].Line)
 }
 
 func findIndexWithAddress(locs []*pb.Location, address uint64) int {
@@ -172,14 +172,14 @@ func TestRealSymbolizer(t *testing.T) {
 	require.Equal(t, 3, len(fres.Functions))
 
 	require.Equal(t, "/home/brancz/src/github.com/polarsignals/pprof-labels-example/main.go", fres.Functions[0].Filename)
-	require.Equal(t, "main.main", fres.Functions[0].Name)
-	require.Equal(t, int64(7), lres.Locations[0].Lines[0].Line) // llvm-addr2line gives 10
+	require.Equal(t, "main.iterate", fres.Functions[0].Name)
+	require.Equal(t, int64(27), lres.Locations[0].Lines[0].Line) // llvm-addr2line gives 10
 	require.Equal(t, "/home/brancz/src/github.com/polarsignals/pprof-labels-example/main.go", fres.Functions[1].Filename)
-	require.Equal(t, "main.iterate", fres.Functions[1].Name)
-	require.Equal(t, int64(27), lres.Locations[0].Lines[1].Line)
+	require.Equal(t, "main.iteratePerTenant", fres.Functions[1].Name)
+	require.Equal(t, int64(23), lres.Locations[0].Lines[1].Line)
 	require.Equal(t, "/home/brancz/src/github.com/polarsignals/pprof-labels-example/main.go", fres.Functions[2].Filename)
-	require.Equal(t, "main.iteratePerTenant", fres.Functions[2].Name)
-	require.Equal(t, int64(23), lres.Locations[0].Lines[2].Line)
+	require.Equal(t, "main.main", fres.Functions[2].Name)
+	require.Equal(t, int64(7), lres.Locations[0].Lines[2].Line)
 }
 
 func TestRealSymbolizerDwarfAndSymbols(t *testing.T) {


### PR DESCRIPTION
#### what i do 

use pprof raw get address:

```
1951: 0xfe1475 M=1 google.golang.org/grpc/metadata.Join /home/gitlab-runner/go/pkg/mod/google.golang.org/grpc@v1.48.0/metadata/metadata.go:141 s=0
             google.golang.org/grpc/metadata.MD.Copy /home/gitlab-runner/go/pkg/mod/google.golang.org/grpc@v1.48.0/metadata/metadata.go:92 s=0
             go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc.UnaryServerInterceptor.func1 /home/gitlab-runner/go/pkg/mod/go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.33.0/interceptor.go:304 s=0
```

use parca to tran address:

```
package main

import (
	"debug/elf"
	"log"
	"os"
	"strconv"

	parcadwarf "github.com/parca-dev/parca/pkg/symbol/addr2line"
	"github.com/parca-dev/parca/pkg/symbol/demangle"
)

func main() {
	f, _ := elf.Open(os.Args[1])
	debug, _ := parcadwarf.DWARF(nil, f, demangle.NewDemangler("simple", false))
	pc, _ := strconv.ParseUint(os.Args[2], 16, 64)
	log.Println(debug.PCToLines(pc))
}
```

command:

```
./dwarf/dwarf /home/data/server/otel-collector/data/otelcol-contrib  fe1475
[{297 name:"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc.UnaryServerInterceptor.func1" filename:"/home/gitlab-runner/go/pkg/mod/go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.33.0/interceptor.go"} {138 name:"?" filename:"/home/gitlab-runner/go/pkg/mod/google.golang.org/grpc@v1.48.0/metadata/metadata.go"} {92 name:"?" filename:"/home/gitlab-runner/go/pkg/mod/google.golang.org/grpc@v1.48.0/metadata/metadata.go"}]
```

#### problem

compared with parca output with pprof raw, it have three problem:

- wrong line order compared with pprof.
- could not get inline function name from other compile unit.
- wrong line number of inline function.

#### what things this commit did
fib problem:
- the first commit fix first problem.
- the second commit fix the second problem, it range over all compile unit to build abstractSubprograms.
- the third commit fix the third problem, it use  inline sub routine's field AttrCallLine to get line number.


enhancement about 20% cpu usage:
- cache complication unit range and reuse dwarf.Reader.
#### new program output 
new program output is equal with go pprof raw.
```
[root@plat-sh-infra-prod-jaeger-collector003 dwarf]# ./dwarf  /home/data/server/otel-collector/data/otelcol-contrib fe1475
2022/11/24 15:11:35 [{141 name:"google.golang.org/grpc/metadata.Join" filename:"/home/gitlab-runner/go/pkg/mod/google.golang.org/grpc@v1.48.0/metadata/metadata.go"} {92 name:"google.golang.org/grpc/metadata.MD.Copy" filename:"/home/gitlab-runner/go/pkg/mod/go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.33.0/interceptor.go"} {304 name:"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc.UnaryServerInterceptor.func1" filename:"/home/gitlab-runner/go/pkg/mod/google.golang.org/grpc@v1.48.0/metadata/metadata.go"}] <nil>
```