### PR TITLE
build(deps): update module gopkg.in/yaml.v2 to v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	google.golang.org/grpc v1.53.0
 	google.golang.org/protobuf v1.28.1
 	gopkg.in/dnaeon/go-vcr.v3 v3.1.2
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -234,7 +234,7 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.66.6 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gotest.tools/v3 v3.2.0 // indirect
 	k8s.io/api v0.26.1 // indirect
 	k8s.io/apimachinery v0.26.1 // indirect

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,6 +14,7 @@
 package config
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"net/url"
@@ -30,7 +31,7 @@ import (
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"github.com/prometheus/prometheus/model/relabel"
 	"github.com/thanos-io/objstore/client"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -119,8 +120,9 @@ func (c *Config) SetDirectory(dir string) {
 func Load(s string) (*Config, error) {
 	cfg := &Config{}
 
-	err := yaml.UnmarshalStrict([]byte(s), cfg)
-	if err != nil {
+	dec := yaml.NewDecoder(bytes.NewBuffer([]byte(s)))
+	dec.KnownFields(true)
+	if err := dec.Decode(cfg); err != nil {
 		return nil, err
 	}
 

--- a/pkg/config/secret.go
+++ b/pkg/config/secret.go
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 // This package no longer handles safe yaml parsing. In order to
-// ensure correct yaml unmarshalling, use "yaml.UnmarshalStrict()".
+// ensure correct yaml unmarshalling, use "yaml.Decoder" with "Decoder.KnownFields(true)".
 
 package config
 

--- a/pkg/debuginfo/metadata_test.go
+++ b/pkg/debuginfo/metadata_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/thanos-io/objstore/providers/filesystem"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/protobuf/types/known/timestamppb"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	debuginfopb "github.com/parca-dev/parca/gen/proto/go/parca/debuginfo/v1alpha1"
 )

--- a/pkg/parca/parca.go
+++ b/pkg/parca/parca.go
@@ -49,7 +49,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	debuginfopb "github.com/parca-dev/parca/gen/proto/go/parca/debuginfo/v1alpha1"
 	metastorepb "github.com/parca-dev/parca/gen/proto/go/parca/metastore/v1alpha1"

--- a/pkg/signedupload/client.go
+++ b/pkg/signedupload/client.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	"github.com/thanos-io/objstore/client"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 // DirDelim is the delimiter used to model a directory structure in an object store bucket.

--- a/pkg/signedupload/gcs.go
+++ b/pkg/signedupload/gcs.go
@@ -25,7 +25,7 @@ import (
 	"github.com/thanos-io/objstore/providers/gcs"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/option"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 type GCSClient struct {

--- a/pkg/symbolizer/symbolizer_test.go
+++ b/pkg/symbolizer/symbolizer_test.go
@@ -31,7 +31,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	debuginfopb "github.com/parca-dev/parca/gen/proto/go/parca/debuginfo/v1alpha1"
 	pb "github.com/parca-dev/parca/gen/proto/go/parca/metastore/v1alpha1"


### PR DESCRIPTION
Renovate crashes on this update without a meaningful error and I cannot reproduce it locally, so doing it manually.

Notable breaking changes:

* go-yaml/yaml@085f3822ccabf97875c60131b52575a980b634a8
* go-yaml/yaml@309c9d15755818936fcb0f5c171692693a47efe2