### PR TITLE
parcacol: change stacktrace column to plain encoding

### DIFF
--- a/pkg/parcacol/schema.go
+++ b/pkg/parcacol/schema.go
@@ -116,8 +116,10 @@ func Schema() (*dynparquet.Schema, error) {
 			}, {
 				Name: ColumnStacktrace,
 				StorageLayout: &schemapb.StorageLayout{
-					Type:        schemapb.StorageLayout_TYPE_STRING,
-					Encoding:    schemapb.StorageLayout_ENCODING_RLE_DICTIONARY,
+					Type: schemapb.StorageLayout_TYPE_STRING,
+					// NOTE: using RLE dictionary causes compaction to explode
+					// in memory due to high cardinality of the dictionaries.
+					Encoding:    schemapb.StorageLayout_ENCODING_PLAIN_UNSPECIFIED,
 					Compression: schemapb.StorageLayout_COMPRESSION_LZ4_RAW,
 				},
 				Dynamic: false,


### PR DESCRIPTION
The stacktrace column was previously encoded as a RLE_DICTIONARY. This has been seen to cause memory bloat since the cardinality of stacktrace values is quite high.