### PR TITLE
symbolizer: Log addresses in hexadecimal

### DIFF
--- a/pkg/symbol/addr2line/dwarf.go
+++ b/pkg/symbol/addr2line/dwarf.go
@@ -57,7 +57,7 @@ func (dl *DwarfLiner) PCToLines(addr uint64) (lines []profile.LocationLine, err 
 
 	lines, err = dl.dbgFile.SourceLines(addr)
 	if err != nil {
-		level.Debug(dl.logger).Log("msg", "failed to symbolize location", "addr", addr, "err", err)
+		level.Debug(dl.logger).Log("msg", "failed to symbolize location", "addr", fmt.Sprintf("0x%x", addr), "err", err)
 		return nil, err
 	}
 	return lines, nil

--- a/pkg/symbol/symbol.go
+++ b/pkg/symbol/symbol.go
@@ -137,7 +137,7 @@ func (s *Symbolizer) Symbolize(ctx context.Context, m *pb.Mapping, locations []*
 
 // pcToLines returns the line number of the given PC while keeping the track of symbolization attempts and failures.
 func (s *Symbolizer) pcToLines(liner liner, buildID, key string, addr uint64) []profile.LocationLine {
-	logger := log.With(s.logger, "addr", addr, "buildid", buildID)
+	logger := log.With(s.logger, "addr", fmt.Sprintf("0x%x", addr), "buildid", buildID)
 	// Check if we already attempt to symbolize this location and failed.
 	if _, failedBefore := s.symbolizationFailed[key][addr]; failedBefore {
 		level.Debug(logger).Log("msg", "location already had been attempted to be symbolized and failed, skipping")


### PR DESCRIPTION
Found this while taking a look at https://github.com/parca-dev/parca/issues/1757#issuecomment-1338061948

Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>