### PR TITLE
Update outdated navbar styles for phones

### DIFF
--- a/ui/packages/app/web/src/components/ui/Navbar.tsx
+++ b/ui/packages/app/web/src/components/ui/Navbar.tsx
@@ -145,8 +145,8 @@ const Navbar = () => {
                   href={item.href}
                   className={cx(
                     isCurrentPage(item)
-                      ? 'bg-gray-900 text-white'
-                      : 'text-gray-300 hover:bg-gray-700 hover:text-white',
+                      ? 'bg-gray-900 dark:bg-gray-700 text-white'
+                      : 'text-gray-700 dark:text-gray-300 hover:bg-gray-700 hover:text-white',
                     'block px-3 py-2 rounded-md text-base font-medium'
                   )}
                   aria-current={isCurrentPage(item) ? 'page' : undefined}


### PR DESCRIPTION
Seems like we missed updating the styles for small screens.
![broken](https://user-images.githubusercontent.com/872251/227926320-16d29153-5f21-4ec1-9d58-c287b09eaf81.png)
![fixed](https://user-images.githubusercontent.com/872251/227926327-9aa7b0ef-6680-4fb4-ac23-eb70da1deace.png)
