### PR TITLE
Remove usage of lerna bootstrap

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -59,7 +59,7 @@ jobs:
           node-version-file: .node-version
           cache: yarn
       - name: Install dependencies and build app
-        run: yarn install --frozen-lockfile --prefer-offline && yarn bootstrap && yarn build
+        run: yarn install --frozen-lockfile --prefer-offline && yarn build
         # 👇 Adds Chromatic as a step in the workflow
       - name: Publish to Chromatic
         uses: chromaui/action@47e754905fb417deb8ddffd4db3ecc51eca0d54d # v1

--- a/.github/workflows/ui-publish-components.yml
+++ b/.github/workflows/ui-publish-components.yml
@@ -69,9 +69,9 @@ jobs:
           git config --global user.name "${{ github.actor }}"
           git config --global user.email "${{ github.actor }}@users.noreply.github.com"
 
-      - name: Bootstrap lerna
+      - name: Install packages with yarn
         working-directory: ui
-        run: yarn bootstrap
+        run: yarn install
 
       - name: Build Packages
         working-directory: ui

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ go/test-clean:
 UI_FILES ?= $(shell find ./ui -name "*" -not -path "./ui/lib/node_modules/*" -not -path "./ui/node_modules/*" -not -path "./ui/packages/app/template/node_modules/*" -not -path "./ui/packages/app/web/node_modules/*" -not -path "./ui/packages/app/web/build/*")
 .PHONY: ui/build
 ui/build: $(UI_FILES)
-	cd ui && yarn install --frozen-lockfile --prefer-offline && yarn bootstrap && yarn build
+	cd ui && yarn install --frozen-lockfile --prefer-offline && yarn build
 
 .PHONY: ui/test
 ui/test:

--- a/ui/package.json
+++ b/ui/package.json
@@ -8,7 +8,6 @@
     "fix": "eslint --fix --ext .ts,.tsx,.js packages/*",
     "type-check": "tsc --noEmit",
     "test": "jest --coverage --config jest.config.cjs",
-    "bootstrap": "lerna bootstrap",
     "build": "lerna run build",
     "watch": "lerna run --parallel watch",
     "publish:ci": "lerna publish --yes --no-verify-access",


### PR DESCRIPTION
This PR removes the usage of lerna bootsrap and simply replaces with yarn install as documented [here](https://lerna.js.org/docs/legacy-package-management). 