### PR TITLE
Update `buf.gen.yaml` to use new buf plugins

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -8,7 +8,7 @@ managed:
 
 plugins:
   # renovate: datasource=github-releases depName=protocolbuffers/protobuf-go
-  - remote: buf.build/protocolbuffers/plugins/go:v1.28.1-1
+  - plugin: buf.build/protocolbuffers/go:v1.28.1
     out: gen/proto/go
     opt: paths=source_relative
 
@@ -19,21 +19,21 @@ plugins:
       - paths=source_relative,features=marshal+unmarshal+size+pool+grpc
 
   # renovate: datasource=github-releases depName=timostamm/protobuf-ts
-  - remote: buf.build/timostamm/plugins/protobuf-ts:v2.8.2-1
+  - plugin: buf.build/community/timostamm-protobuf-ts:v2.8.2
     out: ui/packages/shared/client/src
     opt:
       - long_type_string
       - generate_dependencies
 
   # renovate: datasource=github-releases depName=grpc-ecosystem/grpc-gateway
-  - remote: buf.build/grpc-ecosystem/plugins/grpc-gateway:v2.15.2-1
+  - plugin: buf.build/grpc-ecosystem/gateway:v2.15.2
     out: gen/proto/go
     opt:
       - paths=source_relative
       - generate_unbound_methods=true
 
   # renovate: datasource=github-releases depName=grpc-ecosystem/grpc-gateway
-  - remote: buf.build/grpc-ecosystem/plugins/openapiv2:v2.15.2-1
+  - plugin: buf.build/grpc-ecosystem/openapiv2:v2.15.2
     out: gen/proto/swagger
     opt:
       - allow_merge=false

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -26,14 +26,14 @@ plugins:
       - generate_dependencies
 
   # renovate: datasource=github-releases depName=grpc-ecosystem/grpc-gateway
-  - remote: buf.build/grpc-ecosystem/plugins/grpc-gateway:v2.15.0-1
+  - remote: buf.build/grpc-ecosystem/plugins/grpc-gateway:v2.15.2-1
     out: gen/proto/go
     opt:
       - paths=source_relative
       - generate_unbound_methods=true
 
   # renovate: datasource=github-releases depName=grpc-ecosystem/grpc-gateway
-  - remote: buf.build/grpc-ecosystem/plugins/openapiv2:v2.15.0-1
+  - remote: buf.build/grpc-ecosystem/plugins/openapiv2:v2.15.2-1
     out: gen/proto/swagger
     opt:
       - allow_merge=false

