### PR TITLE
pkg/profile: Remove pointer

### DIFF
--- a/pkg/parcacol/arrow.go
+++ b/pkg/parcacol/arrow.go
@@ -123,7 +123,7 @@ func (c *ArrowToProfileConverter) SymbolizeNormalizedProfile(ctx context.Context
 }
 
 func (c *ArrowToProfileConverter) resolveStacktraces(ctx context.Context, stacktraceIDs []string) (
-	[][]*profile.Location,
+	[][]profile.Location,
 	error,
 ) {
 	ctx, span := c.tracer.Start(ctx, "resolve-stacktraces")
@@ -162,9 +162,9 @@ func (c *ArrowToProfileConverter) resolveStacktraces(ctx context.Context, stackt
 		return nil, err
 	}
 
-	stacktraceLocations := make([][]*profile.Location, len(sres.Stacktraces))
+	stacktraceLocations := make([][]profile.Location, len(sres.Stacktraces))
 	for i, stacktrace := range sres.Stacktraces {
-		stacktraceLocations[i] = make([]*profile.Location, len(stacktrace.LocationIds))
+		stacktraceLocations[i] = make([]profile.Location, len(stacktrace.LocationIds))
 		for j, id := range stacktrace.LocationIds {
 			stacktraceLocations[i][j] = locations[locationIndex[id]]
 		}
@@ -178,7 +178,7 @@ func (c *ArrowToProfileConverter) getLocationsFromSerializedLocations(
 	locationIds []string,
 	locations []*pb.Location,
 ) (
-	[]*profile.Location,
+	[]profile.Location,
 	error,
 ) {
 	mappingIndex := map[string]int{}
@@ -226,7 +226,7 @@ func (c *ArrowToProfileConverter) getLocationsFromSerializedLocations(
 		return nil, fmt.Errorf("get functions by ids: %w", err)
 	}
 
-	res := make([]*profile.Location, 0, len(locations))
+	res := make([]profile.Location, 0, len(locations))
 	for _, location := range locations {
 		var mapping *pb.Mapping
 		if location.MappingId != "" {
@@ -245,7 +245,7 @@ func (c *ArrowToProfileConverter) getLocationsFromSerializedLocations(
 			}
 		}
 
-		res = append(res, &profile.Location{
+		res = append(res, profile.Location{
 			ID:       location.Id,
 			Address:  location.Address,
 			IsFolded: location.IsFolded,

--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -44,7 +44,7 @@ type NumLabel struct {
 }
 
 type SymbolizedSample struct {
-	Locations []*Location
+	Locations []Location
 	Value     int64
 	DiffValue int64
 	Label     map[string]string

--- a/pkg/query/callgraph.go
+++ b/pkg/query/callgraph.go
@@ -87,7 +87,7 @@ func getNodeKey(node *querypb.CallgraphNode) string {
 // locationToCallgraphNodes converts a location to its tree nodes, if the location
 // has multiple inlined functions it creates multiple nodes for each inlined
 // function.
-func locationToCallgraphNodes(location *profile.Location) []*querypb.CallgraphNode {
+func locationToCallgraphNodes(location profile.Location) []*querypb.CallgraphNode {
 	if len(location.Lines) > 0 {
 		return linesToCallgraphNodes(
 			location,
@@ -117,7 +117,7 @@ func locationToCallgraphNodes(location *profile.Location) []*querypb.CallgraphNo
 // linesToCallgraphNodes turns inlined `lines` into a stack of TreeNode items and
 // returns the slice of items in order from outer-most to inner-most.
 func linesToCallgraphNodes(
-	location *profile.Location,
+	location profile.Location,
 	mapping *pb.Mapping,
 	lines []profile.LocationLine,
 ) []*querypb.CallgraphNode {
@@ -145,7 +145,7 @@ func linesToCallgraphNodes(
 }
 
 func lineToGraphNode(
-	location *profile.Location,
+	location profile.Location,
 	mapping *pb.Mapping,
 	line profile.LocationLine,
 ) *querypb.CallgraphNode {

--- a/pkg/query/flamegraph.go
+++ b/pkg/query/flamegraph.go
@@ -244,7 +244,7 @@ func equalsByName(a, b *querypb.FlamegraphNode) bool {
 // locationToTreeNodes converts a location to its tree nodes, if the location
 // has multiple inlined functions it creates multiple nodes for each inlined
 // function.
-func locationToTreeNodes(location *profile.Location) []*querypb.FlamegraphNode {
+func locationToTreeNodes(location profile.Location) []*querypb.FlamegraphNode {
 	if len(location.Lines) > 0 {
 		return linesToTreeNodes(
 			location,
@@ -273,7 +273,7 @@ func locationToTreeNodes(location *profile.Location) []*querypb.FlamegraphNode {
 // linesToTreeNodes turns inlined `lines` into a stack of TreeNode items and
 // returns the slice of items in order from outer-most to inner-most.
 func linesToTreeNodes(
-	location *profile.Location,
+	location profile.Location,
 	mapping *pb.Mapping,
 	lines []profile.LocationLine,
 ) []*querypb.FlamegraphNode {
@@ -304,7 +304,7 @@ func linesToTreeNodes(
 }
 
 func lineToTreeNode(
-	location *profile.Location,
+	location profile.Location,
 	mapping *pb.Mapping,
 	line profile.LocationLine,
 	child *querypb.FlamegraphNode,

--- a/pkg/query/flamegraph_table.go
+++ b/pkg/query/flamegraph_table.go
@@ -223,7 +223,7 @@ func (c *tableConverter) AddMapping(m *metastorev1alpha1.Mapping) uint32 {
 
 // AddLocation by its ID and only add it if it's not yet in the table.
 // Returns the locations's index in the table.
-func (c *tableConverter) AddLocation(l *profile.Location) uint32 {
+func (c *tableConverter) AddLocation(l profile.Location) uint32 {
 	if i, ok := c.locationsIndex[l.ID]; ok {
 		return i
 	}


### PR DESCRIPTION
This pointer was causing about 15% of CPU time of the query path purely because it needs to be allocated on the heap.