### PR TITLE
Fix link to release page

### DIFF
--- a/ui/packages/app/web/src/components/ReleaseNotesViewer/index.tsx
+++ b/ui/packages/app/web/src/components/ReleaseNotesViewer/index.tsx
@@ -98,7 +98,7 @@ const ReleaseNotesViewer = ({version}: Props) => {
                 className="w-fit"
                 onClick={() => {
                   window.open(
-                    `https://github.com/parca-dev/parca/releases/tag/${version}`,
+                    `https://github.com/parca-dev/parca/releases/tag/v${version}`,
                     '_blank'
                   );
                   onClose();


### PR DESCRIPTION
The `Full Changelog` button is pointing to https://github.com/parca-dev/parca/releases/tag/0.17.0 instead of https://github.com/parca-dev/parca/releases/tag/v0.17.0