### PR TITLE
fix click, drag, and keydown behavior

### DIFF
--- a/ui/packages/shared/profile/src/MetricsGraph/index.tsx
+++ b/ui/packages/shared/profile/src/MetricsGraph/index.tsx
@@ -221,6 +221,11 @@ export const RawMetricsGraph = ({
   const highlighted = getClosest();
 
   const onMouseDown = (e: React.MouseEvent<SVGSVGElement | HTMLDivElement, MouseEvent>): void => {
+    // if shift is down, disable mouse behavior
+    if (isShiftDown) {
+      return;
+    }
+
     // only left mouse button
     if (e.button !== 0) {
       return;
@@ -251,6 +256,10 @@ export const RawMetricsGraph = ({
   };
 
   const onMouseUp = (e: React.MouseEvent<SVGSVGElement | HTMLDivElement, MouseEvent>): void => {
+    if (isShiftDown) {
+      return;
+    }
+
     setDragging(false);
 
     if (relPos === -1) {
@@ -283,6 +292,11 @@ export const RawMetricsGraph = ({
   const throttledSetPos = throttle(setPos, 20);
 
   const onMouseMove = (e: React.MouseEvent<SVGSVGElement | HTMLDivElement, MouseEvent>): void => {
+    // do not update position if shift is down because this means the user is locking the tooltip
+    if (isShiftDown) {
+      return;
+    }
+
     // X/Y coordinate array relative to svg
     const rel = pointer(e);
 
@@ -291,9 +305,7 @@ export const RawMetricsGraph = ({
     const yCoordinate = rel[1];
     const yCoordinateWithoutMargin = yCoordinate - margin;
 
-    if (!isShiftDown) {
-      throttledSetPos([xCoordinateWithoutMargin, yCoordinateWithoutMargin]);
-    }
+    throttledSetPos([xCoordinateWithoutMargin, yCoordinateWithoutMargin]);
   };
 
   const findSelectedProfile = (): HighlightedSeries | null => {


### PR DESCRIPTION
Resolves MetricsGraph issues regarding point selection, range selection, freezing the tooltip, and taking screenshots.

**Problem:**
We've had several reports of bugs when interacting with the MetricsGraph. Sometimes, the MetricsGraph goes into a mode where instead of clicking on a point it will zoom in, the MetricsGraph Tooltip doesn't work anymore either.

**Solution:**
Currently, we have special logic in place that freezes the Metrics Graph tooltip when the user holds down the 'Shift' key. However, 'Shift' is a special key that is used for certain shortcuts (such as taking a screenshots on Mac). The issue here is that when the shift key was pressed, followed by 'command' in order to take a screenshot, the application was paused as it entered screenshot mode and `isShiftDown` in our `useKeyDown` hook did not update on 'keyup'. The last captured event was 'keydown' of the shift key, therefore `isShiftDown` remained stuck in a 'down' state, even though it was no longer down.  Manually resetting `isShiftDown` state to false when the user hits the "Meta" key (in Mac = command, in Windows = Control) was able to solve this issue. 

Additionally, clicks outside of the tooltip have been disabled when shift is held down in order to ensure that only the tooltip can be clicked while the tooltip is frozen. This was able to resolve issues around unexpected zooming. 