--- a/gen/proto/go/google/api/http.pb.go
+++ b/gen/proto/go/google/api/http.pb.go
@@ -126,19 +126,19 @@ func (x *Http) GetFullyDecodeReservedExpansion() bool {
 //
 // Example:
 //
-//     service Messaging {
-//       rpc GetMessage(GetMessageRequest) returns (Message) {
-//         option (google.api.http) = {
-//             get: "/v1/{name=messages/*}"
-//         };
-//       }
-//     }
-//     message GetMessageRequest {
-//       string name = 1; // Mapped to URL path.
-//     }
-//     message Message {
-//       string text = 1; // The resource content.
-//     }
+//	service Messaging {
+//	  rpc GetMessage(GetMessageRequest) returns (Message) {
+//	    option (google.api.http) = {
+//	        get: "/v1/{name=messages/*}"
+//	    };
+//	  }
+//	}
+//	message GetMessageRequest {
+//	  string name = 1; // Mapped to URL path.
+//	}
+//	message Message {
+//	  string text = 1; // The resource content.
+//	}
 //
 // This enables an HTTP REST to gRPC mapping as below:
 //
@@ -150,21 +150,21 @@ func (x *Http) GetFullyDecodeReservedExpansion() bool {
 // automatically become HTTP query parameters if there is no HTTP request body.
 // For example:
 //
-//     service Messaging {
-//       rpc GetMessage(GetMessageRequest) returns (Message) {
-//         option (google.api.http) = {
-//             get:"/v1/messages/{message_id}"
-//         };
-//       }
-//     }
-//     message GetMessageRequest {
-//       message SubMessage {
-//         string subfield = 1;
-//       }
-//       string message_id = 1; // Mapped to URL path.
-//       int64 revision = 2;    // Mapped to URL query parameter `revision`.
-//       SubMessage sub = 3;    // Mapped to URL query parameter `sub.subfield`.
-//     }
+//	service Messaging {
+//	  rpc GetMessage(GetMessageRequest) returns (Message) {
+//	    option (google.api.http) = {
+//	        get:"/v1/messages/{message_id}"
+//	    };
+//	  }
+//	}
+//	message GetMessageRequest {
+//	  message SubMessage {
+//	    string subfield = 1;
+//	  }
+//	  string message_id = 1; // Mapped to URL path.
+//	  int64 revision = 2;    // Mapped to URL query parameter `revision`.
+//	  SubMessage sub = 3;    // Mapped to URL query parameter `sub.subfield`.
+//	}
 //
 // This enables a HTTP JSON to RPC mapping as below:
 //
@@ -185,18 +185,18 @@ func (x *Http) GetFullyDecodeReservedExpansion() bool {
 // specifies the mapping. Consider a REST update method on the
 // message resource collection:
 //
-//     service Messaging {
-//       rpc UpdateMessage(UpdateMessageRequest) returns (Message) {
-//         option (google.api.http) = {
-//           patch: "/v1/messages/{message_id}"
-//           body: "message"
-//         };
-//       }
-//     }
-//     message UpdateMessageRequest {
-//       string message_id = 1; // mapped to the URL
-//       Message message = 2;   // mapped to the body
-//     }
+//	service Messaging {
+//	  rpc UpdateMessage(UpdateMessageRequest) returns (Message) {
+//	    option (google.api.http) = {
+//	      patch: "/v1/messages/{message_id}"
+//	      body: "message"
+//	    };
+//	  }
+//	}
+//	message UpdateMessageRequest {
+//	  string message_id = 1; // mapped to the URL
+//	  Message message = 2;   // mapped to the body
+//	}
 //
 // The following HTTP JSON to RPC mapping is enabled, where the
 // representation of the JSON in the request body is determined by
@@ -212,19 +212,18 @@ func (x *Http) GetFullyDecodeReservedExpansion() bool {
 // request body.  This enables the following alternative definition of
 // the update method:
 //
-//     service Messaging {
-//       rpc UpdateMessage(Message) returns (Message) {
-//         option (google.api.http) = {
-//           patch: "/v1/messages/{message_id}"
-//           body: "*"
-//         };
-//       }
-//     }
-//     message Message {
-//       string message_id = 1;
-//       string text = 2;
-//     }
-//
+//	service Messaging {
+//	  rpc UpdateMessage(Message) returns (Message) {
+//	    option (google.api.http) = {
+//	      patch: "/v1/messages/{message_id}"
+//	      body: "*"
+//	    };
+//	  }
+//	}
+//	message Message {
+//	  string message_id = 1;
+//	  string text = 2;
+//	}
 //
 // The following HTTP JSON to RPC mapping is enabled:
 //
@@ -242,20 +241,20 @@ func (x *Http) GetFullyDecodeReservedExpansion() bool {
 // It is possible to define multiple HTTP methods for one RPC by using
 // the `additional_bindings` option. Example:
 //
-//     service Messaging {
-//       rpc GetMessage(GetMessageRequest) returns (Message) {
-//         option (google.api.http) = {
-//           get: "/v1/messages/{message_id}"
-//           additional_bindings {
-//             get: "/v1/users/{user_id}/messages/{message_id}"
-//           }
-//         };
-//       }
-//     }
-//     message GetMessageRequest {
-//       string message_id = 1;
-//       string user_id = 2;
-//     }
+//	service Messaging {
+//	  rpc GetMessage(GetMessageRequest) returns (Message) {
+//	    option (google.api.http) = {
+//	      get: "/v1/messages/{message_id}"
+//	      additional_bindings {
+//	        get: "/v1/users/{user_id}/messages/{message_id}"
+//	      }
+//	    };
+//	  }
+//	}
+//	message GetMessageRequest {
+//	  string message_id = 1;
+//	  string user_id = 2;
+//	}
 //
 // This enables the following two alternative HTTP JSON to RPC mappings:
 //
@@ -267,15 +266,15 @@ func (x *Http) GetFullyDecodeReservedExpansion() bool {
 //
 // ## Rules for HTTP mapping
 //
-// 1. Leaf request fields (recursive expansion nested messages in the request
-//    message) are classified into three categories:
-//    - Fields referred by the path template. They are passed via the URL path.
-//    - Fields referred by the [HttpRule.body][google.api.HttpRule.body]. They are passed via the HTTP
-//      request body.
-//    - All other fields are passed via the URL query parameters, and the
-//      parameter name is the field path in the request message. A repeated
-//      field can be represented as multiple query parameters under the same
-//      name.
+//  1. Leaf request fields (recursive expansion nested messages in the request
+//     message) are classified into three categories:
+//     - Fields referred by the path template. They are passed via the URL path.
+//     - Fields referred by the [HttpRule.body][google.api.HttpRule.body]. They are passed via the HTTP
+//     request body.
+//     - All other fields are passed via the URL query parameters, and the
+//     parameter name is the field path in the request message. A repeated
+//     field can be represented as multiple query parameters under the same
+//     name.
 //  2. If [HttpRule.body][google.api.HttpRule.body] is "*", there is no URL query parameter, all fields
 //     are passed via URL path and HTTP request body.
 //  3. If [HttpRule.body][google.api.HttpRule.body] is omitted, there is no HTTP request body, all
@@ -283,12 +282,12 @@ func (x *Http) GetFullyDecodeReservedExpansion() bool {
 //
 // ### Path template syntax
 //
-//     Template = "/" Segments [ Verb ] ;
-//     Segments = Segment { "/" Segment } ;
-//     Segment  = "*" | "**" | LITERAL | Variable ;
-//     Variable = "{" FieldPath [ "=" Segments ] "}" ;
-//     FieldPath = IDENT { "." IDENT } ;
-//     Verb     = ":" LITERAL ;
+//	Template = "/" Segments [ Verb ] ;
+//	Segments = Segment { "/" Segment } ;
+//	Segment  = "*" | "**" | LITERAL | Variable ;
+//	Variable = "{" FieldPath [ "=" Segments ] "}" ;
+//	FieldPath = IDENT { "." IDENT } ;
+//	Verb     = ":" LITERAL ;
 //
 // The syntax `*` matches a single URL path segment. The syntax `**` matches
 // zero or more URL path segments, which must be the last part of the URL path
@@ -337,11 +336,11 @@ func (x *Http) GetFullyDecodeReservedExpansion() bool {
 //
 // Example:
 //
-//     http:
-//       rules:
-//         # Selects a gRPC method and applies HttpRule to it.
-//         - selector: example.v1.Messaging.GetMessage
-//           get: /v1/messages/{message_id}/{sub.subfield}
+//	http:
+//	  rules:
+//	    # Selects a gRPC method and applies HttpRule to it.
+//	    - selector: example.v1.Messaging.GetMessage
+//	      get: /v1/messages/{message_id}/{sub.subfield}
 //
 // ## Special notes
 //
@@ -384,6 +383,7 @@ type HttpRule struct {
 	// can be defined using the 'custom' field.
 	//
 	// Types that are assignable to Pattern:
+	//
 	//	*HttpRule_Get
 	//	*HttpRule_Put
 	//	*HttpRule_Post

--- a/gen/proto/go/google/pprof/profile.pb.go
+++ b/gen/proto/go/google/pprof/profile.pb.go
@@ -65,9 +65,13 @@ type Profile struct {
 
 	// A description of the samples associated with each Sample.value.
 	// For a cpu profile this might be:
-	//   [["cpu","nanoseconds"]] or [["wall","seconds"]] or [["syscall","count"]]
+	//
+	//	[["cpu","nanoseconds"]] or [["wall","seconds"]] or [["syscall","count"]]
+	//
 	// For a heap profile, this might be:
-	//   [["allocations","count"], ["space","bytes"]],
+	//
+	//	[["allocations","count"], ["space","bytes"]],
+	//
 	// If one of the values represents the number of events represented
 	// by the sample, by convention it should be at index 0 and use
 	// sample_type.unit == "count".
@@ -602,8 +606,9 @@ type Location struct {
 	// preceding entries were inlined.
 	//
 	// E.g., if memcpy() is inlined into printf:
-	//    line[0].function_name == "memcpy"
-	//    line[1].function_name == "printf"
+	//
+	//	line[0].function_name == "memcpy"
+	//	line[1].function_name == "printf"
 	Line []*Line `protobuf:"bytes,4,rep,name=line,proto3" json:"line,omitempty"`
 	// Provides an indication that multiple symbols map to this location's
 	// address, for example due to identical code folding by the linker. In that

--- a/gen/proto/go/grpc/health/v1/health.pb.gw.go
+++ b/gen/proto/go/grpc/health/v1/health.pb.gw.go
@@ -134,7 +134,7 @@ func RegisterHealthHandlerServer(ctx context.Context, mux *runtime.ServeMux, ser
 // RegisterHealthHandlerFromEndpoint is same as RegisterHealthHandler but
 // automatically dials to "endpoint" and closes the connection when "ctx" gets done.
 func RegisterHealthHandlerFromEndpoint(ctx context.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) (err error) {
-	conn, err := grpc.Dial(endpoint, opts...)
+	conn, err := grpc.DialContext(ctx, endpoint, opts...)
 	if err != nil {
 		return err
 	}

--- a/gen/proto/go/parca/debuginfo/v1alpha1/debuginfo.pb.go
+++ b/gen/proto/go/parca/debuginfo/v1alpha1/debuginfo.pb.go
@@ -595,6 +595,7 @@ type UploadRequest struct {
 	// data contains either the upload info metadata or the debug info
 	//
 	// Types that are assignable to Data:
+	//
 	//	*UploadRequest_Info
 	//	*UploadRequest_ChunkData
 	Data isUploadRequest_Data `protobuf_oneof:"data"`

--- a/gen/proto/go/parca/debuginfo/v1alpha1/debuginfo.pb.gw.go
+++ b/gen/proto/go/parca/debuginfo/v1alpha1/debuginfo.pb.gw.go
@@ -271,7 +271,7 @@ func RegisterDebuginfoServiceHandlerServer(ctx context.Context, mux *runtime.Ser
 // RegisterDebuginfoServiceHandlerFromEndpoint is same as RegisterDebuginfoServiceHandler but
 // automatically dials to "endpoint" and closes the connection when "ctx" gets done.
 func RegisterDebuginfoServiceHandlerFromEndpoint(ctx context.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) (err error) {
-	conn, err := grpc.Dial(endpoint, opts...)
+	conn, err := grpc.DialContext(ctx, endpoint, opts...)
 	if err != nil {
 		return err
 	}

--- a/gen/proto/go/parca/metastore/v1alpha1/metastore.pb.gw.go
+++ b/gen/proto/go/parca/metastore/v1alpha1/metastore.pb.gw.go
@@ -633,7 +633,7 @@ func RegisterMetastoreServiceHandlerServer(ctx context.Context, mux *runtime.Ser
 // RegisterMetastoreServiceHandlerFromEndpoint is same as RegisterMetastoreServiceHandler but
 // automatically dials to "endpoint" and closes the connection when "ctx" gets done.
 func RegisterMetastoreServiceHandlerFromEndpoint(ctx context.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) (err error) {
-	conn, err := grpc.Dial(endpoint, opts...)
+	conn, err := grpc.DialContext(ctx, endpoint, opts...)
 	if err != nil {
 		return err
 	}

--- a/gen/proto/go/parca/profilestore/v1alpha1/profilestore.pb.gw.go
+++ b/gen/proto/go/parca/profilestore/v1alpha1/profilestore.pb.gw.go
@@ -154,7 +154,7 @@ func RegisterAgentsServiceHandlerServer(ctx context.Context, mux *runtime.ServeM
 // RegisterProfileStoreServiceHandlerFromEndpoint is same as RegisterProfileStoreServiceHandler but
 // automatically dials to "endpoint" and closes the connection when "ctx" gets done.
 func RegisterProfileStoreServiceHandlerFromEndpoint(ctx context.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) (err error) {
-	conn, err := grpc.Dial(endpoint, opts...)
+	conn, err := grpc.DialContext(ctx, endpoint, opts...)
 	if err != nil {
 		return err
 	}
@@ -225,7 +225,7 @@ var (
 // RegisterAgentsServiceHandlerFromEndpoint is same as RegisterAgentsServiceHandler but
 // automatically dials to "endpoint" and closes the connection when "ctx" gets done.
 func RegisterAgentsServiceHandlerFromEndpoint(ctx context.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) (err error) {
-	conn, err := grpc.Dial(endpoint, opts...)
+	conn, err := grpc.DialContext(ctx, endpoint, opts...)
 	if err != nil {
 		return err
 	}

--- a/gen/proto/go/parca/query/v1alpha1/query.pb.go
+++ b/gen/proto/go/parca/query/v1alpha1/query.pb.go
@@ -843,6 +843,7 @@ type ProfileDiffSelection struct {
 	// options are the available options for a diff selection
 	//
 	// Types that are assignable to Options:
+	//
 	//	*ProfileDiffSelection_Merge
 	//	*ProfileDiffSelection_Single
 	Options isProfileDiffSelection_Options `protobuf_oneof:"options"`
@@ -937,6 +938,7 @@ type QueryRequest struct {
 	// options are the options corresponding to the mode
 	//
 	// Types that are assignable to Options:
+	//
 	//	*QueryRequest_Diff
 	//	*QueryRequest_Merge
 	//	*QueryRequest_Single
@@ -1961,6 +1963,7 @@ type QueryResponse struct {
 	// report is the generated report
 	//
 	// Types that are assignable to Report:
+	//
 	//	*QueryResponse_Flamegraph
 	//	*QueryResponse_Pprof
 	//	*QueryResponse_Top
@@ -2246,7 +2249,7 @@ type LabelsResponse struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	/// label_names are the set of matching label names
+	// / label_names are the set of matching label names
 	LabelNames []string `protobuf:"bytes,1,rep,name=label_names,json=labelNames,proto3" json:"label_names,omitempty"`
 	// warnings is unimplemented
 	Warnings []string `protobuf:"bytes,2,rep,name=warnings,proto3" json:"warnings,omitempty"`

--- a/gen/proto/go/parca/query/v1alpha1/query.pb.gw.go
+++ b/gen/proto/go/parca/query/v1alpha1/query.pb.gw.go
@@ -484,7 +484,7 @@ func RegisterQueryServiceHandlerServer(ctx context.Context, mux *runtime.ServeMu
 // RegisterQueryServiceHandlerFromEndpoint is same as RegisterQueryServiceHandler but
 // automatically dials to "endpoint" and closes the connection when "ctx" gets done.
 func RegisterQueryServiceHandlerFromEndpoint(ctx context.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) (err error) {
-	conn, err := grpc.Dial(endpoint, opts...)
+	conn, err := grpc.DialContext(ctx, endpoint, opts...)
 	if err != nil {
 		return err
 	}

--- a/gen/proto/go/parca/scrape/v1alpha1/scrape.pb.gw.go
+++ b/gen/proto/go/parca/scrape/v1alpha1/scrape.pb.gw.go
@@ -104,7 +104,7 @@ func RegisterScrapeServiceHandlerServer(ctx context.Context, mux *runtime.ServeM
 // RegisterScrapeServiceHandlerFromEndpoint is same as RegisterScrapeServiceHandler but
 // automatically dials to "endpoint" and closes the connection when "ctx" gets done.
 func RegisterScrapeServiceHandlerFromEndpoint(ctx context.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) (err error) {
-	conn, err := grpc.Dial(endpoint, opts...)
+	conn, err := grpc.DialContext(ctx, endpoint, opts...)
 	if err != nil {
 		return err
 	}

--- a/gen/proto/go/parca/share/v1alpha1/share.pb.go
+++ b/gen/proto/go/parca/share/v1alpha1/share.pb.go
@@ -320,6 +320,7 @@ type QueryResponse struct {
 	// report is the generated report
 	//
 	// Types that are assignable to Report:
+	//
 	//	*QueryResponse_Flamegraph
 	//	*QueryResponse_Pprof
 	//	*QueryResponse_Top

--- a/gen/proto/go/parca/share/v1alpha1/share.pb.gw.go
+++ b/gen/proto/go/parca/share/v1alpha1/share.pb.gw.go
@@ -220,7 +220,7 @@ func RegisterShareServiceHandlerServer(ctx context.Context, mux *runtime.ServeMu
 // RegisterShareServiceHandlerFromEndpoint is same as RegisterShareServiceHandler but
 // automatically dials to "endpoint" and closes the connection when "ctx" gets done.
 func RegisterShareServiceHandlerFromEndpoint(ctx context.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) (err error) {
-	conn, err := grpc.Dial(endpoint, opts...)
+	conn, err := grpc.DialContext(ctx, endpoint, opts...)
 	if err != nil {
 		return err
 	}

--- a/gen/proto/swagger/google/api/annotations.swagger.json
+++ b/gen/proto/swagger/google/api/annotations.swagger.json
@@ -34,6 +34,7 @@
         "details": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/protobufAny"
           }
         }

--- a/gen/proto/swagger/google/api/http.swagger.json
+++ b/gen/proto/swagger/google/api/http.swagger.json
@@ -34,6 +34,7 @@
         "details": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/protobufAny"
           }
         }

--- a/gen/proto/swagger/grpc/health/v1/health.swagger.json
+++ b/gen/proto/swagger/grpc/health/v1/health.swagger.json
@@ -50,6 +50,7 @@
         "details": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/protobufAny"
           }
         }

--- a/gen/proto/swagger/parca/debuginfo/v1alpha1/debuginfo.swagger.json
+++ b/gen/proto/swagger/parca/debuginfo/v1alpha1/debuginfo.swagger.json
@@ -64,6 +64,7 @@
         "details": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/protobufAny"
           }
         }

--- a/gen/proto/swagger/parca/metastore/v1alpha1/metastore.swagger.json
+++ b/gen/proto/swagger/parca/metastore/v1alpha1/metastore.swagger.json
@@ -102,6 +102,7 @@
         "lines": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/metastorev1alpha1Line"
           },
           "description": "lines are the call frames represented by this location. Multiple lines\nindicate they have been inlined."
@@ -195,6 +196,7 @@
         "details": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/protobufAny"
           }
         }
@@ -210,6 +212,7 @@
         "functions": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/metastorev1alpha1Function"
           },
           "description": "Functions that are known to the backing metastore."
@@ -223,6 +226,7 @@
         "functions": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/metastorev1alpha1Function"
           },
           "description": "Functions that are known to the backing metastore. If any functions didn't\nexist before the request they have now been persisted and are uniquely\nidentifyable through their key."
@@ -236,6 +240,7 @@
         "locations": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/metastorev1alpha1Location"
           },
           "description": "Locations that are known to the backing metastore. If any locations didn't\nexist before the request they have now been persisted and are uniquely\nidentifyable through their key."
@@ -249,6 +254,7 @@
         "mappings": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/metastorev1alpha1Mapping"
           },
           "description": "Mappings that are known to the backing metastore. If any mappings didn't\nexist before the request they have now been persisted and are uniquely\nidentifyable through their key."
@@ -262,6 +268,7 @@
         "stacktraces": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1alpha1Stacktrace"
           },
           "description": "Stacktraces that are known to the backing metastore. If any stacktraces\ndidn't exist before the request they have now been persisted and are\nuniquely identifyable through their key."
@@ -275,6 +282,7 @@
         "locations": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/metastorev1alpha1Location"
           },
           "description": "Locations that are known to the backing metastore."
@@ -288,6 +296,7 @@
         "mappings": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/metastorev1alpha1Mapping"
           },
           "description": "Mappings that are known to the backing metastore."
@@ -318,6 +327,7 @@
         "stacktraces": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1alpha1Stacktrace"
           },
           "description": "Stacktraces that are known to the backing metastore."
@@ -331,6 +341,7 @@
         "locations": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/metastorev1alpha1Location"
           },
           "description": "Locations that have a mapping and address that should be symbolizable."

--- a/gen/proto/swagger/parca/profilestore/v1alpha1/profilestore.swagger.json
+++ b/gen/proto/swagger/parca/profilestore/v1alpha1/profilestore.swagger.json
@@ -113,6 +113,7 @@
         "details": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/protobufAny"
           }
         }
@@ -147,6 +148,7 @@
         "agents": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1alpha1Agent"
           },
           "title": "agents is a list of agents"
@@ -160,6 +162,7 @@
         "labels": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/profilestorev1alpha1Label"
           },
           "title": "labels are the grouping of labels"
@@ -177,6 +180,7 @@
         "samples": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1alpha1RawSample"
           },
           "title": "samples are the set of profile bytes"
@@ -205,6 +209,7 @@
         "series": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1alpha1RawProfileSeries"
           },
           "title": "series is a set raw pprof profiles and accompanying labels"

--- a/gen/proto/swagger/parca/query/v1alpha1/query.swagger.json
+++ b/gen/proto/swagger/parca/query/v1alpha1/query.swagger.json
@@ -604,6 +604,7 @@
         "lines": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/metastorev1alpha1Line"
           },
           "description": "lines are the call frames represented by this location. Multiple lines\nindicate they have been inlined."
@@ -681,6 +682,7 @@
         "types": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1alpha1ProfileType"
           },
           "description": "types is the list of available profile types."
@@ -796,6 +798,7 @@
         "details": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/protobufAny"
           }
         }
@@ -807,6 +810,7 @@
         "nodes": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1alpha1CallgraphNode"
           },
           "title": "nodes are the nodes in the callgraph"
@@ -814,6 +818,7 @@
         "edges": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1alpha1CallgraphEdge"
           },
           "title": "edges are the edges connecting nodes in the callgraph"
