### PR TITLE
fix: change automaxprocs log level to debug

### DIFF
--- a/cmd/parca/main.go
+++ b/cmd/parca/main.go
@@ -54,7 +54,7 @@ func main() {
 	)
 
 	if _, err := maxprocs.Set(maxprocs.Logger(func(format string, a ...interface{}) {
-		level.Info(logger).Log("msg", fmt.Sprintf(format, a...))
+		level.Debug(logger).Log("msg", fmt.Sprintf(format, a...))
 	})); err != nil {
 		level.Warn(logger).Log("msg", "failed to set GOMAXPROCS automatically", "err", err)
 	}


### PR DESCRIPTION
This is related to internals, and irrelevant to the end-user. I would not like it to appear as recommendation to use CPU limits. 