### PR TITLE
perf: automatically set GOMAXPROCS to match Linux container CPU quota

### DIFF
--- a/cmd/parca/main.go
+++ b/cmd/parca/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/common-nighthawk/go-figure"
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/automaxprocs/maxprocs"
 
 	"github.com/parca-dev/parca/pkg/parca"
 )
@@ -51,6 +52,12 @@ func main() {
 		"commit", commit,
 		"config", fmt.Sprint(flags),
 	)
+
+	if _, err := maxprocs.Set(maxprocs.Logger(func(format string, a ...interface{}) {
+		level.Info(logger).Log("msg", fmt.Sprintf(format, a...))
+	})); err != nil {
+		level.Warn(logger).Log("msg", "failed to set GOMAXPROCS automatically", "err", err)
+	}
 
 	registry := prometheus.NewRegistry()
 

--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.13.0
 	go.opentelemetry.io/otel/sdk v1.13.0
 	go.opentelemetry.io/otel/trace v1.13.0
+	go.uber.org/automaxprocs v1.5.1
 	golang.org/x/exp v0.0.0-20230129154200-a960b3787bd2
 	golang.org/x/net v0.5.0
 	golang.org/x/oauth2 v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -785,6 +785,7 @@ github.com/polarsignals/frostdb v0.0.0-20230210083527-d16391dd0e26 h1:XC/lAvGRyZ
 github.com/polarsignals/frostdb v0.0.0-20230210083527-d16391dd0e26/go.mod h1:5k/hEIPI3Cm47N8TOzXmknqWEkSpl+/Nwi1AOM8AQf0=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
+github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829/go.mod h1:p2iRAGwDERtqlqzRXnrOVns+ignqQo//hLXqYxZYVNs=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
@@ -983,6 +984,8 @@ go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/atomic v1.10.0 h1:9qC72Qh0+3MqyJbAn8YU5xVq1frD8bn3JtD2oXtafVQ=
 go.uber.org/atomic v1.10.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
+go.uber.org/automaxprocs v1.5.1 h1:e1YG66Lrk73dn4qhg8WFSvhF0JuFQF0ERIp4rpuV8Qk=
+go.uber.org/automaxprocs v1.5.1/go.mod h1:BF4eumQw0P9GtnuxxovUd06vwm1o18oMzFtK66vU6XU=
 go.uber.org/goleak v1.2.0 h1:xqgm/S+aQvhWFTtR0XK3Jvg7z8kGV8P4X14IzwN3Eqk=
 go.uber.org/goleak v1.2.0/go.mod h1:XJYK+MuIchqpmGmUSAzotztawfKvYLUIgg7guXrwVUo=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=


### PR DESCRIPTION
* Without CPU quota
	
  ```console
  $ docker run --rm -v "${PWD}:${PWD}" -w "${PWD}" busybox bin/parca
  [LOGO]
  level=info name=parca ts=2023-02-15T19:45:41.246609299Z caller=main.go:57 msg="maxprocs: Leaving GOMAXPROCS=8: CPU quota undefined"
  level=info name=parca ts=2023-02-15T19:45:41.247233375Z caller=factory.go:52 msg="loading bucket configuration"
  level=info name=parca ts=2023-02-15T19:45:41.251136091Z caller=badger.go:53 msg="Set nextTxnTs to 0"
  level=info name=parca ts=2023-02-15T19:45:41.256082093Z caller=server.go:93 msg="starting server" addr=:7070
  ```

* With CPU quota

  ```console
  $ docker run --rm --cpus 1 -v "${PWD}:${PWD}" -w "${PWD}" busybox bin/parca
  [LOGO]
  level=info name=parca ts=2023-02-15T19:48:05.507968398Z caller=main.go:57 msg="maxprocs: Updating GOMAXPROCS=1: determined from CPU quota"
  level=info name=parca ts=2023-02-15T19:48:05.508397761Z caller=factory.go:52 msg="loading bucket configuration"
  level=info name=parca ts=2023-02-15T19:48:05.510701363Z caller=badger.go:53 msg="Set nextTxnTs to 0"
  level=info name=parca ts=2023-02-15T19:48:05.516954926Z caller=server.go:93 msg="starting server" addr=:7070
  ```

As a reminder, CPU limits are **not** considered a best practice in Kubernetes (but some users may still have use cases for them): [home.robusta.dev/blog/stop-using-cpu-limits](https://home.robusta.dev/blog/stop-using-cpu-limits). Anyway, if CPU limits are in use, performance will be better if `GOMAXPROCS` is appropriately tuned. 

Documentation: https://pkg.go.dev/go.uber.org/automaxprocs@v1.5.1/maxprocs