### PR TITLE
pkg/parcacol: Handle NULL strings in Values API call

### DIFF
--- a/pkg/parcacol/querier.go
+++ b/pkg/parcacol/querier.go
@@ -100,6 +100,11 @@ func (q *Querier) Labels(
 			}
 
 			for i := 0; i < stringCol.Len(); i++ {
+				// This should usually not happen, but better safe than sorry.
+				if stringCol.IsNull(i) {
+					continue
+				}
+
 				val := stringCol.Value(i)
 				seen[strings.TrimPrefix(val, "labels.")] = struct{}{}
 			}
@@ -142,6 +147,10 @@ func (q *Querier) Values(
 			}
 
 			for i := 0; i < dict.Len(); i++ {
+				if dict.IsNull(i) {
+					continue
+				}
+
 				val := StringValueFromDictionary(dict, i)
 
 				// Because of an implementation detail of aggregations in
@@ -149,7 +158,7 @@ func (q *Querier) Values(
 				// is equivalent to the label not existing at all, so we need
 				// to skip it.
 				if len(val) > 0 {
-					vals = append(vals, string(val))
+					vals = append(vals, val)
 				}
 			}
 


### PR DESCRIPTION
This previously resulted in random strings showing up in the dropdown... Best case it was an empty string.