### PR TITLE
Optimize render flamegraph

### DIFF
--- a/pkg/query/columnquery.go
+++ b/pkg/query/columnquery.go
@@ -75,14 +75,14 @@ func newTableConverterPool() *sync.Pool {
 	return &sync.Pool{
 		New: func() any {
 			return &tableConverter{
-				stringsSlice:   make([]string, 0, 300),
-				stringsIndex:   make(map[string]uint32, 300),
-				mappingsSlice:  make([]*metastorev1alpha1.Mapping, 0, 300),
-				mappingsIndex:  make(map[string]uint32, 300),
-				locationsSlice: make([]*metastorev1alpha1.Location, 0, 300),
-				locationsIndex: make(map[string]uint32, 300),
-				functionsSlice: make([]*metastorev1alpha1.Function, 0, 300),
-				functionsIndex: make(map[string]uint32, 300),
+				stringsSlice:   []string{},
+				stringsIndex:   map[string]uint32{},
+				mappingsSlice:  []*metastorev1alpha1.Mapping{},
+				mappingsIndex:  map[string]uint32{},
+				locationsSlice: []*metastorev1alpha1.Location{},
+				locationsIndex: map[string]uint32{},
+				functionsSlice: []*metastorev1alpha1.Function{},
+				functionsIndex: map[string]uint32{},
 			}
 		},
 	}

--- a/pkg/query/flamegraph_flat_test.go
+++ b/pkg/query/flamegraph_flat_test.go
@@ -227,7 +227,7 @@ func testGenerateFlamegraphFromProfile(t *testing.T, l metastorepb.MetastoreServ
 	sp, err := parcacol.NewArrowToProfileConverter(tracer, l).SymbolizeNormalizedProfile(ctx, profiles[0])
 	require.NoError(t, err)
 
-	fg, err := GenerateFlamegraphTable(ctx, tracer, sp, nodeTrimFraction)
+	fg, err := GenerateFlamegraphTable(ctx, tracer, sp, nodeTrimFraction, newTableConverterPool())
 	require.NoError(t, err)
 
 	return fg


### PR DESCRIPTION
The render flamegraph function can spend a lot of time allocating and gc'ing buffers. This adds a sync.pool for the buffers for rendering.

```
thor@thors-MacBook-Pro query % benchstat before.txt after.txt
name                                     old time/op    new time/op    delta
_GenerateFlamegraphTable_FromProfile-10     760µs ± 5%     696µs ± 5%  -8.35%  (p=0.000 n=10+10)

name                                     old alloc/op   new alloc/op   delta
_GenerateFlamegraphTable_FromProfile-10    1.23MB ± 0%    1.15MB ± 0%  -6.68%  (p=0.000 n=10+9)

name                                     old allocs/op  new allocs/op  delta
_GenerateFlamegraphTable_FromProfile-10     11.7k ± 0%     11.6k ± 0%  -0.64%  (p=0.000 n=10+10)
```

It produces moderate savings