### PR TITLE
pkg/parca: Create structs for flag categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,11 @@ Flags:
                                 Path to config file.
       --mode="all"              Scraper only runs a scraper that sends to a
                                 remote gRPC endpoint. All runs all components.
-      --log-level="info"        log level.
       --http-address=":7070"    Address to bind HTTP server to.
       --port=""                 (DEPRECATED) Use http-address instead.
+      --log-level="info"        Log level.
+      --log-format="logfmt"     Configure if structured logging as JSON or as
+                                logfmt
       --cors-allowed-origins=CORS-ALLOWED-ORIGINS,...
                                 Allowed CORS origins.
       --otlp-address=STRING     OpenTelemetry collector address to send traces
@@ -120,26 +122,26 @@ Flags:
       --symbolizer-number-of-tries=3
                                 Number of tries to attempt to symbolize an
                                 unsybolized location
-      --metastore="badger"      Which metastore implementation to use
-      --profile-share-server="api.pprof.me:443"
-                                gRPC address to send share profile requests to.
-      --debug-infod-upstream-servers=https://debuginfod.elfutils.org,...
+      --debuginfod-upstream-servers=https://debuginfod.elfutils.org,...
                                 Upstream debuginfod servers. Defaults to
                                 https://debuginfod.elfutils.org. It is an
                                 ordered list of servers to try. Learn more at
                                 https://sourceware.org/elfutils/Debuginfod.html
-      --debug-infod-http-request-timeout=5m
+      --debuginfod-http-request-timeout=5m
                                 Timeout duration for HTTP request to upstream
                                 debuginfod server. Defaults to 5m
-      --debuginfo-cache-dir="/tmp"
+      --debuginfod-cache-dir="/tmp"
                                 Path to directory where debuginfo is cached.
-      --debuginfo-upload-max-size=1000000000
+      --debuginfod-upload-max-size=1000000000
                                 Maximum size of debuginfo upload in bytes.
-      --debuginfo-upload-max-duration=15m
+      --debuginfod-upload-max-duration=15m
                                 Maximum duration of debuginfo upload.
-      --debuginfo-uploads-signed-url
+      --debuginfod-uploads-signed-url
                                 Whether to use signed URLs for debuginfo
                                 uploads.
+      --metastore="badger"      Which metastore implementation to use
+      --profile-share-server="api.pprof.me:443"
+                                gRPC address to send share profile requests to.
       --store-address=STRING    gRPC address to send profiles and symbols to.
       --bearer-token=STRING     Bearer token to authenticate with store.
       --bearer-token-file=STRING

--- a/README.md
+++ b/README.md
@@ -122,6 +122,15 @@ Flags:
       --symbolizer-number-of-tries=3
                                 Number of tries to attempt to symbolize an
                                 unsybolized location
+      --debuginfo-cache-dir="/tmp"
+                                Path to directory where debuginfo is cached.
+      --debuginfo-upload-max-size=1000000000
+                                Maximum size of debuginfo upload in bytes.
+      --debuginfo-upload-max-duration=15m
+                                Maximum duration of debuginfo upload.
+      --debuginfo-uploads-signed-url
+                                Whether to use signed URLs for debuginfo
+                                uploads.
       --debuginfod-upstream-servers=https://debuginfod.elfutils.org,...
                                 Upstream debuginfod servers. Defaults to
                                 https://debuginfod.elfutils.org. It is an
@@ -130,15 +139,6 @@ Flags:
       --debuginfod-http-request-timeout=5m
                                 Timeout duration for HTTP request to upstream
                                 debuginfod server. Defaults to 5m
-      --debuginfod-cache-dir="/tmp"
-                                Path to directory where debuginfo is cached.
-      --debuginfod-upload-max-size=1000000000
-                                Maximum size of debuginfo upload in bytes.
-      --debuginfod-upload-max-duration=15m
-                                Maximum duration of debuginfo upload.
-      --debuginfod-uploads-signed-url
-                                Whether to use signed URLs for debuginfo
-                                uploads.
       --metastore="badger"      Which metastore implementation to use
       --profile-share-server="api.pprof.me:443"
                                 gRPC address to send share profile requests to.

