### PR TITLE
pkg/debuginfo: Cache positive exists lookups

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.0-rc.3
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.14.0
+	github.com/hashicorp/golang-lru/v2 v2.0.1
 	github.com/ianlancetaylor/demangle v0.0.0-20220517205856-0058ec4f073c
 	github.com/improbable-eng/grpc-web v0.15.0
 	github.com/klauspost/compress v1.15.12

--- a/go.sum
+++ b/go.sum
@@ -581,6 +581,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/hashicorp/golang-lru/v2 v2.0.1 h1:5pv5N1lT1fjLg2VQ5KWc7kmucp2x/kvFOnxuVTqZ6x4=
+github.com/hashicorp/golang-lru/v2 v2.0.1/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=

--- a/pkg/debuginfo/store_test.go
+++ b/pkg/debuginfo/store_test.go
@@ -143,4 +143,15 @@ func TestStore(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, debuginfopb.DownloadInfo_SOURCE_UPLOAD, downloader.Info().Source)
 	require.NoError(t, downloader.Close())
+
+	bucket, err = client.NewBucket(logger, cfg, prometheus.NewRegistry(), "parca/store")
+	require.NoError(t, err)
+
+	// Replace bucket with a new empty one.
+	s.bucket = bucket
+
+	// Test that the response is cached.
+	exists, err = c.Exists(context.Background(), hex.EncodeToString([]byte("section")), "abcd")
+	require.NoError(t, err)
+	require.True(t, exists)
 }


### PR DESCRIPTION
Previously we issued lots of repeated lookups in object storage. Since this data is immutable, once this result is positive, it will never change again, so we can cache the response forever.

How we got here: I noticed that our object storage bill was about ~50% class A operations (the other ~50% are egress network traffic). A quick Prometheus query revealed that 92% of all object storage requests are `iter` requests by the debuginfo API:

<img width="1904" alt="Screenshot 2022-12-06 at 10 51 31" src="https://user-images.githubusercontent.com/4546722/205942131-fe0877dd-fc34-46e6-945b-64187e8241f0.png">

Then I queried some continuous profiling data to discover which stacks are spending the most CPU time (therefore most often called) that call the iter function (screenshot is from Polar Signals Cloud):

<img width="1905" alt="Screenshot 2022-12-06 at 10 50 42" src="https://user-images.githubusercontent.com/4546722/205942790-a55cf7be-af3c-4713-b36b-f893a0c330d0.png">

This shows clearly that the majority of times the `Exists` gRPC call calls the `iter` function, more specifically even the `find` function that I added caching to in this patch. So I checked what we can do about that, and it turns out all the positive answers can be cached therefore saving what I believe must be the overwhelming majority of API calls.

Once merged I can observe this for a day and check whether we get the saving that I anticipate.