### PR TITLE
ui: Add a default visualization for the dashboard_items params

### DIFF
--- a/ui/packages/shared/profile/src/Callgraph/index.tsx
+++ b/ui/packages/shared/profile/src/Callgraph/index.tsx
@@ -187,7 +187,7 @@ const Callgraph = ({graph, sampleUnit, width, colorRange}: Props): JSX.Element =
   const [rawDashboardItems] = useURLState({param: 'dashboard_items'});
 
   const dashboardItems =
-    (rawDashboardItems as string[]) !== undefined ? (rawDashboardItems as string[]) : ['icicle'];
+    rawDashboardItems !== undefined ? (rawDashboardItems as string[]) : ['icicle'];
 
   useEffect(() => {
     const getDataWithPositions = async (): Promise<void> => {

--- a/ui/packages/shared/profile/src/Callgraph/index.tsx
+++ b/ui/packages/shared/profile/src/Callgraph/index.tsx
@@ -186,7 +186,8 @@ const Callgraph = ({graph, sampleUnit, width, colorRange}: Props): JSX.Element =
   const isSearchEmpty = currentSearchString === undefined || currentSearchString === '';
   const [rawDashboardItems] = useURLState({param: 'dashboard_items'});
 
-  const dashboardItems = rawDashboardItems as string[];
+  const dashboardItems =
+    (rawDashboardItems as string[]) !== undefined ? (rawDashboardItems as string[]) : ['icicle'];
 
   useEffect(() => {
     const getDataWithPositions = async (): Promise<void> => {

--- a/ui/packages/shared/profile/src/ProfileView/ViewSelector.tsx
+++ b/ui/packages/shared/profile/src/ProfileView/ViewSelector.tsx
@@ -35,7 +35,7 @@ const ViewSelector = ({
   disabled = false,
 }: Props): JSX.Element => {
   const [callgraphEnabled] = useUIFeatureFlag('callgraph');
-  const [dashboardItems, setDashboardItems] = useURLState({
+  const [dashboardItems = ['icicle'], setDashboardItems] = useURLState({
     param: 'dashboard_items',
     navigateTo,
   });

--- a/ui/packages/shared/profile/src/ProfileView/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileView/index.tsx
@@ -106,7 +106,8 @@ export const ProfileView = ({
     navigateTo,
   });
   const [currentSearchString] = useURLState({param: 'search_string'});
-  const dashboardItems = rawDashboardItems as string[];
+  const dashboardItems =
+    (rawDashboardItems as string[]) !== undefined ? rawDashboardItems : ['icicle'];
   const isDarkMode = useAppSelector(selectDarkMode);
   const isMultiPanelView = dashboardItems.length > 1;
 

--- a/ui/packages/shared/profile/src/ProfileView/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileView/index.tsx
@@ -107,7 +107,7 @@ export const ProfileView = ({
   });
   const [currentSearchString] = useURLState({param: 'search_string'});
   const dashboardItems =
-    (rawDashboardItems as string[]) !== undefined ? rawDashboardItems : ['icicle'];
+    rawDashboardItems !== undefined ? (rawDashboardItems as string[]) : ['icicle'];
   const isDarkMode = useAppSelector(selectDarkMode);
   const isMultiPanelView = dashboardItems.length > 1;
 

--- a/ui/packages/shared/profile/src/ProfileView/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileView/index.tsx
@@ -106,8 +106,14 @@ export const ProfileView = ({
     navigateTo,
   });
   const [currentSearchString] = useURLState({param: 'search_string'});
-  const dashboardItems =
-    rawDashboardItems !== undefined ? (rawDashboardItems as string[]) : ['icicle'];
+
+  const dashboardItems = useMemo(() => {
+    if (rawDashboardItems !== undefined) {
+      return rawDashboardItems as string[];
+    }
+    return ['icicle'];
+  }, [rawDashboardItems]);
+
   const isDarkMode = useAppSelector(selectDarkMode);
   const isMultiPanelView = dashboardItems.length > 1;
 

--- a/ui/packages/shared/profile/src/TopTable/index.tsx
+++ b/ui/packages/shared/profile/src/TopTable/index.tsx
@@ -76,7 +76,8 @@ export const TopTable = React.memo(function TopTable({
 
   const compareMode: boolean = rawcompareMode === undefined ? false : rawcompareMode === 'true';
 
-  const dashboardItems = rawDashboardItems as string[];
+  const dashboardItems =
+    (rawDashboardItems as string[]) !== undefined ? rawDashboardItems : ['icicle'];
 
   const columns = useMemo(() => {
     const cols: Array<ColumnDef<TopNode, any>> = [

--- a/ui/packages/shared/profile/src/TopTable/index.tsx
+++ b/ui/packages/shared/profile/src/TopTable/index.tsx
@@ -76,8 +76,12 @@ export const TopTable = React.memo(function TopTable({
 
   const compareMode: boolean = rawcompareMode === undefined ? false : rawcompareMode === 'true';
 
-  const dashboardItems =
-    rawDashboardItems !== undefined ? (rawDashboardItems as string[]) : ['icicle'];
+  const dashboardItems = useMemo(() => {
+    if (rawDashboardItems !== undefined) {
+      return rawDashboardItems as string[];
+    }
+    return ['icicle'];
+  }, [rawDashboardItems]);
 
   const columns = useMemo(() => {
     const cols: Array<ColumnDef<TopNode, any>> = [

--- a/ui/packages/shared/profile/src/TopTable/index.tsx
+++ b/ui/packages/shared/profile/src/TopTable/index.tsx
@@ -77,7 +77,7 @@ export const TopTable = React.memo(function TopTable({
   const compareMode: boolean = rawcompareMode === undefined ? false : rawcompareMode === 'true';
 
   const dashboardItems =
-    (rawDashboardItems as string[]) !== undefined ? rawDashboardItems : ['icicle'];
+    rawDashboardItems !== undefined ? (rawDashboardItems as string[]) : ['icicle'];
 
   const columns = useMemo(() => {
     const cols: Array<ColumnDef<TopNode, any>> = [


### PR DESCRIPTION
We were not initializing a value for the `dashboard_items` param and this is causing pprof.me to crash.

This will ensure that other apps that uses the `ProfileView` component has a default value (`icicle`) to fall too