### PR TITLE
Support stacktrace ID's as a slice of strings

### DIFF
--- a/pkg/parcacol/arrow.go
+++ b/pkg/parcacol/arrow.go
@@ -105,7 +105,7 @@ func (c *ArrowToProfileConverter) Convert(
 func (c *ArrowToProfileConverter) SymbolizeNormalizedProfile(ctx context.Context, p *profile.NormalizedProfile) (*profile.Profile, error) {
 	stacktraceIDs := make([]string, len(p.Samples))
 	for i, sample := range p.Samples {
-		stacktraceIDs[i] = sample.StacktraceID
+		stacktraceIDs[i] = sample.StacktraceID[0]
 	}
 
 	stacktraceLocations, err := c.resolveStacktraces(ctx, stacktraceIDs)

--- a/pkg/parcacol/normalizer.go
+++ b/pkg/parcacol/normalizer.go
@@ -85,7 +85,7 @@ func (n *MetastoreNormalizer) NormalizePprof(ctx context.Context, name string, t
 			}
 
 			ns := &profile.NormalizedSample{
-				StacktraceID: stacktraces[i].Id,
+				StacktraceID: []string{stacktraces[i].Id},
 				Value:        sample.Value[j],
 				Label:        labels,
 				NumLabel:     numLabels,

--- a/pkg/parcacol/sample.go
+++ b/pkg/parcacol/sample.go
@@ -68,7 +68,7 @@ func SampleToParquetRow(
 			row = append(row, parquet.ValueOf(meta.SampleType.Unit).Level(0, 0, columnIndex))
 			columnIndex++
 		case ColumnStacktrace:
-			row = append(row, parquet.ValueOf(s.StacktraceID).Level(0, 0, columnIndex))
+			row = append(row, parquet.ValueOf(s.StacktraceID[0]).Level(0, 0, columnIndex))
 			columnIndex++
 		case ColumnTimestamp:
 			row = append(row, parquet.ValueOf(meta.Timestamp).Level(0, 0, columnIndex))
@@ -169,7 +169,7 @@ func SeriesToArrowRecord(
 							err = bldr.Field(i).(*array.BinaryDictionaryBuilder).AppendString(p.Meta.SampleType.Unit)
 							i++
 						case ColumnStacktrace:
-							bldr.Field(i).(*array.BinaryBuilder).AppendString(sample.StacktraceID)
+							bldr.Field(i).(*array.BinaryBuilder).AppendString(sample.StacktraceID[0])
 							i++
 						case ColumnTimestamp:
 							bldr.Field(i).(*array.Int64Builder).Append(p.Meta.Timestamp)

--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -52,7 +52,7 @@ type SymbolizedSample struct {
 }
 
 type NormalizedSample struct {
-	StacktraceID string
+	StacktraceID []string
 	Value        int64
 	DiffValue    int64
 	Label        map[string]string

--- a/pkg/query/columnquery_test.go
+++ b/pkg/query/columnquery_test.go
@@ -562,7 +562,7 @@ func TestColumnQueryAPIQueryDiff(t *testing.T) {
 				Timestamp:  1,
 			},
 			Samples: []*profile.NormalizedSample{{
-				StacktraceID: st1.Id,
+				StacktraceID: []string{st1.Id},
 				Value:        1,
 			}},
 		}}},
@@ -578,7 +578,7 @@ func TestColumnQueryAPIQueryDiff(t *testing.T) {
 				Timestamp:  2,
 			},
 			Samples: []*profile.NormalizedSample{{
-				StacktraceID: st2.Id,
+				StacktraceID: []string{st2.Id},
 				Value:        2,
 			}},
 		}}},

