### PR TITLE
pkg/debuginfo: Validate size of upload is set

### DIFF
--- a/pkg/debuginfo/store.go
+++ b/pkg/debuginfo/store.go
@@ -238,6 +238,9 @@ func (s *Store) InitiateUpload(ctx context.Context, req *debuginfopb.InitiateUpl
 	if req.Hash == "" {
 		return nil, status.Error(codes.InvalidArgument, "hash must be set")
 	}
+	if req.Size == 0 {
+		return nil, status.Error(codes.InvalidArgument, "size must be set")
+	}
 
 	// We don't want to blindly accept upload initiation requests that
 	// shouldn't have happened.

--- a/pkg/debuginfo/store_test.go
+++ b/pkg/debuginfo/store_test.go
@@ -123,6 +123,7 @@ func TestStore(t *testing.T) {
 	_, err = debuginfoClient.InitiateUpload(ctx, &debuginfopb.InitiateUploadRequest{
 		BuildId: "abcd",
 		Hash:    "foo",
+		Size:    2,
 	})
 	require.NoError(t, err)
 
@@ -144,6 +145,7 @@ func TestStore(t *testing.T) {
 	initiateResp, err := debuginfoClient.InitiateUpload(ctx, &debuginfopb.InitiateUploadRequest{
 		BuildId: "abcd",
 		Hash:    "foo",
+		Size:    2,
 	})
 	require.NoError(t, err)
 
@@ -192,6 +194,7 @@ func TestStore(t *testing.T) {
 	_, err = debuginfoClient.InitiateUpload(ctx, &debuginfopb.InitiateUploadRequest{
 		BuildId: "abcd",
 		Hash:    "foo",
+		Size:    2,
 	})
 	require.EqualError(t, err, "rpc error: code = AlreadyExists desc = Debuginfo already exists and is marked as invalid, but the proposed hash is the same as the one already available, therefore the upload is not accepted as it would result in the same invalid debuginfos.")
 


### PR DESCRIPTION
Small improvement that is not strictly necessary since an upload of 0 wouldn't hurt, but we should rather error than let the client do something that doesn't make sense.