@@ -944,6 +949,7 @@
         "locations": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/metastorev1alpha1Location"
           },
           "description": "locations deduplicated by their ID to be referenced by nodes."
@@ -951,6 +957,7 @@
         "mapping": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/metastorev1alpha1Mapping"
           },
           "description": "mapping deduplicated by their ID to be referenced by nodes."
@@ -958,6 +965,7 @@
         "function": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/metastorev1alpha1Function"
           },
           "description": "function deduplicated by their ID to be referenced by nodes."
@@ -990,6 +998,7 @@
         "children": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1alpha1FlamegraphNode"
           },
           "title": "children are the child nodes"
@@ -1045,6 +1054,7 @@
         "children": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1alpha1FlamegraphNode"
           },
           "title": "children are the list of the children of the root node"
@@ -1058,6 +1068,7 @@
         "labels": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/profilestorev1alpha1Label"
           },
           "title": "labels are the grouping of labels"
@@ -1136,6 +1147,7 @@
         "samples": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1alpha1MetricsSample"
           },
           "title": "samples is the set of top-level cumulative values of the corresponding profiles"
@@ -1215,6 +1227,7 @@
         "series": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1alpha1MetricsSeries"
           },
           "title": "series is the set of metrics series that satisfy the query range request"
@@ -1282,6 +1295,7 @@
         "list": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1alpha1TopNode"
           },
           "title": "list are the list of ordered elements of the table"