--- a/cmd/parca/main.go
+++ b/cmd/parca/main.go
@@ -45,7 +45,7 @@ func main() {
 	serverStr := figure.NewColorFigure("Parca", "roman", "cyan", true)
 	serverStr.Print()
 
-	logger := parca.NewLogger(flags.LogLevel, parca.LogFormatLogfmt, "parca")
+	logger := parca.NewLogger(flags.Logs.Level, flags.Logs.Format, "parca")
 	level.Debug(logger).Log("msg", "parca initialized",
 		"version", version,
 		"commit", commit,

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -30,7 +30,7 @@ type ObjectStorageValidRule struct{}
 func (v ObjectStorageValidRule) Validate(value interface{}) error {
 	c, ok := value.(*ObjectStorage)
 	if !ok {
-		return errors.New("DebugInfo is invalid")
+		return errors.New("debuginfod is invalid")
 	}
 	return validation.ValidateStruct(c,
 		validation.Field(&c.Bucket, validation.Required, BucketValid),

--- a/pkg/parca/logger.go
+++ b/pkg/parca/logger.go
@@ -21,8 +21,7 @@ import (
 )
 
 const (
-	LogFormatLogfmt = "logfmt"
-	LogFormatJSON   = "json"
+	LogFormatJSON = "json"
 )
 
 // NewLogger returns a log.Logger that prints in the provided format at the
@@ -51,9 +50,10 @@ func NewLogger(logLevel, logFormat, debugName string) log.Logger {
 		panic("unexpected log level")
 	}
 
-	logger = log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
+	writer := log.NewSyncWriter(os.Stderr)
+	logger = log.NewLogfmtLogger(writer)
 	if logFormat == LogFormatJSON {
-		logger = log.NewJSONLogger(log.NewSyncWriter(os.Stderr))
+		logger = log.NewJSONLogger(writer)
 	}
 
 	logger = level.NewFilter(logger, lvl)

--- a/pkg/parca/parca.go
+++ b/pkg/parca/parca.go
@@ -78,9 +78,10 @@ const (
 type Flags struct {
 	ConfigPath  string `default:"parca.yaml" help:"Path to config file."`
 	Mode        string `default:"all" enum:"all,scraper-only" help:"Scraper only runs a scraper that sends to a remote gRPC endpoint. All runs all components."`
-	LogLevel    string `default:"info" enum:"error,warn,info,debug" help:"log level."`
 	HTTPAddress string `default:":7070" help:"Address to bind HTTP server to."`
 	Port        string `default:"" help:"(DEPRECATED) Use http-address instead."`
+
+	Logs FlagsLogs `embed:"" prefix:"log-"`
 
 	CORSAllowedOrigins []string `help:"Allowed CORS origins."`
 	OTLPAddress        string   `help:"OpenTelemetry collector address to send traces to."`
@@ -108,6 +109,11 @@ type Flags struct {
 	Insecure           bool              `kong:"help='Send gRPC requests via plaintext instead of TLS.'"`
 	InsecureSkipVerify bool              `kong:"help='Skip TLS certificate verification.'"`
 	ExternalLabel      map[string]string `kong:"help='Label(s) to attach to all profiles in scraper-only mode.'"`
+}
+
+type FlagsLogs struct {
+	Level  string `enum:"error,warn,info,debug" default:"info" help:"Log level."`
+	Format string `enum:"logfmt,json" default:"logfmt" help:"Configure if structured logging as JSON or as logfmt"`
 }
 
 type FlagsStorage struct {

--- a/pkg/parca/parca_test.go
+++ b/pkg/parca/parca_test.go
@@ -65,11 +65,13 @@ func benchmarkSetup(ctx context.Context, b *testing.B) (pb.ProfileStoreServiceCl
 	go func() {
 		defer close(done)
 		err := Run(ctx, logger, reg, &Flags{
-			ConfigPath:          "testdata/parca.yaml",
-			Port:                addr,
-			Metastore:           metaStoreBadger,
-			StorageGranuleSize:  8 * 1024,
-			StorageActiveMemory: 512 * 1024 * 1024,
+			ConfigPath: "testdata/parca.yaml",
+			Port:       addr,
+			Metastore:  metaStoreBadger,
+			Storage: FlagsStorage{
+				GranuleSize:  8 * 1024,
+				ActiveMemory: 512 * 1024 * 1024,
+			},
 		}, "test-version")
 		if !errors.Is(err, context.Canceled) {
 			require.NoError(b, err)


### PR DESCRIPTION
This is just a start. 
We probably want to start some of the Parca Agent structs here too (since they are already a bit more cleaned up).
Then Parca Agent could reuse the same structs to make for very consistent flags across projects. 