### PR TITLE
ui: User preferences icon and release notes viewer bugfix

### DIFF
--- a/ui/packages/app/web/src/components/ReleaseNotesViewer/index.tsx
+++ b/ui/packages/app/web/src/components/ReleaseNotesViewer/index.tsx
@@ -36,7 +36,7 @@ const ReleaseNotesViewer = ({version}: Props) => {
         return;
       }
       const release = await fetch(
-        `https://api.github.com/repos/parca-dev/parca/releases/tags/${version}`
+        `https://api.github.com/repos/parca-dev/parca/releases/tags/v${version}`
       ).then(res => res.json());
       setReleaseNotes(
         `Here's the list of changes in this release:\n${release.body

--- a/ui/packages/shared/components/src/Button/index.tsx
+++ b/ui/packages/shared/components/src/Button/index.tsx
@@ -62,7 +62,7 @@ const Button = ({
       className={cx(
         disabled ? 'opacity-50 pointer-events-none' : '',
         ...Object.values(BUTTON_VARIANT[variant]),
-        'cursor-pointer group relative w-full flex text-sm rounded-md text-white focus:outline-none focus:ring-2 focus:ring-offset-2 items-center justify-center',
+        'cursor-pointer group relative w-full flex text-sm rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 items-center justify-center',
         className
       )}
       disabled={disabled}


### PR DESCRIPTION
Strangely, the `Press Shift to copy` is working fine in this branch, will wait for the preview build. 