### PR TITLE
pkg/profilestore: Reduce allocs in writeSeries

### DIFF
--- a/pkg/profilestore/profilecolumnstore.go
+++ b/pkg/profilestore/profilecolumnstore.go
@@ -99,8 +99,9 @@ func (s *ProfileColumnStore) writeSeries(ctx context.Context, req *profilestorep
 		s.bufferPool,
 	)
 
+	ls := make(labels.Labels, 0)
 	for _, series := range req.Series {
-		ls := make(labels.Labels, 0, len(series.Labels.Labels))
+		ls = ls[:0]
 		for _, l := range series.Labels.Labels {
 			if valid := model.LabelName(l.Name).IsValid(); !valid {
 				return status.Errorf(codes.InvalidArgument, "invalid label name: %v", l.Name)

--- a/pkg/profilestore/profilestore_test.go
+++ b/pkg/profilestore/profilestore_test.go
@@ -111,3 +111,79 @@ func Test_LabelName_Error(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkProfileColumnStoreWriteSeries(b *testing.B) {
+	ctx := context.Background()
+	logger := log.NewNopLogger()
+	reg := prometheus.NewRegistry()
+	tracer := trace.NewNoopTracerProvider().Tracer("")
+	col, err := frostdb.New()
+	require.NoError(b, err)
+	colDB, err := col.DB(ctx, "parca")
+	require.NoError(b, err)
+
+	schema, err := parcacol.Schema()
+	require.NoError(b, err)
+
+	table, err := colDB.Table(
+		"stacktraces",
+		frostdb.NewTableConfig(schema),
+	)
+	require.NoError(b, err)
+	m := metastoretest.NewTestMetastore(
+		b,
+		logger,
+		reg,
+		tracer,
+	)
+
+	api := NewProfileColumnStore(
+		logger,
+		tracer,
+		metastore.NewInProcessClient(m),
+		table,
+		schema,
+		false,
+	)
+
+	req := &profilestorepb.WriteRawRequest{
+		Series: []*profilestorepb.RawProfileSeries{
+			{
+				Labels: &profilestorepb.LabelSet{
+					Labels: []*profilestorepb.Label{
+						{
+							Name:  "n0",
+							Value: "v0",
+						},
+					},
+				},
+			},
+			{
+				Labels: &profilestorepb.LabelSet{
+					Labels: []*profilestorepb.Label{
+						{
+							Name:  "n1",
+							Value: "v1",
+						},
+					},
+				},
+			},
+			{
+				Labels: &profilestorepb.LabelSet{
+					Labels: []*profilestorepb.Label{
+						{
+							Name:  "n2",
+							Value: "v2",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for n := 0; n < b.N; n++ {
+		api.writeSeries(ctx, req)
+	}
+}

--- a/pkg/profilestore/profilestore_test.go
+++ b/pkg/profilestore/profilestore_test.go
@@ -143,7 +143,6 @@ func BenchmarkProfileColumnStoreWriteSeries(b *testing.B) {
 		metastore.NewInProcessClient(m),
 		table,
 		schema,
-		false,
 	)
 
 	req := &profilestorepb.WriteRawRequest{


### PR DESCRIPTION
Potentially it's possible to reduce allocs in `ProfileColumnStore.writeSeries` if it's possible to reuse a slice of labels (I followed the call stack and didn't find any concurrent access, but I might be missing something).

```
# new
BenchmarkProfileColumnStoreWriteSeries-12  5725592  197.7 ns/op  120 B/op  5 allocs/op
# old
BenchmarkProfileColumnStoreWriteSeries-12  4249389  259.8 ns/op  184 B/op  7 allocs/op
```

<details>

<summary>new</summary>

```
(pprof) list writeS
Total: 1.26GB
ROUTINE ======================== github.com/parca-dev/parca/pkg/profilestore.(*ProfileColumnStore).writeSeries
  655.02MB   762.02MB (flat, cum) 59.16% of Total
         .          .    105:}
         .          .    106:
         .          .    107:func (s *ProfileColumnStore) writeSeries(ctx context.Context, req *profilestorepb.WriteRawRequest) error {
         .          .    108:	ingester := parcacol.NewIngester(
         .          .    109:		s.logger,
         .      107MB    110:		parcacol.NewNormalizer(s.metastore),
         .          .    111:		s.table,
         .          .    112:		s.schema,
         .          .    113:		s.bufferPool,
         .          .    114:	)
         .          .    115:
         .          .    116:	ls := make(labels.Labels, 0)
         .          .    117:	for _, series := range req.Series {
         .          .    118:		ls = ls[:0]
         .          .    119:		for _, l := range series.Labels.Labels {
         .          .    120:			if valid := model.LabelName(l.Name).IsValid(); !valid {
         .          .    121:				return status.Errorf(codes.InvalidArgument, "invalid label name: %v", l.Name)
         .          .    122:			}
         .          .    123:
  215.51MB   215.51MB    124:			ls = append(ls, labels.Label{
         .          .    125:				Name:  l.Name,
         .          .    126:				Value: l.Value,
         .          .    127:			})
         .          .    128:		}
         .          .    129:
         .          .    130:		// Must ensure label-set is sorted and HasDuplicateLabelNames also required a sorted label-set
  439.51MB   439.51MB    131:		sort.Sort(ls)
         .          .    132:		if name, has := ls.HasDuplicateLabelNames(); has {
         .          .    133:			return status.Errorf(codes.InvalidArgument, "duplicate label names: %v", name)
         .          .    134:		}
         .          .    135:
         .          .    136:		for _, sample := range series.Samples {
```

</details>

<details>

<summary>old</summary>

```
(pprof) list writeS
Total: 1.43GB
ROUTINE ======================== github.com/parca-dev/parca/pkg/profilestore.(*ProfileColumnStore).writeSeries
  859.52MB   941.52MB (flat, cum) 64.23% of Total
         .          .    105:}
         .          .    106:
         .          .    107:func (s *ProfileColumnStore) writeSeries(ctx context.Context, req *profilestorepb.WriteRawRequest) error {
         .          .    108:	ingester := parcacol.NewIngester(
         .          .    109:		s.logger,
         .       82MB    110:		parcacol.NewNormalizer(s.metastore),
         .          .    111:		s.table,
         .          .    112:		s.schema,
         .          .    113:		s.bufferPool,
         .          .    114:	)
         .          .    115:
         .          .    116:	for _, series := range req.Series {
  508.02MB   508.02MB    117:		ls := make(labels.Labels, 0, len(series.Labels.Labels))
         .          .    118:		for _, l := range series.Labels.Labels {
         .          .    119:			if valid := model.LabelName(l.Name).IsValid(); !valid {
         .          .    120:				return status.Errorf(codes.InvalidArgument, "invalid label name: %v", l.Name)
         .          .    121:			}
         .          .    122:
         .          .    123:			ls = append(ls, labels.Label{
         .          .    124:				Name:  l.Name,
         .          .    125:				Value: l.Value,
         .          .    126:			})
         .          .    127:		}
         .          .    128:
         .          .    129:		// Must ensure label-set is sorted and HasDuplicateLabelNames also required a sorted label-set
  351.51MB   351.51MB    130:		sort.Sort(ls)
         .          .    131:		if name, has := ls.HasDuplicateLabelNames(); has {
         .          .    132:			return status.Errorf(codes.InvalidArgument, "duplicate label names: %v", name)
         .          .    133:		}
         .          .    134:
         .          .    135:		for _, sample := range series.Samples {
```

</details>