### PR TITLE
deps: update parquet and frostdb

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/prometheus/client_golang v1.14.0
 	github.com/prometheus/common v0.39.0
 	github.com/prometheus/prometheus v0.41.0
-	github.com/segmentio/parquet-go v0.0.0-20230120165150-63d6a781234f
+	github.com/segmentio/parquet-go v0.0.0-20230209224803-1d85e8136681
 	github.com/stretchr/testify v1.8.1
 	github.com/thanos-io/objstore v0.0.0-20221213124554-e4d8ba6bc6f3
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.38.0

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/klauspost/compress v1.15.15
 	github.com/nanmu42/limitio v1.0.0
 	github.com/oklog/run v1.1.0
-	github.com/polarsignals/frostdb v0.0.0-20230131141416-395932c312ca
+	github.com/polarsignals/frostdb v0.0.0-20230210083527-d16391dd0e26
 	github.com/prometheus/client_golang v1.14.0
 	github.com/prometheus/common v0.39.0
 	github.com/prometheus/prometheus v0.41.0

--- a/go.sum
+++ b/go.sum
@@ -781,8 +781,8 @@ github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6J
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/polarsignals/frostdb v0.0.0-20230131141416-395932c312ca h1:GsZ0QwtixC/m69Fb6ihEaCB4JDAqUuHVA4N9TAhSyVk=
-github.com/polarsignals/frostdb v0.0.0-20230131141416-395932c312ca/go.mod h1:oSMHRTUeU8d3r0OfXGdOR3d8bEPHQfbqfB3EvFwEXLQ=
+github.com/polarsignals/frostdb v0.0.0-20230210083527-d16391dd0e26 h1:XC/lAvGRyZLeNkRdXXxehay7XMLeUNfHdwQQMFi88lo=
+github.com/polarsignals/frostdb v0.0.0-20230210083527-d16391dd0e26/go.mod h1:5k/hEIPI3Cm47N8TOzXmknqWEkSpl+/Nwi1AOM8AQf0=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=

--- a/go.sum
+++ b/go.sum
@@ -851,8 +851,8 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
 github.com/segmentio/encoding v0.3.5 h1:UZEiaZ55nlXGDL92scoVuw00RmiRCazIEmvPSbSvt8Y=
 github.com/segmentio/encoding v0.3.5/go.mod h1:n0JeuIqEQrQoPDGsjo8UNd1iA0U8d8+oHAA4E3G3OxM=
-github.com/segmentio/parquet-go v0.0.0-20230120165150-63d6a781234f h1:hJ2eADPXuqfCWPeiDEnney9EfSzGipRDA6igKHYMILg=
-github.com/segmentio/parquet-go v0.0.0-20230120165150-63d6a781234f/go.mod h1:SclLlCfB7c7CH0YerV+OtYmZExyK5rhVOd6UT90erVw=
+github.com/segmentio/parquet-go v0.0.0-20230209224803-1d85e8136681 h1:wjC8jWN4Kt/Per2HczpJzs5xSS0SYBaFa6O9Bc4SkQ8=
+github.com/segmentio/parquet-go v0.0.0-20230209224803-1d85e8136681/go.mod h1:SclLlCfB7c7CH0YerV+OtYmZExyK5rhVOd6UT90erVw=
 github.com/shoenig/test v0.4.6 h1:S1pAVs5L1TSRen3N1YQNtBZIh9Z6d1PyQSUDUweMTqk=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=


### PR DESCRIPTION
This pulls in the following necessary fixes to sorting:

- https://github.com/segmentio/parquet-go/commit/1d85e81366814efe13170410a86be216a8c9b996
- https://github.com/polarsignals/frostdb/commit/a10ca984832919df73b347e6f4c2181800fd90dc