### PR TITLE
pkg/parcacol: Reduce allocs in sampleKey

### DIFF
--- a/pkg/parcacol/normalizer.go
+++ b/pkg/parcacol/normalizer.go
@@ -17,6 +17,8 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strconv"
+	"strings"
 
 	pprofpb "github.com/parca-dev/parca/gen/proto/go/google/pprof"
 	pb "github.com/parca-dev/parca/gen/proto/go/parca/metastore/v1alpha1"
@@ -104,16 +106,29 @@ func (n *MetastoreNormalizer) NormalizePprof(ctx context.Context, name string, t
 	return profiles, nil
 }
 
+// sampleKey combines stack trace ID and all key-value label pairs
+// with a semicolon delimeter.
 func sampleKey(stacktraceID string, labels map[string]string, numLabels map[string]int64) string {
-	key := stacktraceID + ";"
+	var key strings.Builder
+	key.WriteString(stacktraceID)
+	key.WriteRune(';')
+
 	for k, v := range labels {
-		key += fmt.Sprintf("%s=%s;", k, v)
+		key.WriteString(k)
+		key.WriteRune('=')
+		key.WriteString(v)
+		key.WriteRune(';')
 	}
-	key += ";"
+	key.WriteRune(';')
+
 	for k, v := range numLabels {
-		key += fmt.Sprintf("%s=%d;", k, v)
+		key.WriteString(k)
+		key.WriteRune('=')
+		key.WriteString(strconv.FormatInt(v, 10))
+		key.WriteRune(';')
 	}
-	return key
+
+	return key.String()
 }
 
 func LabelNamesFromSamples(

--- a/pkg/parcacol/normalizer_test.go
+++ b/pkg/parcacol/normalizer_test.go
@@ -76,6 +76,36 @@ func TestLabelsFromSample(t *testing.T) {
 	}
 }
 
+func BenchmarkLabelsFromSample(b *testing.B) {
+	var (
+		takenLabels = map[string]string{
+			"foo": "bar",
+		}
+		stringTable = []string{"", "foo", "bar", "exported_foo", "baz"}
+		samples     = []*pprofpb.Label{{
+			Key: 1,
+			Str: 2,
+		}, {
+			Key: 3,
+			Str: 4,
+		}}
+	)
+	var (
+		resultLabels = map[string]string{
+			"exported_foo":          "baz",
+			"exported_exported_foo": "bar",
+		}
+		resultNumLabels = map[string]int64{}
+	)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		labels, numLabels := LabelsFromSample(takenLabels, stringTable, samples)
+		require.Equal(b, resultLabels, labels)
+		require.Equal(b, resultNumLabels, numLabels)
+	}
+}
+
 func TestSampleKey(t *testing.T) {
 	tests := map[string]struct {
 		stacktraceID string

--- a/pkg/parcacol/normalizer_test.go
+++ b/pkg/parcacol/normalizer_test.go
@@ -75,3 +75,67 @@ func TestLabelsFromSample(t *testing.T) {
 		})
 	}
 }
