### PR TITLE
fix: conditionally select GRPC codec

### DIFF
--- a/cmd/parca/main.go
+++ b/cmd/parca/main.go
@@ -21,11 +21,8 @@ import (
 	"github.com/alecthomas/kong"
 	"github.com/common-nighthawk/go-figure"
 	"github.com/go-kit/log/level"
-	vtproto "github.com/planetscale/vtprotobuf/codec/grpc"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/automaxprocs/maxprocs"
-	"google.golang.org/grpc/encoding"
-	_ "google.golang.org/grpc/encoding/proto"
 
 	"github.com/parca-dev/parca/pkg/parca"
 )
@@ -34,10 +31,6 @@ var (
 	version = "dev"
 	commit  = "dev"
 )
-
-func init() {
-	encoding.RegisterCodec(vtproto.Codec{})
-}
 
 func main() {
 	ctx := context.Background()

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,6 @@ require (
 	github.com/klauspost/compress v1.16.5
 	github.com/nanmu42/limitio v1.0.0
 	github.com/oklog/run v1.1.0
-	github.com/planetscale/vtprotobuf v0.4.0
 	github.com/polarsignals/frostdb v0.0.0-20230516175933-552125a71de6
 	github.com/prometheus/client_golang v1.15.1
 	github.com/prometheus/common v0.43.0

--- a/go.sum
+++ b/go.sum
@@ -779,8 +779,6 @@ github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
-github.com/planetscale/vtprotobuf v0.4.0 h1:NEI+g4woRaAZgeZ3sAvbtyvMBRjIv5kE7EWYQ8m4JwY=
-github.com/planetscale/vtprotobuf v0.4.0/go.mod h1:wm1N3qk9G/4+VM1WhpkLbvY/d8+0PbwYYpP5P5VhTks=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/polarsignals/frostdb v0.0.0-20230516175933-552125a71de6 h1:W6osMauT8VuhbyIGgZFHvi8TohuoukZH2yxjvpuSSFs=

--- a/pkg/server/grpc_codec.go
+++ b/pkg/server/grpc_codec.go
@@ -1,0 +1,72 @@
+// Copyright 2023 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Based on:
+// https://github.com/planetscale/vtprotobuf#mixing-protobuf-implementations-with-grpc
+// https://github.com/vitessio/vitess/blob/main/go/vt/servenv/grpc_codec.go
+
+package server
+
+import (
+	"fmt"
+
+	// use the original golang/protobuf package we can continue serializing
+	// messages from our dependencies, particularly for:
+	//   - grpc.health.v1.Health
+	//   - grpc.reflection.v1alpha.ServerReflection
+	//   - grpc.reflection.v1.ServerReflection
+	"google.golang.org/protobuf/proto"
+
+	"google.golang.org/grpc/encoding"
+	_ "google.golang.org/grpc/encoding/proto"
+)
+
+// Name is the name registered for the proto compressor.
+const Name = "proto"
+
+type vtprotoCodec struct{}
+
+type vtprotoMessage interface {
+	MarshalVT() ([]byte, error)
+	UnmarshalVT([]byte) error
+}
+
+func (vtprotoCodec) Marshal(v any) ([]byte, error) {
+	switch v := v.(type) {
+	case vtprotoMessage:
+		return v.MarshalVT()
+	case proto.Message:
+		return proto.Marshal(v)
+	default:
+		return nil, fmt.Errorf("failed to marshal, message is %T, must satisfy the vtprotoMessage interface or want proto.Message", v)
+	}
+}
+
+func (vtprotoCodec) Unmarshal(data []byte, v any) error {
+	switch v := v.(type) {
+	case vtprotoMessage:
+		return v.UnmarshalVT(data)
+	case proto.Message:
+		return proto.Unmarshal(data, v)
+	default:
+		return fmt.Errorf("failed to unmarshal, message is %T, must satisfy the vtprotoMessage interface or want proto.Message", v)
+	}
+}
+
+func (vtprotoCodec) Name() string {
+	return Name
+}
+
+func init() {
+	encoding.RegisterCodec(vtprotoCodec{})
+}


### PR DESCRIPTION
In #3019, I overlooked the health and reflection GPRC services which do not have optimized `vtprotobuf` marshalling code. As a result, the demo pod is stuck in a crash loop with its health probe failing:

```
Events:
  Type     Reason     Age                  From     Message
  ----     ------     ----                 ----     -------
  Warning  Unhealthy  10m (x165 over 85m)  kubelet  (combined from similar events): Readiness probe failed: parsed options:
> addr=:7070 conn_timeout=1s rpc_timeout=1s
> tls=false
> alts=false
> spiffe=false
establishing connection
connection established (took 1.948716ms)
error: health rpc failed: rpc error: code = Internal desc = grpc: error unmarshalling request: failed to unmarshal, message is *grpc_health_v1.HealthCheckRequest (missing vtprotobuf helpers)
  Warning  BackOff  65s (x333 over 83m)  kubelet  Back-off restarting failed container
```

This adds a custom GRPC codec with a type-switch as [documented by `vtprotobuf`](https://github.com/planetscale/vtprotobuf#mixing-protobuf-implementations-with-grpc). Tested with `grpcurl`:

```console
# `grpc.reflection.v1alpha.ServerReflection` works
$ grpcurl -plaintext localhost:7070 list
grpc.health.v1.Health
grpc.reflection.v1alpha.ServerReflection
parca.debuginfo.v1alpha1.DebuginfoService
parca.profilestore.v1alpha1.AgentsService
parca.profilestore.v1alpha1.ProfileStoreService
parca.query.v1alpha1.QueryService
parca.scrape.v1alpha1.ScrapeService

$ grpcurl -plaintext localhost:7070 describe grpc.health.v1.Health
grpc.health.v1.Health is a service:
service Health {
  rpc Check ( .grpc.health.v1.HealthCheckRequest ) returns ( .grpc.health.v1.HealthCheckResponse );
  rpc Watch ( .grpc.health.v1.HealthCheckRequest ) returns ( stream .grpc.health.v1.HealthCheckResponse );
}

# `grpc.health.v1.Health` works
$ grpcurl -plaintext localhost:7070 grpc.health.v1.Health/Check
{
  "status": "SERVING"
}
``` 