### PR TITLE
ui: Fix false positive Profile has no samples message in visualisations

### DIFF
--- a/ui/packages/shared/profile/src/IcicleGraph.tsx
+++ b/ui/packages/shared/profile/src/IcicleGraph.tsx
@@ -26,12 +26,17 @@ import {
 } from '@parca/client/dist/parca/metastore/v1alpha1/metastore';
 import type {HoveringNode} from './GraphTooltip';
 import GraphTooltip from './GraphTooltip';
-import {diffColor, getLastItem, isSearchMatch, selectQueryParam} from '@parca/functions';
+import {
+  diffColor,
+  getLastItem,
+  isSearchMatch,
+  selectQueryParam,
+  useURLState,
+} from '@parca/functions';
 import {selectDarkMode, useAppSelector} from '@parca/store';
 import useIsShiftDown from '@parca/components/src/hooks/useIsShiftDown';
 import {Button} from '@parca/components';
 import {hexifyAddress} from './utils';
-import {useURLState} from '@parca/functions';
 
 interface IcicleGraphProps {
   graph: Flamegraph;

--- a/ui/packages/shared/profile/src/ProfileIcicleGraph/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph/index.tsx
@@ -30,6 +30,7 @@ interface ProfileIcicleGraphProps {
   curPath: string[] | [];
   setNewCurPath: (path: string[]) => void;
   onContainerResize?: ResizeHandler;
+  loading: boolean;
 }
 
 const ProfileIcicleGraph = ({
@@ -38,6 +39,7 @@ const ProfileIcicleGraph = ({
   setNewCurPath,
   sampleUnit,
   onContainerResize,
+  loading,
 }: ProfileIcicleGraphProps): JSX.Element => {
   const compareMode: boolean =
     selectQueryParam('compare_a') === 'true' && selectQueryParam('compare_b') === 'true';
@@ -71,8 +73,10 @@ const ProfileIcicleGraph = ({
     }, [graph]);
 
   if (graph === undefined) return <div>no data...</div>;
+
   const total = graph.total;
-  if (parseFloat(total) === 0) return <>Profile has no samples</>;
+
+  if (parseFloat(total) === 0 && loading === false) return <>Profile has no samples</>;
 
   return (
     <>

--- a/ui/packages/shared/profile/src/ProfileIcicleGraph/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph/index.tsx
@@ -76,7 +76,7 @@ const ProfileIcicleGraph = ({
 
   const total = graph.total;
 
-  if (parseFloat(total) === 0 && loading === false) return <>Profile has no samples</>;
+  if (parseFloat(total) === 0 && !loading) return <>Profile has no samples</>;
 
   return (
     <>

--- a/ui/packages/shared/profile/src/ProfileView/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileView/index.tsx
@@ -226,7 +226,6 @@ export const ProfileView = ({
                     <ProfileShareButton
                       queryRequest={profileSource.QueryRequest()}
                       queryClient={queryClient}
-                      disabled={isLoading}
                     />
                   ) : null}
 
@@ -236,7 +235,6 @@ export const ProfileView = ({
                       e.preventDefault();
                       onDownloadPProf();
                     }}
-                    disabled={isLoading}
                   >
                     Download pprof
                   </Button>

--- a/ui/packages/shared/profile/src/ProfileView/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileView/index.tsx
@@ -157,6 +157,7 @@ export const ProfileView = ({
               graph={flamegraphData.data}
               sampleUnit={sampleUnit}
               onContainerResize={onFlamegraphContainerResize}
+              loading={flamegraphData.loading}
             />
           </Profiler>
         ) : (
@@ -177,7 +178,12 @@ export const ProfileView = ({
       }
       case 'table': {
         return topTableData != null ? (
-          <TopTable data={topTableData.data} sampleUnit={sampleUnit} navigateTo={navigateTo} />
+          <TopTable
+            loading={topTableData.loading}
+            data={topTableData.data}
+            sampleUnit={sampleUnit}
+            navigateTo={navigateTo}
+          />
         ) : (
           <></>
         );

--- a/ui/packages/shared/profile/src/TopTable/index.tsx
+++ b/ui/packages/shared/profile/src/TopTable/index.tsx
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {memo, useCallback, useMemo} from 'react';
+import {useCallback, useMemo} from 'react';
 
 import {
   getLastItem,
@@ -172,7 +172,7 @@ export const TopTable = ({
 
   const total = top != null ? top.list.length : 0;
 
-  if (total === 0 && loading === false) return <>Profile has no samples</>;
+  if (total === 0 && !loading) return <>Profile has no samples</>;
 
   return (
     <>

--- a/ui/packages/shared/profile/src/TopTable/index.tsx
+++ b/ui/packages/shared/profile/src/TopTable/index.tsx
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {useCallback, useMemo} from 'react';
+import {memo, useCallback, useMemo} from 'react';
 
 import {
   getLastItem,
@@ -31,6 +31,7 @@ import {hexifyAddress} from '../utils';
 import '../TopTable.styles.css';
 
 interface TopTableProps {
+  loading: boolean;
   data?: Top;
   sampleUnit: string;
   navigateTo?: NavigateFunction;
@@ -62,7 +63,12 @@ const addPlusSign = (num: string): string => {
   return `+${num}`;
 };
 
-export const TopTable = ({data: top, sampleUnit: unit, navigateTo}: TopTableProps): JSX.Element => {
+export const TopTable = ({
+  data: top,
+  sampleUnit: unit,
+  navigateTo,
+  loading,
+}: TopTableProps): JSX.Element => {
   const router = parseParams(window.location.search);
   const currentSearchString = selectQueryParam('search_string') as string;
   const compareMode =
@@ -166,7 +172,7 @@ export const TopTable = ({data: top, sampleUnit: unit, navigateTo}: TopTableProp
 
   const total = top != null ? top.list.length : 0;
 
-  if (total === 0) return <>Profile has no samples</>;
+  if (total === 0 && loading === false) return <>Profile has no samples</>;
 
   return (
     <>

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -11740,7 +11740,7 @@ debug@^3.0.0, debug@^3.1.0, debug@^3.2.6, debug@^3.2.7:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha512-syBZ+rnAK3EgMsH2aYEOLUW7mZSY9Gb+0wUMCFsZvcmiz+HigA0LOcq/HoQqVuGG+EKykunc7QG2bzrponfaSw==
@@ -15788,7 +15788,7 @@ import-local@^3.0.2:
     pkg-dir "^4.2.0"
     resolve-cwd "^3.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
@@ -18753,11 +18753,6 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha512-bSYo8Pc/f0qAkr8fPJydpJjtrHiSynYfYBjtANIgXv5xEf1WlTC63dIDlgu0s9dmTvzRu1+JJTxcIAHe+sH0FQ==
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -18766,32 +18761,10 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-  integrity sha512-2wlI0JRAGX8WEf4Gm1p/mv/SZ+jLijpj0jyaE/AXeuQphzCgD8ZQW4oSpoN8JAopujOFGU3KMuq7qfHBWlGpjQ==
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha512-S8dUjWr7SUT/X6TBIQ/OYoCHo1Stu1ZRy6uMUSKqzFnZp5G5RyQizSm6kvxD2Ewyy6AVfMg4AToeZzKfF99T5w==
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha512-ev5SP+iFpZOugyab/DEUQxUeZP5qyciVTlgQ1f4Vlw7VUcCD8fVnyIqVUEIaoFH9zjAqdgi69KiofzvVmda/ZQ==
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha512-GTkC6YMprrJZCYU3zcqZj+jkXkrXzq3IPBcF/fIPpNEAB4hZEtXU8zp/RwKOvZl43NUmwDbyRk3+ZTbeRdEBXA==
-
-lodash._getnative@*, lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-  integrity sha512-RrL9VxMEPyDMHOd9uFbvMe8X55X16/cGM5IgOKgRElQZutpX89iS6vwl64duTV1/16w5JY7tuFNXqoekmh1EmA==
 
 lodash._root@~3.0.0:
   version "3.0.1"
@@ -18912,11 +18885,6 @@ lodash.reduce@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.reduce/-/lodash.reduce-4.6.0.tgz#f1ab6b839299ad48f784abbf476596f03b914d3b"
   integrity sha512-6raRe2vxCYBhpBu+B+TtNGUzah+hQjVdu3E17wfusjyrXBka2nBS8OH/gjVZ5PvHOhWmIZTYri09Z6n/QfnNMw==
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha512-L4/arjjuq4noiUJpt3yS6KIKDtJwNe2fIYgMqyYYKoeIfV1iEqvPwhCx23o+R9dzouGihDAPN1dTIRWa7zk8tw==
 
 lodash.size@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
This will fix the current behaviour of the visualizations showing the `Profile has no samples` message for half a second before populating the visualisations with data. The code responsible for showing the message didn't take into account the value of the `loading` property. So I added that as a check before displaying that message.

I also removed the `disabled` property from buttons on ProfileView toolbar i.e. the share profile and download pprof buttons. They also flickered whenever selecting a new profile mostly because we had the disabled property set to the status of the data being loaded.

**demo.parca.dev**
![demo](https://user-images.githubusercontent.com/9016992/216038969-d5831634-43bd-41a7-91d6-3fe5f0c96c85.gif)

This **PR**
![pr](https://user-images.githubusercontent.com/9016992/216068445-4ebd17be-ddbe-4851-84d8-e05249763a4f.gif)

TL:DR No more `Profile has no samples` message and less flickers in the profile view when selecting profiles.

One more thing: I still am not a fan on the very quick flicker that happens even now after this PR, as you can see in the GIF and demo itself, when you click on a profile in the metric graph, the viz still goes empty before showing the data. I tried to find where in the code is responsible for that but i was not successful. Any pointers would be appreciated. I'm thinking a loader might be better than the quick flicker. Or what do y'all think?