### PR TITLE
ui: Remove useEffect fn responsible for resetting current icicle path

### DIFF
--- a/ui/packages/shared/components/src/hooks/useURLState.tsx
+++ b/ui/packages/shared/components/src/hooks/useURLState.tsx
@@ -73,7 +73,7 @@ export const useURLState = ({
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [value, highlightAfterFilteringEnabled, param, withURLUpdate, navigateTo]);
+  }, [value, highlightAfterFilteringEnabled, param, withURLUpdate]);
 
   if (param === 'dashboard_items') {
     let dashboardItems: string[] = [];

--- a/ui/packages/shared/profile/src/ProfileView/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileView/index.tsx
@@ -133,12 +133,10 @@ export const ProfileView = ({
 
   const {loader, perf} = useParcaContext();
 
-  // TODO: Figure out why profileSource's constantly changing value causes an infinite render on PSC, thereby causing the instant reset bug in the icicle graph as reported in https://github.com/polarsignals/polarsignals/issues/1991#event-9340441410
-
-  // useEffect(() => {
-  //   // Reset the current path when the profile source changes
-  //   setCurPath([]);
-  // }, [profileSource]);
+  useEffect(() => {
+    // Reset the current path when the profile source changes
+    setCurPath([]);
+  }, [profileSource]);
 
   useEffect(() => {
     async function loadGraphviz(): Promise<void> {

--- a/ui/packages/shared/profile/src/ProfileView/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileView/index.tsx
@@ -133,10 +133,12 @@ export const ProfileView = ({
 
   const {loader, perf} = useParcaContext();
 
-  useEffect(() => {
-    // Reset the current path when the profile source changes
-    setCurPath([]);
-  }, [profileSource]);
+  // TODO: Figure out why profileSource's constantly changing value causes an infinite render on PSC, thereby causing the instant reset bug in the icicle graph as reported in https://github.com/polarsignals/polarsignals/issues/1991#event-9340441410
+
+  // useEffect(() => {
+  //   // Reset the current path when the profile source changes
+  //   setCurPath([]);
+  // }, [profileSource]);
 
   useEffect(() => {
     async function loadGraphviz(): Promise<void> {


### PR DESCRIPTION
This fixes the bug in [#1991](https://github.com/polarsignals/polarsignals/issues/1991#event-9340441410). 

**Steps to reproduce bug**
- Pull up any icicle graph
- Apply a function filter
- ~~Expand something in the icicle graph~~
- ~~Click on root node~~
- Remove function filter
- From now on anything you click on in the icicle graph has this bug. 

A couple of things to note:

**TL:DR: Removed the `navigateTo` function as a dependency in the useEffect hook in the in the `useURLState` hook.**

This bug doesn't seem to happen in Parca but only on PSC. After some investigating, I discovered this is because this [useEffect](https://github.com/parca-dev/parca/blob/main/ui/packages/shared/profile/src/ProfileView/index.tsx#L136) keeps firing after a function filter has been removed i.e. setting the `curPath` to be an array, effectively causing the icicle graph to reset immediately after any clicking interaction with it. 

Since this only takes place after the function filter is removed, I was able to isolate (did this by commenting the `setStoreValue` line out, and manually updating the URL with a `filter_by_function` query param and then deleting it. The icicle graph did not reset after this manual update) the bug to the [setStoreValue](https://github.com/parca-dev/parca/blob/main/ui/packages/shared/profile/src/ProfileView/FilterByFunctionButton.tsx#L36) function in the `FilterByFunctionbutton` component. The `setStoreValue` function is retrieved from the `useURLState` hook.

Therefore the reason for the infinite re-rendering had to be in the `useURLState` hook, and probably the `useEffect` hook, which had a couple of dependencies, which it used to determine whether to re-render. So I thought to remove the `navigateTo` function as a dependency in the useEffect hook in the in the `useURLState` hook.
 
https://github.com/parca-dev/parca/assets/9016992/aeccc696-bea5-4c69-b065-c6e75e03bcf5