### PR TITLE
ui: Fix displaying targets error and handle scraper-only mode correctly

### DIFF
--- a/ui/packages/app/web/src/pages/targets.tsx
+++ b/ui/packages/app/web/src/pages/targets.tsx
@@ -103,7 +103,7 @@ const TargetsPage = (): JSX.Element => {
   if (targetsError !== null) {
     return <div>Targets Error: {targetsError.toString()}</div>;
   }
-  if (agentsError !== null && agentsError.code !== "UNIMPLEMENTED") {
+  if (agentsError !== null && agentsError.code !== 'UNIMPLEMENTED') {
     return <div>Agents Error: {agentsError.toString()}</div>;
   }
 

--- a/ui/packages/app/web/src/pages/targets.tsx
+++ b/ui/packages/app/web/src/pages/targets.tsx
@@ -100,9 +100,11 @@ const TargetsPage = (): JSX.Element => {
   const {response: targetsResponse, error: targetsError} = useTargets(scrapeClient);
   const {response: agentsResponse, error: agentsError} = useAgents(agentsClient);
 
-  // TODO: We should support showing the other type's response if only one errors.
-  if (targetsError !== null || agentsError !== null) {
-    return <div>Error</div>;
+  if (targetsError !== null) {
+    return <div>Targets Error: {targetsError.toString()}</div>;
+  }
+  if (agentsError !== null && agentsError.code !== "UNIMPLEMENTED") {
+    return <div>Agents Error: {agentsError.toString()}</div>;
   }
 
   const getKeyValuePairFromArray = (key: string, value: Targets) => {


### PR DESCRIPTION
In scraper-only mode the agents gRPC service is not served, therefore returning `UNIMPLEMENTED`, which causes the UI not to be able to render the reply for the targets being scraped.

Additionally this patch also actually renders the errors that occur to allow for better troubleshooting when they do occur.