### PR TITLE
Use scrape interval correctly

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -254,13 +254,13 @@ func (c *ScrapeConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	// Validate the scrape and timeout internal configuration. When /debug/pprof/profile scraping
 	// is enabled we need to make sure there is enough time to complete the scrape.
-	if c.ScrapeTimeout > c.ScrapeInterval {
-		return fmt.Errorf("scrape timeout must be smaller or equal to inverval for: %v", c.JobName)
+	if c.ScrapeTimeout == 0 {
+		c.ScrapeTimeout = c.ScrapeInterval + model.Duration(3*time.Second)
+	}
+	if c.ScrapeTimeout <= c.ScrapeInterval {
+		return fmt.Errorf("scrape timeout must be greater than the interval: %v", c.JobName)
 	}
 
-	if c.ScrapeTimeout == 0 {
-		c.ScrapeTimeout = c.ScrapeInterval
-	}
 	if cfg, ok := c.ProfilingConfig.PprofConfig[pprofProcessCPU]; ok {
 		if *cfg.Enabled && c.ScrapeTimeout < model.Duration(time.Second*2) {
 			return fmt.Errorf("%v scrape_timeout must be at least 2 seconds in %v", pprofProcessCPU, c.JobName)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -42,7 +42,7 @@ func TestLoadComplex(t *testing.T) {
 	complexYAML := `
 scrape_configs:
   - job_name: 'parca'
-    scrape_interval: 10s
+    scrape_interval: 5s
     static_configs:
       - targets: [ 'localhost:10902' ]
     profiling_config:
@@ -74,8 +74,8 @@ scrape_configs:
 		ScrapeConfigs: []*ScrapeConfig{
 			{
 				JobName:        "parca",
-				ScrapeInterval: model.Duration(10 * time.Second),
-				ScrapeTimeout:  model.Duration(10 * time.Second),
+				ScrapeInterval: model.Duration(5 * time.Second),
+				ScrapeTimeout:  model.Duration(8 * time.Second),
 				Scheme:         "http",
 				ProfilingConfig: &ProfilingConfig{
 					PprofConfig: PprofConfig{
@@ -115,14 +115,14 @@ scrape_configs:
 			{
 				JobName:         "empty-profiling-config",
 				ScrapeInterval:  model.Duration(10 * time.Second),
-				ScrapeTimeout:   model.Duration(10 * time.Second),
+				ScrapeTimeout:   model.Duration(13 * time.Second),
 				Scheme:          "http",
 				ProfilingConfig: DefaultScrapeConfig().ProfilingConfig,
 			},
 			{
 				JobName:        "path-prefix",
 				ScrapeInterval: model.Duration(10 * time.Second),
-				ScrapeTimeout:  model.Duration(10 * time.Second),
+				ScrapeTimeout:  model.Duration(13 * time.Second),
 				Scheme:         "http",
 				ProfilingConfig: &ProfilingConfig{
 					PprofPrefix: "/test/prefix",
@@ -158,7 +158,7 @@ scrape_configs:
 			{
 				JobName:        "path-prefix-with-defaults",
 				ScrapeInterval: model.Duration(10 * time.Second),
-				ScrapeTimeout:  model.Duration(10 * time.Second),
+				ScrapeTimeout:  model.Duration(13 * time.Second),
 				Scheme:         "http",
 				ProfilingConfig: &ProfilingConfig{
 					PprofPrefix: "/test/prefix",

--- a/pkg/config/reloader_test.go
+++ b/pkg/config/reloader_test.go
@@ -88,7 +88,7 @@ func TestReloadValid(t *testing.T) {
 	f, reloadConfig := setupReloader(ctx, t)
 	defer f.Close()
 
-	config := `    scrape_timeout: "3s"
+	config := `    scrape_timeout: "4s"
 `
 
 	if _, err := f.WriteString(config); err != nil {
@@ -97,7 +97,7 @@ func TestReloadValid(t *testing.T) {
 
 	select {
 	case cfg := <-reloadConfig:
-		require.Equal(t, model.Duration(time.Second*3), cfg.ScrapeConfigs[0].ScrapeTimeout)
+		require.Equal(t, model.Duration(time.Second*4), cfg.ScrapeConfigs[0].ScrapeTimeout)
 	case <-ctx.Done():
 		t.Error("configuration reload timed out")
 	}

--- a/pkg/scrape/target.go
+++ b/pkg/scrape/target.go
@@ -370,7 +370,7 @@ func targetsFromGroup(tg *targetgroup.Group, cfg *config.ScrapeConfig) ([]*Targe
 				}
 
 				if pcfg, found := cfg.ProfilingConfig.PprofConfig[profType]; found && pcfg.Delta {
-					params.Add("seconds", strconv.Itoa(int(time.Duration(cfg.ScrapeTimeout)/time.Second)-1))
+					params.Add("seconds", strconv.Itoa(int(time.Duration(cfg.ScrapeInterval)/time.Second)))
 				}
 
 				targets = append(targets, NewTarget(lbls, origLabels, params))


### PR DESCRIPTION
Use the scrape interval rather than the timeout to determine the profile duration on scraping. Since taking the profile will take strictly longer than the duration the timeout must be allowed to be larger as well. By default 3s are added to the interval based on real-world obvservations.