### PR TITLE
pkg/parca: Add e2e test for Go PGO

### DIFF
--- a/pkg/parca/testdata/.gitignore
+++ b/pkg/parca/testdata/.gitignore
@@ -1,0 +1,3 @@
+pgotest
+pgotest.prof
+pgotest.res.prof

--- a/pkg/parca/testdata/pgotest.go
+++ b/pkg/parca/testdata/pgotest.go
@@ -1,0 +1,40 @@
+// Copyright 2022 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"log"
+	"os"
+	"runtime/pprof"
+)
+
+func main() {
+	f, err := os.Create("testdata/pgotest.prof")
+	if err != nil {
+		log.Fatal("could not create CPU profile: ", err)
+	}
+	defer f.Close() // error handling omitted for example
+	if err := pprof.StartCPUProfile(f); err != nil {
+		log.Fatal("could not start CPU profile: ", err)
+	}
+
+	hot()
+
+	defer pprof.StopCPUProfile()
+}
+
+func hot() {
+	for i := 0; i < 10_000_000_000; i++ {
+	}
+}


### PR DESCRIPTION
Add a test to ensure that the data exported by Parca can be used by Go's newly added profile-guided optimizations (PGO).

While testing this I realized that the functionality currently expects the samples count to be on index position 1 (understandable since that's where the runtime-generated profiles have it). But Parca takes the profiles apart and only returns a single sample type, therefore it currently panics, which is why this patch includes the small fix for the pprof profile. An issue has already been filed upstream: https://github.com/golang/go/issues/58292