--- a/gen/proto/swagger/parca/scrape/v1alpha1/scrape.swagger.json
+++ b/gen/proto/swagger/parca/scrape/v1alpha1/scrape.swagger.json
@@ -103,6 +103,7 @@
         "details": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/protobufAny"
           }
         }
@@ -114,6 +115,7 @@
         "labels": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/profilestorev1alpha1Label"
           },
           "title": "labels are the grouping of labels"
@@ -162,6 +164,7 @@
         "targets": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1alpha1Target"
           },
           "title": "targets is a list of targets"

--- a/gen/proto/swagger/parca/share/v1alpha1/share.swagger.json
+++ b/gen/proto/swagger/parca/share/v1alpha1/share.swagger.json
@@ -115,6 +115,7 @@
         "lines": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/metastorev1alpha1Line"
           },
           "description": "lines are the call frames represented by this location. Multiple lines\nindicate they have been inlined."
@@ -192,6 +193,7 @@
         "types": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1alpha1ProfileType"
           },
           "description": "list of available profile types."
@@ -262,6 +264,7 @@
         "details": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/protobufAny"
           }
         }
@@ -273,6 +276,7 @@
         "nodes": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1alpha1CallgraphNode"
           },
           "title": "nodes are the nodes in the callgraph"
@@ -280,6 +284,7 @@
         "edges": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1alpha1CallgraphEdge"
           },
           "title": "edges are the edges connecting nodes in the callgraph"