+
+func TestSampleKey(t *testing.T) {
+	tests := map[string]struct {
+		stacktraceID string
+		labels       map[string]string
+		numLabels    map[string]int64
+		want         string
+	}{
+		"no labels": {
+			stacktraceID: "2b-t2tYPDARtdf-_FCsqMnUDllVoG8eHx3DGY6B2zsc=/T7hXckRIomziKtDlxDk8ymfFY0eP56PwOsxoERlyGY8=/MdCcinwyzSndRZX6l3oZ5U9JEiNN1OsxiZcvjaWe434=",
+			labels:       nil,
+			numLabels:    nil,
+			want:         "2b-t2tYPDARtdf-_FCsqMnUDllVoG8eHx3DGY6B2zsc=/T7hXckRIomziKtDlxDk8ymfFY0eP56PwOsxoERlyGY8=/MdCcinwyzSndRZX6l3oZ5U9JEiNN1OsxiZcvjaWe434=;;",
+		},
+		"number labels": {
+			stacktraceID: "2b-t2tYPDARtdf-_FCsqMnUDllVoG8eHx3DGY6B2zsc=/T7hXckRIomziKtDlxDk8ymfFY0eP56PwOsxoERlyGY8=/MdCcinwyzSndRZX6l3oZ5U9JEiNN1OsxiZcvjaWe434=",
+			labels:       nil,
+			numLabels: map[string]int64{
+				"bytes": 98304,
+			},
+			want: "2b-t2tYPDARtdf-_FCsqMnUDllVoG8eHx3DGY6B2zsc=/T7hXckRIomziKtDlxDk8ymfFY0eP56PwOsxoERlyGY8=/MdCcinwyzSndRZX6l3oZ5U9JEiNN1OsxiZcvjaWe434=;;bytes=98304;",
+		},
+		"string and number labels": {
+			stacktraceID: "2b-t2tYPDARtdf-_FCsqMnUDllVoG8eHx3DGY6B2zsc=/T7hXckRIomziKtDlxDk8ymfFY0eP56PwOsxoERlyGY8=/MdCcinwyzSndRZX6l3oZ5U9JEiNN1OsxiZcvjaWe434=",
+			labels: map[string]string{
+				"fizz": "bazz",
+			},
+			numLabels: map[string]int64{
+				"bytes": 98304,
+			},
+			want: "2b-t2tYPDARtdf-_FCsqMnUDllVoG8eHx3DGY6B2zsc=/T7hXckRIomziKtDlxDk8ymfFY0eP56PwOsxoERlyGY8=/MdCcinwyzSndRZX6l3oZ5U9JEiNN1OsxiZcvjaWe434=;fizz=bazz;;bytes=98304;",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := sampleKey(tc.stacktraceID, tc.labels, tc.numLabels)
+			if tc.want != got {
+				t.Errorf("expected %q got %q", tc.want, got)
+			}
+		})
+	}
+}
+
+func BenchmarkSampleKey(b *testing.B) {
+	var (
+		stacktraceID = "2b-t2tYPDARtdf-_FCsqMnUDllVoG8eHx3DGY6B2zsc=/T7hXckRIomziKtDlxDk8ymfFY0eP56PwOsxoERlyGY8=/MdCcinwyzSndRZX6l3oZ5U9JEiNN1OsxiZcvjaWe434="
+		labels       = map[string]string{
+			"fizz": "bazz",
+		}
+		numLabels = map[string]int64{
+			"bytes": 98304,
+		}
+	)
+	want := "2b-t2tYPDARtdf-_FCsqMnUDllVoG8eHx3DGY6B2zsc=/T7hXckRIomziKtDlxDk8ymfFY0eP56PwOsxoERlyGY8=/MdCcinwyzSndRZX6l3oZ5U9JEiNN1OsxiZcvjaWe434=;fizz=bazz;;bytes=98304;"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		got := sampleKey(stacktraceID, labels, numLabels)
+		if want != got {
+			b.Errorf("expected %q got %q", want, got)
+		}
+	}
+}


### PR DESCRIPTION
I was looking where `NormalizeWriteRawRequest` allocates and found a low hanging fruit in `sampleKey` function.

```
# new
BenchmarkSampleKey-12    	 4405494	       279.3 ns/op	     437 B/op	       3 allocs/op
# old
BenchmarkSampleKey-12    	 1849962	       711.8 ns/op	     712 B/op	      10 allocs/op
```

That change reduced allocations in `NormalizeWriteRawRequest` a bit (14K less allocations per operation).

