### PR TITLE
ui: Improve dark styling for targets page and Pill component

### DIFF
--- a/ui/packages/app/web/src/pages/targets.tsx
+++ b/ui/packages/app/web/src/pages/targets.tsx
@@ -155,14 +155,14 @@ const TargetsPage = (): JSX.Element => {
                 <></>
               )}
               {Object.keys(targets ?? {}).length > 0 ? (
-                <div className="overflow-hidden border-b border-gray-200 shadow sm:rounded-lg">
+                <div className="overflow-hidden border-b border-gray-200 dark:border-gray-700 shadow sm:rounded-lg">
                   {sortTargets(targetNamespaces)?.map(namespace => {
                     const name = Object.keys(namespace)[0];
                     const targets = namespace[name].sort((a: Target, b: Target) => {
                       return a.url.localeCompare(b.url);
                     });
                     return (
-                      <div key={name} className="my-2 border-b-2 p-2">
+                      <div key={name} className="my-2 border-b-2 p-2 dark:border-gray-700">
                         <div className="my-2">
                           <span className="text-xl font-semibold">{name}</span>
                         </div>

--- a/ui/packages/shared/components/src/Pill/index.tsx
+++ b/ui/packages/shared/components/src/Pill/index.tsx
@@ -15,28 +15,28 @@ import cx from 'classnames';
 
 const VARIANTS = {
   primary: {
-    color: 'text-gray-600',
-    bg: 'bg-indigo-100',
+    color: 'text-gray-600 dark:text-gray-200',
+    bg: 'bg-indigo-100 dark:bg-indigo-900',
   },
   success: {
-    color: 'text-green-800',
-    bg: 'bg-green-100',
+    color: 'text-green-800 dark:text-green-200',
+    bg: 'bg-green-100 dark:bg-green-900',
   },
   danger: {
-    color: 'text-red-800',
-    bg: 'bg-red-100',
+    color: 'text-red-800 dark:text-red-200',
+    bg: 'bg-red-100 dark:bg-red-900',
   },
   warning: {
-    color: 'text-amber-800',
-    bg: 'bg-amber-100',
+    color: 'text-amber-800 dark:text-amber-200',
+    bg: 'bg-amber-100 dark:bg-amber-900',
   },
   info: {
-    color: 'text-blue-600',
-    bg: 'bg-blue-100',
+    color: 'text-blue-600 dark:text-blue-200',
+    bg: 'bg-blue-100 dark:bg-blue-800',
   },
   neutral: {
-    color: 'text-neutral-800',
-    bg: 'bg-neutral-100',
+    color: 'text-neutral-800 dark:text-neutral-200',
+    bg: 'bg-neutral-100 dark:bg-neutral-900',
   },
 };
 


### PR DESCRIPTION
Been using the dark mode a bit more recently (macOS auto switches) and these pills really caught my eye :smile: 

![before](https://user-images.githubusercontent.com/872251/228794668-a890f50e-f2b4-4a7d-aa00-b323357370d2.png)
![improved](https://user-images.githubusercontent.com/872251/228794681-ef668254-d759-4d9b-85df-10cf8029c1c2.png)