@@ -396,6 +401,7 @@
         "locations": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/metastorev1alpha1Location"
           },
           "description": "locations deduplicated by their ID to be referenced by nodes."
@@ -403,6 +409,7 @@
         "mapping": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/metastorev1alpha1Mapping"
           },
           "description": "mapping deduplicated by their ID to be referenced by nodes."
@@ -410,6 +417,7 @@
         "function": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/metastorev1alpha1Function"
           },
           "description": "function deduplicated by their ID to be referenced by nodes."
@@ -442,6 +450,7 @@
         "children": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1alpha1FlamegraphNode"
           },
           "title": "children are the child nodes"
@@ -497,6 +506,7 @@
         "children": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1alpha1FlamegraphNode"
           },
           "title": "children are the list of the children of the root node"
@@ -540,6 +550,7 @@
         "list": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1alpha1TopNode"
           },
           "title": "list are the list of ordered elements of the table"

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/kit/v2 v2.0.0-rc.3
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.0-rc.3
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
-	github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.0
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.2
 	github.com/ianlancetaylor/demangle v0.0.0-20220517205856-0058ec4f073c
 	github.com/improbable-eng/grpc-web v0.15.0
 	github.com/klauspost/compress v1.15.15
@@ -47,7 +47,7 @@ require (
 	golang.org/x/oauth2 v0.5.0
 	golang.org/x/sync v0.1.0
 	google.golang.org/api v0.110.0
-	google.golang.org/genproto v0.0.0-20230209215440-0dfe4f8abfcc
+	google.golang.org/genproto v0.0.0-20230223222841-637eb2293923
 	google.golang.org/grpc v1.53.0
 	google.golang.org/protobuf v1.28.1
 	gopkg.in/dnaeon/go-vcr.v3 v3.1.2
@@ -58,7 +58,7 @@ require (
 	cloud.google.com/go v0.107.0 // indirect
 	cloud.google.com/go/compute v1.18.0 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
-	cloud.google.com/go/iam v0.8.0 // indirect
+	cloud.google.com/go/iam v0.11.0 // indirect
 	github.com/Azure/azure-sdk-for-go v65.0.0+incompatible // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.2.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ cloud.google.com/go/compute/metadata v0.2.3/go.mod h1:VAV5nSsACxMJvgaAuX6Pk2Aawl
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
 cloud.google.com/go/datastore v1.1.0/go.mod h1:umbIZjpQpHh4hmRpGhH4tLFup+FVzqBi1b3c64qFpCk=
 cloud.google.com/go/firestore v1.1.0/go.mod h1:ulACoGHTpvq5r8rxGJ4ddJZBZqakUQqClKRT5SZwBmk=
-cloud.google.com/go/iam v0.8.0 h1:E2osAkZzxI/+8pZcxVLcDtAQx/u+hZXVryUaYQ5O0Kk=
-cloud.google.com/go/iam v0.8.0/go.mod h1:lga0/y3iH6CX7sYqypWJ33hf7kkfXJag67naqGESjkE=
+cloud.google.com/go/iam v0.11.0 h1:kwCWfKwB6ePZoZnGLwrd3B6Ru/agoHANTUBWpVNIdnM=
+cloud.google.com/go/iam v0.11.0/go.mod h1:9PiLDanza5D+oWFZiH1uG+RnRCfEGKoyl6yo4cgWZGY=
 cloud.google.com/go/longrunning v0.3.0 h1:NjljC+FYPV3uh5/OwWT6pVU+doBqMg2x/rZlE+CamDs=
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
 cloud.google.com/go/pubsub v1.1.0/go.mod h1:EwwdRX2sKPjnvnqCa270oGRyludottCI76h+R3AArQw=
@@ -489,8 +489,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0/go.mod h1:hgWBS7lorOAVIJEQMi4ZsPv9hVvWI6+ch50m39Pf2Ks=
-github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.0 h1:1JYBfzqrWPcCclBwxFCPAou9n+q86mfnu7NAeHfte7A=
-github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.0/go.mod h1:YDZoGHuwE+ov0c8smSH49WLF3F2LaWnYYuDVd+EWrc0=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.2 h1:gDLXvp5S9izjldquuoAhDzccbskOL6tDC5jMSyx3zxE=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.2/go.mod h1:7pdNwVWBBHGiCxa9lAszqCJMbfTISJ7oMftp8+UGV08=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/api v1.3.0/go.mod h1:MmDNSzIMUjNpY/mQ398R4bk2FnqQLoPndWW5VkKPlCE=
 github.com/hashicorp/consul/api v1.18.0 h1:R7PPNzTCeN6VuQNDwwhZWJvzCtGSrNpJqfb22h3yH9g=
@@ -1356,8 +1356,8 @@ google.golang.org/genproto v0.0.0-20210126160654-44e461bb6506/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20211118181313-81c1377c94b1/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/genproto v0.0.0-20220329172620-7be39ac1afc7/go.mod h1:8w6bsBMX6yCPbAVTeqQHvzxW0EIFigd5lZyahWgyfDo=
 google.golang.org/genproto v0.0.0-20220401170504-314d38edb7de/go.mod h1:8w6bsBMX6yCPbAVTeqQHvzxW0EIFigd5lZyahWgyfDo=
-google.golang.org/genproto v0.0.0-20230209215440-0dfe4f8abfcc h1:ijGwO+0vL2hJt5gaygqP2j6PfflOBrRot0IczKbmtio=
-google.golang.org/genproto v0.0.0-20230209215440-0dfe4f8abfcc/go.mod h1:RGgjbofJ8xD9Sq1VVhDM1Vok1vRONV+rg+CjzG4SZKM=
+google.golang.org/genproto v0.0.0-20230223222841-637eb2293923 h1:znp6mq/drrY+6khTAlJUDNFFcDGV2ENLYKpMq8SyCds=
+google.golang.org/genproto v0.0.0-20230223222841-637eb2293923/go.mod h1:3Dl5ZL0q0isWJt+FVcfpQyirqemEuLAK/iFvg1UP1Hw=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.0/go.mod h1:chYK+tFQF0nDUGJgXMSgLCQk3phJEuONr2DCgLDdAQM=


### PR DESCRIPTION
Renovate bot is failing because the newer versions aren't available as the old custom plugins anymore. 