```
$ go test -run=^$ -bench ^BenchmarkNormalizeWriteRawRequest$ -benchmem ./pkg/parcacol -count=50 . | tee bench-new.txt
$ benchstat bench-old.txt bench-new.txt
name                         old time/op    new time/op    delta
NormalizeWriteRawRequest-12    43.9ms ± 7%    43.0ms ± 5%  -2.07%  (p=0.001 n=47+45)

name                         old alloc/op   new alloc/op   delta
NormalizeWriteRawRequest-12    53.5MB ± 1%    53.3MB ± 1%  -0.43%  (p=0.000 n=50+50)

name                         old allocs/op  new allocs/op  delta
NormalizeWriteRawRequest-12      412k ± 0%      398k ± 0%  -3.25%  (p=0.000 n=50+50)
```

<details>

<summary>bench-new.txt</summary>

```
goos: darwin
goarch: amd64
pkg: github.com/parca-dev/parca/pkg/parcacol
cpu: Intel(R) Core(TM) i5-10600 CPU @ 3.30GHz
BenchmarkNormalizeWriteRawRequest-12    	      26	  41450503 ns/op	52988869 B/op	  397158 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      25	  42547738 ns/op	52978531 B/op	  397131 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      26	  45293384 ns/op	53014922 B/op	  397260 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      27	  46488077 ns/op	53047624 B/op	  397375 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      27	  43797060 ns/op	53059125 B/op	  397420 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      27	  45318454 ns/op	53072258 B/op	  397472 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      26	  47198661 ns/op	53068899 B/op	  397471 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      26	  48342296 ns/op	53086328 B/op	  397540 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      27	  46266054 ns/op	53113215 B/op	  397632 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      28	  46436972 ns/op	53147210 B/op	  397753 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      27	  43894445 ns/op	53133457 B/op	  397711 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      27	  43187403 ns/op	53143321 B/op	  397751 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      27	  43404558 ns/op	53155233 B/op	  397797 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      27	  43286190 ns/op	53165813 B/op	  397838 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      27	  42972443 ns/op	53180453 B/op	  397897 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      26	  42445053 ns/op	53171058 B/op	  397872 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      27	  43726505 ns/op	53208184 B/op	  398005 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      28	  44037887 ns/op	53238478 B/op	  398110 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      28	  42820660 ns/op	53245201 B/op	  398137 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      28	  42969337 ns/op	53258786 B/op	  398191 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      30	  43782973 ns/op	53304840 B/op	  398348 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      27	  41109552 ns/op	53252430 B/op	  398178 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      26	  41656053 ns/op	53248349 B/op	  398176 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      25	  42605000 ns/op	53246657 B/op	  398184 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      26	  44019762 ns/op	53290607 B/op	  398341 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      25	  42042087 ns/op	53265377 B/op	  398257 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      27	  43435473 ns/op	53330448 B/op	  398484 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      27	  43722774 ns/op	53344220 B/op	  398538 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      27	  43735235 ns/op	53358731 B/op	  398595 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      26	  42237970 ns/op	53336572 B/op	  398522 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      25	  42792199 ns/op	53333366 B/op	  398524 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      25	  42526412 ns/op	53343033 B/op	  398561 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      27	  43725315 ns/op	53406018 B/op	  398781 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      25	  43993561 ns/op	53383761 B/op	  398722 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      26	  43081086 ns/op	53406023 B/op	  398795 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      27	  44093126 ns/op	53447939 B/op	  398946 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      26	  43241454 ns/op	53433318 B/op	  398901 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      27	  42540234 ns/op	53459461 B/op	  398991 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      27	  42770302 ns/op	53468748 B/op	  399027 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      26	  42902881 ns/op	53465844 B/op	  399029 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      27	  42176349 ns/op	53487344 B/op	  399100 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      26	  41480551 ns/op	53473163 B/op	  399057 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      26	  43417418 ns/op	53509994 B/op	  399203 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      27	  42157394 ns/op	53521395 B/op	  399233 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      27	  42420235 ns/op	53540494 B/op	  399309 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      26	  43143625 ns/op	53543139 B/op	  399333 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      26	  42087192 ns/op	53541444 B/op	  399326 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      27	  42638841 ns/op	53580197 B/op	  399465 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      27	  42815126 ns/op	53593678 B/op	  399517 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      26	  42059198 ns/op	53575494 B/op	  399459 allocs/op
PASS
ok  	github.com/parca-dev/parca/pkg/parcacol	64.947s
```

