### PR TITLE
ui: Flamegraph tooltip perf improvement

### DIFF
--- a/ui/packages/shared/profile/src/GraphTooltip/index.tsx
+++ b/ui/packages/shared/profile/src/GraphTooltip/index.tsx
@@ -13,8 +13,6 @@
 
 import {useEffect, useMemo, useState} from 'react';
 
-
-
 import {pointer} from 'd3-selection';
 import {CopyToClipboard} from 'react-copy-to-clipboard';
 import {usePopper} from 'react-popper';
@@ -31,10 +29,6 @@ import {selectHoveringNode, useAppSelector} from '@parca/store';
 
 import {hexifyAddress, truncateString, truncateStringReverse} from '../';
 import {ExpandOnHover} from './ExpandOnHoverValue';
-
-
-
-
 
 const NoData = (): JSX.Element => {
   return <span className="rounded bg-gray-200 dark:bg-gray-800 px-2">Not available</span>;

--- a/ui/packages/shared/profile/src/GraphTooltip/index.tsx
+++ b/ui/packages/shared/profile/src/GraphTooltip/index.tsx
@@ -11,7 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {useEffect, useState} from 'react';
+import {useEffect, useMemo, useState} from 'react';
+
+
 
 import {pointer} from 'd3-selection';
 import {CopyToClipboard} from 'react-copy-to-clipboard';
@@ -25,9 +27,14 @@ import {
 } from '@parca/client/dist/parca/metastore/v1alpha1/metastore';
 import {useKeyDown} from '@parca/components';
 import {getLastItem, valueFormatter} from '@parca/functions';
+import {selectHoveringNode, useAppSelector} from '@parca/store';
 
 import {hexifyAddress, truncateString, truncateStringReverse} from '../';
 import {ExpandOnHover} from './ExpandOnHoverValue';
+
+
+
+
 
 const NoData = (): JSX.Element => {
   return <span className="rounded bg-gray-200 dark:bg-gray-800 px-2">Not available</span>;
@@ -38,7 +45,7 @@ interface GraphTooltipProps {
   y?: number;
   unit: string;
   total: number;
-  hoveringNode: HoveringNode;
+  hoveringNode?: HoveringNode;
   contextElement: Element | null;
   isFixed?: boolean;
   virtualContextElement?: boolean;
@@ -360,7 +367,7 @@ const GraphTooltip = ({
   y,
   unit,
   total,
-  hoveringNode,
+  hoveringNode: hoveringNodeProp,
   contextElement,
   isFixed = false,
   virtualContextElement = true,
@@ -369,6 +376,22 @@ const GraphTooltip = ({
   locations,
   functions,
 }: GraphTooltipProps): JSX.Element => {
+  const hoveringNodeState = useAppSelector(selectHoveringNode);
+  const hoveringNode = useMemo<HoveringNode>(() => {
+    const h = (hoveringNodeProp ?? hoveringNodeState) as HoveringNode;
+    if (h == null) {
+      return h;
+    }
+
+    // Cloning the object to avoid the mutating error as this is Redux store object and we are modifying the meta object in GraphTooltipContent component.
+    return {
+      ...h,
+      meta: {
+        ...h.meta,
+      },
+    };
+  }, [hoveringNodeProp, hoveringNodeState]);
+
   const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(null);
 
   const {styles, attributes, ...popperProps} = usePopper(

--- a/ui/packages/shared/profile/src/ProfileExplorer/ProfileExplorerSingle.tsx
+++ b/ui/packages/shared/profile/src/ProfileExplorer/ProfileExplorerSingle.tsx
@@ -11,12 +11,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {QueryServiceClient} from '@parca/client';
-import {KeyDownProvider} from '@parca/components';
-import type {NavigateFunction} from '@parca/functions';
+import { QueryServiceClient } from '@parca/client';
+import { KeyDownProvider } from '@parca/components';
+import type { NavigateFunction } from '@parca/functions';
 
-import {ProfileSelection, ProfileViewWithData} from '..';
-import ProfileSelector, {QuerySelection} from '../ProfileSelector';
+
+
+import { ProfileSelection, ProfileViewWithData } from '..';
+import ProfileSelector, { QuerySelection } from '../ProfileSelector';
+
+
+
+
 
 interface ProfileExplorerSingleProps {
   queryClient: QueryServiceClient;
@@ -38,7 +44,7 @@ const ProfileExplorerSingle = ({
   navigateTo,
 }: ProfileExplorerSingleProps): JSX.Element => {
   return (
-    <KeyDownProvider>
+    <>
       <div className="grid grid-cols-1">
         <div>
           <ProfileSelector
@@ -67,7 +73,7 @@ const ProfileExplorerSingle = ({
           )}
         </div>
       </div>
-    </KeyDownProvider>
+    </>
   );
 };
 

--- a/ui/packages/shared/profile/src/ProfileExplorer/ProfileExplorerSingle.tsx
+++ b/ui/packages/shared/profile/src/ProfileExplorer/ProfileExplorerSingle.tsx
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 import {QueryServiceClient} from '@parca/client';
-import {KeyDownProvider} from '@parca/components';
 import type {NavigateFunction} from '@parca/functions';
 
 import {ProfileSelection, ProfileViewWithData} from '..';

--- a/ui/packages/shared/profile/src/ProfileExplorer/ProfileExplorerSingle.tsx
+++ b/ui/packages/shared/profile/src/ProfileExplorer/ProfileExplorerSingle.tsx
@@ -11,18 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { QueryServiceClient } from '@parca/client';
-import { KeyDownProvider } from '@parca/components';
-import type { NavigateFunction } from '@parca/functions';
+import {QueryServiceClient} from '@parca/client';
+import {KeyDownProvider} from '@parca/components';
+import type {NavigateFunction} from '@parca/functions';
 
-
-
-import { ProfileSelection, ProfileViewWithData } from '..';
-import ProfileSelector, { QuerySelection } from '../ProfileSelector';
-
-
-
-
+import {ProfileSelection, ProfileViewWithData} from '..';
+import ProfileSelector, {QuerySelection} from '../ProfileSelector';
 
 interface ProfileExplorerSingleProps {
   queryClient: QueryServiceClient;

--- a/ui/packages/shared/profile/src/ProfileExplorer/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileExplorer/index.tsx
@@ -11,13 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { useEffect, useState } from 'react';
+import {useEffect, useState} from 'react';
 
-
-
-import { Provider } from 'react-redux';
-
-
+import {Provider} from 'react-redux';
 
 import {QueryServiceClient} from '@parca/client';
 import {DateTimeRange, KeyDownProvider, useParcaContext} from '@parca/components';

--- a/ui/packages/shared/profile/src/ProfileExplorer/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileExplorer/index.tsx
@@ -11,12 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {useEffect, useState} from 'react';
+import { useEffect, useState } from 'react';
 
-import {Provider} from 'react-redux';
+
+
+import { Provider } from 'react-redux';
+
+
 
 import {QueryServiceClient} from '@parca/client';
-import {DateTimeRange, useParcaContext} from '@parca/components';
+import {DateTimeRange, KeyDownProvider, useParcaContext} from '@parca/components';
 import type {NavigateFunction} from '@parca/functions';
 import {store} from '@parca/store';
 
@@ -391,11 +395,13 @@ const ProfileExplorer = ({
 
   return (
     <Provider store={reduxStore}>
-      <ProfileExplorerApp
-        queryClient={queryClient}
-        queryParams={queryParams}
-        navigateTo={navigateTo}
-      />
+      <KeyDownProvider>
+        <ProfileExplorerApp
+          queryClient={queryClient}
+          queryParams={queryParams}
+          navigateTo={navigateTo}
+        />
+      </KeyDownProvider>
     </Provider>
   );
 };

--- a/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraph/IcicleGraphNodes.tsx
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraph/IcicleGraphNodes.tsx
@@ -16,7 +16,7 @@ import React, {useMemo} from 'react';
 import cx from 'classnames';
 import {scaleLinear} from 'd3-scale';
 
-import {FlamegraphNode, FlamegraphRootNode} from '@parca/client';
+import {FlamegraphNode} from '@parca/client';
 import {
   Location,
   Mapping,

--- a/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraph/IcicleGraphNodes.tsx
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraph/IcicleGraphNodes.tsx
@@ -11,7 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import React, {useMemo} from 'react';
+import React, { useMemo } from 'react';
+
+
 
 import cx from 'classnames';
 import {scaleLinear} from 'd3-scale';
@@ -24,7 +26,7 @@ import {
 } from '@parca/client/dist/parca/metastore/v1alpha1/metastore';
 import {useKeyDown} from '@parca/components';
 import {isSearchMatch} from '@parca/functions';
-import {selectBinaries, useAppSelector} from '@parca/store';
+import {selectBinaries, setHoveringNode, useAppDispatch, useAppSelector} from '@parca/store';
 
 import useNodeColor from './useNodeColor';
 import {nodeLabel} from './utils';
@@ -44,14 +46,13 @@ interface IcicleGraphNodesProps {
   level: number;
   curPath: string[];
   setCurPath: (path: string[]) => void;
-  setHoveringNode: (node: FlamegraphNode | FlamegraphRootNode | undefined) => void;
   path: string[];
   xScale: (value: number) => number;
   searchString?: string;
   compareMode: boolean;
 }
 
-export const IcicleGraphNodes = React.memo(function IcicleGraphNodes({
+export const IcicleGraphNodes = React.memo(function IcicleGraphNodesNoMemo({
   data,
   strings,
   mappings,
@@ -63,7 +64,6 @@ export const IcicleGraphNodes = React.memo(function IcicleGraphNodes({
   total,
   totalWidth,
   level,
-  setHoveringNode,
   path,
   setCurPath,
   curPath,
@@ -83,7 +83,7 @@ export const IcicleGraphNodes = React.memo(function IcicleGraphNodes({
 
   return (
     <g transform={`translate(${x}, ${y})`}>
-      {nodes.map((d, i) => {
+      {nodes.map(function nodeMapper(d, i) {
         const start = nodes.slice(0, i).reduce((sum, d) => sum + parseFloat(d.cumulative), 0);
         const xStart = xScale(start);
 
@@ -96,7 +96,6 @@ export const IcicleGraphNodes = React.memo(function IcicleGraphNodes({
             height={RowHeight}
             path={path}
             setCurPath={setCurPath}
-            setHoveringNode={setHoveringNode}
             level={level}
             curPath={curPath}
             data={d}
@@ -130,7 +129,6 @@ interface IcicleNodeProps {
   path: string[];
   total: number;
   setCurPath: (path: string[]) => void;
-  setHoveringNode: (node: FlamegraphNode | FlamegraphRootNode | undefined) => void;
   xScale: (value: number) => number;
   isRoot?: boolean;
   searchString?: string;
@@ -147,12 +145,11 @@ const fadedIcicleRectStyles = {
   opacity: '0.5',
 };
 
-export const IcicleNode = React.memo(function IcicleNode({
+export const IcicleNode = React.memo(function IcicleNodeNoMemo({
   x,
   y,
   height,
   setCurPath,
-  setHoveringNode,
   curPath,
   level,
   path,
@@ -169,6 +166,7 @@ export const IcicleNode = React.memo(function IcicleNode({
   compareMode,
 }: IcicleNodeProps): JSX.Element {
   const binaries = useAppSelector(selectBinaries);
+  const dispatch = useAppDispatch();
   const {isShiftDown} = useKeyDown();
   const colorResult = useNodeColor({data, compareMode});
   const name = useMemo(() => {
@@ -206,12 +204,12 @@ export const IcicleNode = React.memo(function IcicleNode({
   const onMouseEnter = (): void => {
     if (isShiftDown) return;
 
-    setHoveringNode(data);
+    dispatch(setHoveringNode(data));
   };
   const onMouseLeave = (): void => {
     if (isShiftDown) return;
 
-    setHoveringNode(undefined);
+    dispatch(setHoveringNode(undefined));
   };
 
   return (
@@ -258,7 +256,6 @@ export const IcicleNode = React.memo(function IcicleNode({
           total={total}
           totalWidth={totalWidth}
           level={nextLevel}
-          setHoveringNode={setHoveringNode}
           path={nextPath}
           curPath={nextCurPath}
           setCurPath={setCurPath}

--- a/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraph/IcicleGraphNodes.tsx
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraph/IcicleGraphNodes.tsx
@@ -11,9 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import React, { useMemo } from 'react';
-
-
+import React, {useMemo} from 'react';
 
 import cx from 'classnames';
 import {scaleLinear} from 'd3-scale';

--- a/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraph/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraph/index.tsx
@@ -15,11 +15,11 @@ import {memo, useEffect, useMemo, useRef, useState} from 'react';
 
 import {scaleLinear} from 'd3-scale';
 
-import {Flamegraph, FlamegraphNode, FlamegraphRootNode} from '@parca/client';
+import {Flamegraph} from '@parca/client';
 import {selectQueryParam, type NavigateFunction} from '@parca/functions';
-import {selectHoveringNode, setHoveringNode, useAppDispatch, useAppSelector} from '@parca/store';
+import {setHoveringNode, useAppDispatch} from '@parca/store';
 
-import GraphTooltip, {type HoveringNode} from '../../GraphTooltip';
+import GraphTooltip from '../../GraphTooltip';
 import ColorStackLegend from './ColorStackLegend';
 import {IcicleNode, RowHeight} from './IcicleGraphNodes';
 import useColoredGraph from './useColoredGraph';

--- a/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraph/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraph/index.tsx
@@ -11,15 +11,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { memo, useEffect, useMemo, useRef, useState } from 'react';
+import {memo, useEffect, useMemo, useRef, useState} from 'react';
 
+import {scaleLinear} from 'd3-scale';
 
-
-import { scaleLinear } from 'd3-scale';
-
-
-
-import { Flamegraph, FlamegraphNode, FlamegraphRootNode } from '@parca/client';
+import {Flamegraph, FlamegraphNode, FlamegraphRootNode} from '@parca/client';
 import {selectQueryParam, type NavigateFunction} from '@parca/functions';
 import {selectHoveringNode, setHoveringNode, useAppDispatch, useAppSelector} from '@parca/store';
 

--- a/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraph/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraph/index.tsx
@@ -11,12 +11,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {memo, useEffect, useMemo, useRef, useState} from 'react';
+import { memo, useEffect, useMemo, useRef, useState } from 'react';
 
-import {scaleLinear} from 'd3-scale';
 
-import {Flamegraph, FlamegraphNode, FlamegraphRootNode} from '@parca/client';
+
+import { scaleLinear } from 'd3-scale';
+
+
+
+import { Flamegraph, FlamegraphNode, FlamegraphRootNode } from '@parca/client';
 import {selectQueryParam, type NavigateFunction} from '@parca/functions';
+import {selectHoveringNode, setHoveringNode, useAppDispatch, useAppSelector} from '@parca/store';
 
 import GraphTooltip, {type HoveringNode} from '../../GraphTooltip';
 import ColorStackLegend from './ColorStackLegend';
@@ -40,9 +45,7 @@ export const IcicleGraph = memo(function IcicleGraph({
   sampleUnit,
   navigateTo,
 }: IcicleGraphProps): JSX.Element {
-  const [hoveringNode, setHoveringNode] = useState<
-    FlamegraphNode | FlamegraphRootNode | undefined
-  >();
+  const dispatch = useAppDispatch();
   const [height, setHeight] = useState(0);
   const svg = useRef(null);
   const ref = useRef<SVGGElement>(null);
@@ -71,12 +74,11 @@ export const IcicleGraph = memo(function IcicleGraph({
   }
 
   return (
-    <div onMouseLeave={() => setHoveringNode(undefined)}>
+    <div onMouseLeave={() => dispatch(setHoveringNode(undefined))}>
       <ColorStackLegend navigateTo={navigateTo} compareMode={compareMode} />
       <GraphTooltip
         unit={sampleUnit}
         total={total}
-        hoveringNode={hoveringNode as HoveringNode}
         contextElement={svg.current}
         strings={coloredGraph.stringTable}
         mappings={coloredGraph.mapping}
@@ -98,7 +100,6 @@ export const IcicleGraph = memo(function IcicleGraph({
               totalWidth={width}
               height={RowHeight}
               setCurPath={setCurPath}
-              setHoveringNode={setHoveringNode}
               curPath={curPath}
               data={coloredGraph.root}
               strings={coloredGraph.stringTable}

--- a/ui/packages/shared/store/package.json
+++ b/ui/packages/shared/store/package.json
@@ -13,6 +13,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@parca/client": "^0.16.65",
     "@parca/functions": "^0.16.66",
     "@reduxjs/toolkit": "^1.7.2",
     "react-redux": "^8.0.2",

--- a/ui/packages/shared/store/src/slices/colorsSlice.ts
+++ b/ui/packages/shared/store/src/slices/colorsSlice.ts
@@ -11,9 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
-
-
+import {createSlice, type PayloadAction} from '@reduxjs/toolkit';
 
 import {FlamegraphNode, FlamegraphRootNode} from '@parca/client';
 import {COLOR_PROFILES, type ColorProfileName, type ColorsDuo} from '@parca/functions';

--- a/ui/packages/shared/store/src/slices/colorsSlice.ts
+++ b/ui/packages/shared/store/src/slices/colorsSlice.ts
@@ -11,8 +11,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {createSlice, type PayloadAction} from '@reduxjs/toolkit';
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
+
+
+import {FlamegraphNode, FlamegraphRootNode} from '@parca/client';
 import {COLOR_PROFILES, type ColorProfileName, type ColorsDuo} from '@parca/functions';
 
 import type {RootState} from '../store';
@@ -20,16 +23,20 @@ import type {RootState} from '../store';
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type StackColorMap = {[key: string]: string};
 
+export type HoveringNode = FlamegraphNode | FlamegraphRootNode | undefined;
+
 // Define a type for the slice state
 export interface ColorsState {
   colors: StackColorMap;
   binaries: string[];
+  hoveringNode: HoveringNode;
 }
 
 // Define the initial state using that type
 const initialState: ColorsState = {
   colors: {},
   binaries: [],
+  hoveringNode: undefined,
 };
 
 export interface StackColor {
@@ -126,17 +133,22 @@ export const colorsSlice = createSlice({
           }
         );
     },
+    setHoveringNode: (state, action: PayloadAction<HoveringNode>) => {
+      state.hoveringNode = action.payload;
+    },
     resetColors: state => {
       state.colors = {};
     },
   },
 });
 
-export const {addColor, resetColors, setFeatures} = colorsSlice.actions;
+export const {addColor, resetColors, setFeatures, setHoveringNode} = colorsSlice.actions;
 
 // Other code such as selectors can use the imported `RootState` type
 export const selectStackColors = (state: RootState): StackColorMap => state.colors.colors;
 
 export const selectBinaries = (state: RootState): string[] => state.colors.binaries;
+
+export const selectHoveringNode = (state: RootState): HoveringNode => state.colors.hoveringNode;
 
 export default colorsSlice.reducer;


### PR DESCRIPTION
Moved the `hoveringNode` state from the `IcicleGraph` component to redux store to prevent the unwanted renders while hovering around the flamegraph. 