### PR TITLE
pkg/debuginfo: close bucket reader

### DIFF
--- a/pkg/debuginfo/metadata.go
+++ b/pkg/debuginfo/metadata.go
@@ -110,6 +110,7 @@ func (m *ObjectStoreMetadata) Fetch(ctx context.Context, buildID string) (*debug
 		}
 		return nil, fmt.Errorf("fetch debuginfo metadata from object storage: %w", err)
 	}
+	defer r.Close()
 
 	content, err := io.ReadAll(r)
 	if err != nil {


### PR DESCRIPTION
must close the reader of bucket, or there would be many goroutine.
![截屏2023-02-22 下午2 33 24](https://user-images.githubusercontent.com/52686065/220541576-f8ae58c5-5677-454d-872f-bbe2419f34de.png)