</details>

<details>

<summary>bench-old.txt</summary>

```
goos: darwin
goarch: amd64
pkg: github.com/parca-dev/parca/pkg/parcacol
cpu: Intel(R) Core(TM) i5-10600 CPU @ 3.30GHz
BenchmarkNormalizeWriteRawRequest-12    	      26	  42337314 ns/op	53229174 B/op	  410569 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      25	  43626863 ns/op	53217564 B/op	  410539 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      26	  46197596 ns/op	53252775 B/op	  410661 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      26	  46195105 ns/op	53267046 B/op	  410718 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      27	  46604315 ns/op	53298870 B/op	  410828 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      21	  50452648 ns/op	53180300 B/op	  410465 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      27	  48726690 ns/op	53327663 B/op	  410942 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      27	  49416643 ns/op	53345011 B/op	  411010 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      27	  47021429 ns/op	53353899 B/op	  411043 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      27	  46301722 ns/op	53364365 B/op	  411085 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      27	  46276497 ns/op	53376390 B/op	  411132 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      28	  45700010 ns/op	53409294 B/op	  411250 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      28	  44886606 ns/op	53415902 B/op	  411275 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      26	  44029247 ns/op	53388668 B/op	  411194 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      27	  44863047 ns/op	53422861 B/op	  411315 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      26	  44029414 ns/op	53416924 B/op	  411307 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      25	  44119689 ns/op	53405528 B/op	  411275 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      25	  43024868 ns/op	53412510 B/op	  411303 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      25	  43961423 ns/op	53429568 B/op	  411370 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      26	  44712753 ns/op	53468523 B/op	  411509 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      27	  43525612 ns/op	53492452 B/op	  411588 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      28	  44731921 ns/op	53531583 B/op	  411729 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      28	  42853638 ns/op	53530381 B/op	  411725 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      25	  43225060 ns/op	53488485 B/op	  411601 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      27	  43710137 ns/op	53544462 B/op	  411793 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      26	  43169532 ns/op	53531445 B/op	  411755 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      26	  44028843 ns/op	53553226 B/op	  411841 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      26	  42066721 ns/op	53547484 B/op	  411816 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      25	  42622156 ns/op	53546083 B/op	  411827 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      27	  44831835 ns/op	53613952 B/op	  412065 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      26	  43013397 ns/op	53594223 B/op	  412001 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      25	  43503835 ns/op	53589111 B/op	  411996 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      26	  43575646 ns/op	53623075 B/op	  412115 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      26	  45119068 ns/op	53652419 B/op	  412229 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      27	  44719536 ns/op	53677572 B/op	  412315 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      26	  42682628 ns/op	53651655 B/op	  412227 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      27	  42354122 ns/op	53678172 B/op	  412317 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      26	  42568798 ns/op	53674996 B/op	  412320 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      26	  42711893 ns/op	53687958 B/op	  412369 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      25	  43836963 ns/op	53692238 B/op	  412401 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      25	  43439458 ns/op	53701412 B/op	  412437 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      26	  44824842 ns/op	53752743 B/op	  412624 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      25	  42788219 ns/op	53716921 B/op	  412496 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      26	  44917601 ns/op	53777043 B/op	  412718 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      27	  43622795 ns/op	53790220 B/op	  412756 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      25	  43375827 ns/op	53759429 B/op	  412664 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      25	  41833342 ns/op	53753813 B/op	  412642 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      25	  41160969 ns/op	53754832 B/op	  412644 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      25	  42368329 ns/op	53786585 B/op	  412772 allocs/op
BenchmarkNormalizeWriteRawRequest-12    	      25	  43155804 ns/op	53808926 B/op	  412859 allocs/op
PASS
ok  	github.com/parca-dev/parca/pkg/parcacol	64.881s
```

</details>