--- a/pkg/query/flamegraph_flat_test.go
+++ b/pkg/query/flamegraph_flat_test.go
@@ -131,13 +131,13 @@ func TestGenerateFlamegraphFlat(t *testing.T) {
 
 	p, err := parcacol.NewArrowToProfileConverter(tracer, metastore).SymbolizeNormalizedProfile(ctx, &parcaprofile.NormalizedProfile{
 		Samples: []*parcaprofile.NormalizedSample{{
-			StacktraceID: s1.Id,
+			StacktraceID: []string{s1.Id},
 			Value:        2,
 		}, {
-			StacktraceID: s2.Id,
+			StacktraceID: []string{s2.Id},
 			Value:        1,
 		}, {
-			StacktraceID: s3.Id,
+			StacktraceID: []string{s3.Id},
 			Value:        3,
 		}},
 	})

--- a/pkg/query/flamegraph_table_test.go
+++ b/pkg/query/flamegraph_table_test.go
@@ -132,13 +132,13 @@ func TestGenerateFlamegraphTable(t *testing.T) {
 
 	p, err := parcacol.NewArrowToProfileConverter(tracer, metastore).SymbolizeNormalizedProfile(ctx, &parcaprofile.NormalizedProfile{
 		Samples: []*parcaprofile.NormalizedSample{{
-			StacktraceID: s1.Id,
+			StacktraceID: []string{s1.Id},
 			Value:        2,
 		}, {
-			StacktraceID: s2.Id,
+			StacktraceID: []string{s2.Id},
 			Value:        1,
 		}, {
-			StacktraceID: s3.Id,
+			StacktraceID: []string{s3.Id},
 			Value:        3,
 		}},
 	})
@@ -294,14 +294,14 @@ func TestGenerateFlamegraphTableTrimming(t *testing.T) {
 
 	p, err := parcacol.NewArrowToProfileConverter(tracer, metastore).SymbolizeNormalizedProfile(ctx, &parcaprofile.NormalizedProfile{
 		Samples: []*parcaprofile.NormalizedSample{{
-			StacktraceID: s1.Id,
+			StacktraceID: []string{s1.Id},
 			Value:        10,
 		}, {
 			// The following two samples are trimmed from the flamegraph.
-			StacktraceID: s2.Id,
+			StacktraceID: []string{s2.Id},
 			Value:        1,
 		}, {
-			StacktraceID: s3.Id,
+			StacktraceID: []string{s3.Id},
 			Value:        3,
 		}},
 	})
@@ -438,16 +438,16 @@ func TestGenerateFlamegraphTableMergeMappings(t *testing.T) {
 
 	p, err := parcacol.NewArrowToProfileConverter(tracer, metastore).SymbolizeNormalizedProfile(ctx, &parcaprofile.NormalizedProfile{
 		Samples: []*parcaprofile.NormalizedSample{{
-			StacktraceID: s1.Id,
+			StacktraceID: []string{s1.Id},
 			Value:        2,
 		}, {
-			StacktraceID: s3.Id,
+			StacktraceID: []string{s3.Id},
 			Value:        2,
 		}, {
-			StacktraceID: s4.Id,
+			StacktraceID: []string{s4.Id},
 			Value:        2,
 		}, {
-			StacktraceID: s2.Id,
+			StacktraceID: []string{s2.Id},
 			Value:        1,
 		}},
 	})
@@ -1181,18 +1181,18 @@ func TestFlamegraphTrimmingAndFiltering(t *testing.T) {
 
 	p, err := parcacol.NewArrowToProfileConverter(tracer, metastore).SymbolizeNormalizedProfile(ctx, &parcaprofile.NormalizedProfile{
 		Samples: []*parcaprofile.NormalizedSample{{
-			StacktraceID: s1.Id,
+			StacktraceID: []string{s1.Id},
 			Value:        2,
 		}, {
-			StacktraceID: s2.Id,
+			StacktraceID: []string{s2.Id},
 			Value:        1,
 		}, {
 			// Only this sample will be in the final flamegraph.
 			// The two above will be filtered and the last one will be trimmed.
-			StacktraceID: s3.Id,
+			StacktraceID: []string{s3.Id},
 			Value:        12,
 		}, {
-			StacktraceID: s4.Id,
+			StacktraceID: []string{s4.Id},
 			Value:        3,
 		}},
 	})

--- a/pkg/query/pprof_test.go
+++ b/pkg/query/pprof_test.go
@@ -166,7 +166,7 @@ func TestGeneratePprofNilMapping(t *testing.T) {
 	tracer := trace.NewNoopTracerProvider().Tracer("")
 	symbolizedProfile, err := parcacol.NewArrowToProfileConverter(tracer, metastore).SymbolizeNormalizedProfile(ctx, &parcaprofile.NormalizedProfile{
 		Samples: []*parcaprofile.NormalizedSample{{
-			StacktraceID: s.Id,
+			StacktraceID: []string{s.Id},
 			Value:        1,
 		}},
 	})

--- a/pkg/query/top_test.go
+++ b/pkg/query/top_test.go
@@ -142,13 +142,13 @@ func TestGenerateTopTableAggregateFlat(t *testing.T) {
 
 	p, err := parcacol.NewArrowToProfileConverter(tracer, metastore).SymbolizeNormalizedProfile(ctx, &profile.NormalizedProfile{
 		Samples: []*profile.NormalizedSample{{
-			StacktraceID: st1.Id,
+			StacktraceID: []string{st1.Id},
 			Value:        1,
 		}, {
-			StacktraceID: st2.Id,
+			StacktraceID: []string{st2.Id},
 			Value:        1,
 		}, {
-			StacktraceID: st3.Id,
+			StacktraceID: []string{st3.Id},
 			Value:        1,
 		}},
 	})


### PR DESCRIPTION
Changes the `StacktraceID` from a `string` to a `[]string` which allows the stack trace to be stored as a slice of locations instead of just a single string.