### PR TITLE
parcacol: change schema sort order so that timestamp sorts before stacktrace

### DIFF
--- a/pkg/parcacol/schema.go
+++ b/pkg/parcacol/schema.go
@@ -162,12 +162,12 @@ func Schema() (*dynparquet.Schema, error) {
 				Direction:  schemapb.SortingColumn_DIRECTION_ASCENDING,
 				NullsFirst: true,
 			}, {
+				Name:      ColumnTimestamp,
+				Direction: schemapb.SortingColumn_DIRECTION_ASCENDING,
+			}, {
 				Name:       ColumnStacktrace,
 				Direction:  schemapb.SortingColumn_DIRECTION_ASCENDING,
 				NullsFirst: true,
-			}, {
-				Name:      ColumnTimestamp,
-				Direction: schemapb.SortingColumn_DIRECTION_ASCENDING,
 			}, {
 				Name:       ColumnPprofLabels,
 				Direction:  schemapb.SortingColumn_DIRECTION_ASCENDING,


### PR DESCRIPTION
This has been shown to improve performance in benchmarks because more data can be filtered out at the scan layer before parquet decompression and conversion. Additionally, we will be able to take advantage of this ordering for more efficient execution using ordered aggregations.