### PR TITLE
ui: Automatically use system settings for Parca's theme

### DIFF
--- a/ui/packages/app/web/src/components/ui/ThemeToggle.tsx
+++ b/ui/packages/app/web/src/components/ui/ThemeToggle.tsx
@@ -68,6 +68,7 @@ const ThemeToggle = () => {
       label: 'Light',
       icon: 'heroicons:sun-20-solid',
       onSelect: () => updateModesOnly(false),
+      selected: !isSystemSettingsTheme && !isDarkMode,
     },
 
     {
@@ -75,6 +76,7 @@ const ThemeToggle = () => {
       label: 'Dark',
       icon: 'heroicons:moon-20-solid',
       onSelect: () => updateModesOnly(true),
+      selected: !isSystemSettingsTheme && isDarkMode,
     },
 
     {
@@ -82,6 +84,7 @@ const ThemeToggle = () => {
       label: 'System',
       icon: 'heroicons:computer-desktop-solid',
       onSelect: updateWithSystemSettings,
+      selected: isSystemSettingsTheme,
     },
   ];
 
@@ -101,7 +104,7 @@ const ThemeToggle = () => {
         }
       >
         {modes.map(item => (
-          <Dropdown.Item key={item.key} onSelect={item.onSelect}>
+          <Dropdown.Item key={item.key} onSelect={item.onSelect} selected={item.selected}>
             <div className="flex items-center">
               <span className="mr-2">
                 <Icon icon={item.icon} />

--- a/ui/packages/shared/components/src/Dropdown/index.tsx
+++ b/ui/packages/shared/components/src/Dropdown/index.tsx
@@ -83,7 +83,7 @@ const Item = ({
           className={cx(
             active ? 'bg-indigo-500 text-white' : 'text-gray-900 dark:text-white',
             'group mb-px flex w-full items-center rounded-md px-2 py-2 text-sm',
-            selected && 'bg-indigo-500 font-bold !text-white'
+            selected != null && selected ? 'bg-indigo-500 font-bold !text-white' : ''
           )}
           onClick={onSelect}
         >

--- a/ui/packages/shared/components/src/Dropdown/index.tsx
+++ b/ui/packages/shared/components/src/Dropdown/index.tsx
@@ -70,9 +70,11 @@ const Dropdown = ({
 const Item = ({
   children,
   onSelect,
+  selected,
 }: {
   children: React.ReactNode;
   onSelect: () => void;
+  selected?: boolean;
 }): JSX.Element => {
   return (
     <Menu.Item>
@@ -80,7 +82,8 @@ const Item = ({
         <button
           className={cx(
             active ? 'bg-indigo-500 text-white' : 'text-gray-900 dark:text-white',
-            'group flex w-full items-center rounded-md px-2 py-2 text-sm'
+            'group mb-px flex w-full items-center rounded-md px-2 py-2 text-sm',
+            selected && 'bg-indigo-500 font-bold !text-white'
           )}
           onClick={onSelect}
         >

--- a/ui/packages/shared/store/src/slices/uiSlice.ts
+++ b/ui/packages/shared/store/src/slices/uiSlice.ts
@@ -24,7 +24,7 @@ export interface UiState {
 // Define the initial state using that type
 const initialState: UiState = {
   darkMode: false,
-  parcaThemeSystemSettings: false,
+  parcaThemeSystemSettings: true,
 };
 
 export const uiSlice = createSlice({


### PR DESCRIPTION
After demoing this during Parca Office hours, we came to the consensus that the system settings theme mode should be chosen automatically, as opposed to the previous method where the user had to first select system settings.