### PR TITLE
pkg/metastore: Reduce allocs in MakeLocationID

### DIFF
--- a/pkg/metastore/badger.go
+++ b/pkg/metastore/badger.go
@@ -29,8 +29,9 @@ import (
 // BadgerMetastore is an implementation of the metastore using the badger KV
 // store.
 type BadgerMetastore struct {
-	tracer trace.Tracer
-	logger log.Logger
+	tracer   trace.Tracer
+	logger   log.Logger
+	keymaker *KeyMaker
 
 	db *badger.DB
 
@@ -68,9 +69,10 @@ func NewBadgerMetastore(
 	db *badger.DB,
 ) *BadgerMetastore {
 	return &BadgerMetastore{
-		db:     db,
-		tracer: tracer,
-		logger: logger,
+		db:       db,
+		tracer:   tracer,
+		logger:   logger,
+		keymaker: NewKeyMaker(),
 	}
 }
 
@@ -305,7 +307,7 @@ func (m *BadgerMetastore) GetOrCreateLocations(ctx context.Context, r *pb.GetOrC
 
 	locationKeys := make([]string, 0, len(r.Locations))
 	for _, location := range r.Locations {
-		locationKeys = append(locationKeys, MakeLocationKey(location))
+		locationKeys = append(locationKeys, m.keymaker.MakeLocationKey(location))
 	}
 
 	err := m.db.Update(func(txn *badger.Txn) error {

--- a/pkg/metastore/kv.go
+++ b/pkg/metastore/kv.go
@@ -75,19 +75,18 @@ func (m *KeyMaker) MakeLocationID(l *pb.Location) string {
 		}
 	}
 
-	hash := sha512.New512_256()
-	hash.Write(hbuf.Bytes())
-	sum := hash.Sum(nil)
-	mappingId := l.MappingId
-	if mappingId == "" {
-		mappingId = "unknown-mapping"
-	}
+	sum := sha512.Sum512_256(hbuf.Bytes())
 
 	hashLen := base64.URLEncoding.EncodedLen(len(sum))
 	hbuf.Reset()
 	hbuf.Grow(hashLen)
 	b := hbuf.Bytes()[:hashLen]
-	base64.URLEncoding.Encode(b, sum)
+	base64.URLEncoding.Encode(b, sum[:])
+
+	mappingId := l.MappingId
+	if mappingId == "" {
+		mappingId = "unknown-mapping"
+	}
 
 	return mappingId + "/" + string(b)
 }

--- a/pkg/metastore/kv_test.go
+++ b/pkg/metastore/kv_test.go
@@ -1,0 +1,103 @@
+// Copyright 2022-2023 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metastore
+
+import (
+	"testing"
+
+	pb "github.com/parca-dev/parca/gen/proto/go/parca/metastore/v1alpha1"
+)
+
+func TestMakeLocationID(t *testing.T) {
+	tests := map[string]struct {
+		loc  *pb.Location
+		want string
+	}{
+		"one line": {
+			loc: &pb.Location{
+				Address:   9424419,
+				MappingId: "2b-t2tYPDARtdf-_FCsqMnUDllVoG8eHx3DGY6B2zsc=",
+				Lines: []*pb.Line{
+					{
+						FunctionId: "dFRfEsG-uRAep6DtB_p4adjSQiRipfgf0LTZ3B05k74=/auEFFJYKPIUbrC2nw-kBi9ePl80B2bwY6mCyCpUeC78=",
+						Line:       206,
+					},
+				},
+			},
+			want: "2b-t2tYPDARtdf-_FCsqMnUDllVoG8eHx3DGY6B2zsc=/kBL4fDvKSLKe5R_x08kcKOji7UXafFAYjquOeVeZsrA=",
+		},
+		"two lines": {
+			loc: &pb.Location{
+				Address:   9287454,
+				MappingId: "2b-t2tYPDARtdf-_FCsqMnUDllVoG8eHx3DGY6B2zsc=",
+				Lines: []*pb.Line{
+					{
+						FunctionId: "M0phtCvUI0mtpx5-BIqngA332lj6UjfSV64urDi6C1U=/sMz0kkKiNbEqtL2vipylGI9f2Lc-M1ExWCZWu9KKo5I=",
+						Line:       88,
+					},
+					{
+						FunctionId: "APOSsLfLXhP_xNKKKwdpqtMv1ROA5u2xTbWCHYxFIVM=/vSrEl_sMYM6DXy8DmzcBC2yxXNr_Duv0hrrHZLeVws0=",
+						Line:       41,
+					},
+					{
+						FunctionId: "IXXv_eDgJGGpb7ikH21IOdbpfBzTPuRWklMHyheBez4=/joa-isXk0b6wK7TcTHqFVXm1Z5uG17Wpd44wuo8LYqA=",
+						Line:       201,
+					},
+				},
+			},
+			want: "2b-t2tYPDARtdf-_FCsqMnUDllVoG8eHx3DGY6B2zsc=/q2qKTcQ2-RK6Hz06jcBWjT_mve0TYLGYXlFLCUzFdXs=",
+		},
+	}
+
+	km := NewKeyMaker()
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := km.MakeLocationID(tc.loc)
+			if tc.want != got {
+				t.Errorf("expected %q got %q", tc.want, got)
+			}
+		})
+	}
+}
+
+func BenchmarkMakeLocationID(b *testing.B) {
+	km := NewKeyMaker()
+	loc := &pb.Location{
+		Address:   9287454,
+		MappingId: "2b-t2tYPDARtdf-_FCsqMnUDllVoG8eHx3DGY6B2zsc=",
+		Lines: []*pb.Line{
+			{
+				FunctionId: "M0phtCvUI0mtpx5-BIqngA332lj6UjfSV64urDi6C1U=/sMz0kkKiNbEqtL2vipylGI9f2Lc-M1ExWCZWu9KKo5I=",
+				Line:       88,
+			},
+			{
+				FunctionId: "APOSsLfLXhP_xNKKKwdpqtMv1ROA5u2xTbWCHYxFIVM=/vSrEl_sMYM6DXy8DmzcBC2yxXNr_Duv0hrrHZLeVws0=",
+				Line:       41,
+			},
+			{
+				FunctionId: "IXXv_eDgJGGpb7ikH21IOdbpfBzTPuRWklMHyheBez4=/joa-isXk0b6wK7TcTHqFVXm1Z5uG17Wpd44wuo8LYqA=",
+				Line:       201,
+			},
+		},
+	}
+	want := "2b-t2tYPDARtdf-_FCsqMnUDllVoG8eHx3DGY6B2zsc=/q2qKTcQ2-RK6Hz06jcBWjT_mve0TYLGYXlFLCUzFdXs="
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		got := km.MakeLocationID(loc)
+		if want != got {
+			b.Errorf("expected %q got %q", want, got)
+		}
+	}
+}


### PR DESCRIPTION
Reduced allocations in `MakeLocationID`.

```
$ go test -run=^$ -bench ^BenchmarkMakeLocationID$ -benchmem ./pkg/metastore -count=1
...
# new
BenchmarkMakeLocationID-12    	 3224959	       370.4 ns/op	      96 B/op	       1 allocs/op
# old
BenchmarkMakeLocationID-12    	 1859330	       647.9 ns/op	     560 B/op	      10 allocs/op
```

This helped to shave 17K allocations per operation in `NormalizeWriteRawRequest`.

```
$ benchstat bench-old.txt bench-new.txt
name                         old time/op    new time/op    delta
NormalizeWriteRawRequest-12    43.9ms ± 7%    43.1ms ± 5%  -1.89%  (p=0.001 n=47+46)

name                         old alloc/op   new alloc/op   delta
NormalizeWriteRawRequest-12    53.5MB ± 1%    52.7MB ± 1%  -1.62%  (p=0.000 n=50+50)

name                         old allocs/op  new allocs/op  delta
NormalizeWriteRawRequest-12      412k ± 0%      395k ± 0%  -4.12%  (p=0.000 n=50+50)
```

Together with https://github.com/parca-dev/parca/pull/3061 it should save ~31K/operation.