### PR TITLE
chore(deps): use official nodejs image for development

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,3 +1,4 @@
+# vim: ft=dockerfile
 FROM docker.io/node:16.19.0-alpine@sha256:1298fd170c45954fec3d4d063437750f89802d72743816663664cfe9aa152b4b AS ui-deps
 
 WORKDIR /app

--- a/Dockerfile.go.dev
+++ b/Dockerfile.go.dev
@@ -1,3 +1,4 @@
+# vim: ft=dockerfile
 # Designed to only used by Tilt to iterate faster on the API.
 FROM docker.io/golang:1.19.5-alpine@sha256:2381c1e5f8350a901597d633b2e517775eeac7a6682be39225a93b22cfd0f8bb AS builder
 

--- a/ui/Dockerfile.dev
+++ b/ui/Dockerfile.dev
@@ -1,4 +1,5 @@
-FROM docker.io/mhart/alpine-node:16.4.2@sha256:c9014e9e5b33f29d47c867ea548edc0235ba71677f40456409a44c278d8a8e01
+# vim: ft=dockerfile
+FROM docker.io/node:16.19.0-alpine@sha256:1298fd170c45954fec3d4d063437750f89802d72743816663664cfe9aa152b4b
 WORKDIR /app
 
 COPY package.json yarn.lock ./


### PR DESCRIPTION
[mhart/alpine-node#deprecated](https://github.com/mhart/alpine-node#deprecated)

(The `# vim: ft=dockerfile` comment adds syntax highlighting in GitHub)

Related to #2540