### PR TITLE
perf(scrape): apply optimizations from upstream prometheus

### DIFF
--- a/pkg/scrape/scrape.go
+++ b/pkg/scrape/scrape.go
@@ -206,10 +206,12 @@ func (sp *scrapePool) Sync(tgs []*targetgroup.Group) {
 	start := time.Now()
 
 	var all []*Target
+	var targets []*Target
+	lb := labels.NewBuilder(labels.EmptyLabels())
 	sp.mtx.Lock()
 	sp.droppedTargets = []*Target{}
 	for _, tg := range tgs {
-		targets, err := targetsFromGroup(tg, sp.config)
+		targets, err := targetsFromGroup(tg, sp.config, targets, lb)
 		if err != nil {
 			level.Error(sp.logger).Log("msg", "creating targets failed", "err", err)
 			continue

--- a/pkg/scrape/scrape.go
+++ b/pkg/scrape/scrape.go
@@ -218,9 +218,12 @@ func (sp *scrapePool) Sync(tgs []*targetgroup.Group) {
 		}
 
 		for _, t := range targets {
-			if !t.Labels().IsEmpty() {
+			// Replicate .Labels().IsEmpty() with a loop here to avoid generating garbage.
+			nonEmpty := false
+			t.LabelsRange(func(l labels.Label) { nonEmpty = true })
+			if nonEmpty {
 				all = append(all, t)
-			} else if !t.DiscoveredLabels().IsEmpty() {
+			} else if !t.discoveredLabels.IsEmpty() {
 				sp.droppedTargets = append(sp.droppedTargets, t)
 			}
 		}

--- a/pkg/scrape/target.go
+++ b/pkg/scrape/target.go
@@ -117,6 +117,15 @@ func (t *Target) Labels() labels.Labels {
 	return b.Labels()
 }
 
+// LabelsRange calls f on each public label of the target.
+func (t *Target) LabelsRange(f func(l labels.Label)) {
+	t.labels.Range(func(l labels.Label) {
+		if !strings.HasPrefix(l.Name, model.ReservedLabelPrefix) {
+			f(l)
+		}
+	})
+}
+
 // DiscoveredLabels returns a copy of the target's labels before any processing.
 func (t *Target) DiscoveredLabels() labels.Labels {
 	t.mtx.Lock()


### PR DESCRIPTION
This applies allocation optimizations related to scraping targets.

See upstream PR prometheus/prometheus#12048 and prometheus/prometheus#12084 (and prometheus/prometheus#12173)