### PR TITLE
fix(config): fix reloading config from Kubernetes ConfigMap

### DIFF
--- a/pkg/config/reloader.go
+++ b/pkg/config/reloader.go
@@ -15,6 +15,7 @@ package config
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -97,7 +98,21 @@ func (r *ConfigReloader) watchFile() {
 				level.Debug(r.logger).Log("msg", "config file watcher events channel closed. exiting goroutine.")
 				return
 			}
-			if event.Op&fsnotify.Write == fsnotify.Write {
+			if event.Has(fsnotify.Remove) {
+				// Handle case where the config file is a symlink (e.g. Kubernetes ConfigMap)
+				level.Debug(r.logger).Log("msg", "config file has been removed/recreated")
+				// Ensure watcher has stopped monitoring the removed file
+				if err := r.watcher.Remove(event.Name); err != nil && !errors.Is(err, fsnotify.ErrNonExistentWatch) {
+					level.Error(r.logger).Log("msg", "failed to stop watching old config file", "err", err, "path", r.filename)
+					return
+				}
+				// Watch new file (fsnotify follows symlinks)
+				if err := r.watcher.Add(r.filename); err != nil {
+					level.Error(r.logger).Log("msg", "failed to start watching new config file", "err", err, "path", r.filename)
+					return
+				}
+				r.triggerReload <- struct{}{}
+			} else if event.Has(fsnotify.Write) {
 				level.Debug(r.logger).Log("msg", "config file has been modified")
 				r.triggerReload <- struct{}{}
 			}

--- a/pkg/config/reloader_test.go
+++ b/pkg/config/reloader_test.go
@@ -124,3 +124,103 @@ func TestReloadInvalid(t *testing.T) {
 	case <-ctx.Done():
 	}
 }
+
+func TestReloadSymlink(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(time.Millisecond*300))
+	defer cancel()
+	logger := log.NewNopLogger()
+	reg := prometheus.NewRegistry()
+	reloadConfig := make(chan *Config, 1)
+
+	tmpDir := t.TempDir()
+	filenameOld := filepath.Join(tmpDir, "parca_old.yaml")
+	filenameNew := filepath.Join(tmpDir, "parca_new.yaml")
+	symlinkName := filepath.Join(tmpDir, "parca.yaml")
+
+	config := `object_storage:
+  bucket:
+    type: "FILESYSTEM"
+    config:
+      directory: "./tmp"
+
+scrape_configs:
+  - job_name: "default"
+    scrape_interval: "3s"
+    static_configs:
+      - targets: [ '127.0.0.1:7070' ]
+`
+
+	// Create old config file
+	fold, err := os.OpenFile(filenameOld, os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Errorf("failed to open config file: %v", err)
+	}
+	if _, err := fold.WriteString(config); err != nil {
+		t.Errorf("failed to write old config file: %v", err)
+	}
+	fold.Close()
+
+	// Create symlink to old config file
+	if err := os.Symlink(filenameOld, symlinkName); err != nil {
+		t.Errorf("failed to create symlink to old config file: %v", err)
+	}
+
+	config += `    scrape_timeout: "4s"
+`
+
+	// Create new config file
+	fnew, err := os.OpenFile(filenameNew, os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Errorf("failed to open new config file: %v", err)
+	}
+	if _, err := fnew.WriteString(config); err != nil {
+		t.Errorf("failed to write new config file: %v", err)
+	}
+	fnew.Close()
+
+	// Set up reloader
+	reloaders := []ComponentReloader{
+		{
+			Name: "test",
+			Reloader: func(cfg *Config) error {
+				reloadConfig <- cfg
+				return nil
+			},
+		},
+	}
+
+	cfgReloader, err := NewConfigReloader(logger, reg, symlinkName, reloaders)
+	if err != nil {
+		t.Errorf("failed to instantiate config reloader: %v", err)
+	}
+
+	go cfgReloader.Run(ctx)
+
+	time.Sleep(time.Millisecond * 100)
+
+	// Recreate symlink, but pointing to new config file
+	if err := os.Remove(symlinkName); err != nil {
+		t.Errorf("failed to remove symlink to old config file: %v", err)
+	}
+	if err := os.Symlink(filenameNew, symlinkName); err != nil {
+		t.Errorf("failed to create symlink to new config file: %v", err)
+	}
+	// Delete old config file
+	// Actually triggers the reload since the symlink was followed
+	// when the watcher was created
+	// https://github.com/fsnotify/fsnotify/issues/199
+	// https://github.com/fsnotify/fsnotify/issues/394
+	if err := os.Remove(filenameOld); err != nil {
+		t.Errorf("failed to remove old config file: %v", err)
+	}
+
+	// Wait for reload
+	select {
+	case cfg := <-reloadConfig:
+		require.Equal(t, model.Duration(time.Second*4), cfg.ScrapeConfigs[0].ScrapeTimeout)
+	case <-ctx.Done():
+		t.Error("configuration reload timed out")
+	}
+}


### PR DESCRIPTION
This properly handle reloading the configuration from a Kubernetes ConfigMap which uses a symlink, a case I had initially overlooked.

In this case, the reload is triggered by the deletion of the old version of the config, not the symlink deletion/re-creation as fsnotify follows them when creating the watcher.