### PR TITLE
pkg/parcacol: Fix NewNormalizer call in test

### DIFF
--- a/pkg/parcacol/ingest_test.go
+++ b/pkg/parcacol/ingest_test.go
@@ -288,7 +288,7 @@ func BenchmarkNormalizeWriteRawRequest(b *testing.B) {
 	fileContent, err := os.ReadFile("../query/testdata/alloc_objects.pb.gz")
 	require.NoError(b, err)
 
-	normalizer := NewNormalizer(metastore)
+	normalizer := NewNormalizer(metastore, true)
 	req := &profilestorepb.WriteRawRequest{
 		Series: []*profilestorepb.RawProfileSeries{{
 			Labels: &profilestorepb.LabelSet{


### PR DESCRIPTION
Seems like something was incorrectly merged or rebased or whatever after #2955...
This should fix the CI currently failing on `main`.

cc @marselester @kakkoyun 
