### PR TITLE
fix(server): handle gRPC-Web requests over HTTP2

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -293,16 +293,11 @@ func grpcHandlerFunc(grpcServer *grpc.Server, otherHandler http.Handler, allowed
 	})
 
 	return corsMiddleware.Handler(h2c.NewHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.ProtoMajor == 2 && strings.Contains(r.Header.Get("Content-Type"), "application/grpc") {
-			grpcServer.ServeHTTP(w, r)
-		} else {
-			if wrappedGrpc.IsGrpcWebRequest(r) {
-				wrappedGrpc.ServeHTTP(w, r)
-				return
-			}
-
-			otherHandler.ServeHTTP(w, r)
+		if strings.HasPrefix(r.Header.Get("Content-Type"), "application/grpc") {
+			wrappedGrpc.ServeHTTP(w, r)
+			return
 		}
+		otherHandler.ServeHTTP(w, r)
 	}), &http2.Server{}))
 }
 


### PR DESCRIPTION
After much testing, I found out the following:

HTTP1.1 works: :heavy_check_mark:

```shell
$ curl --http1.1 127.0.0.1:7070/api/grpc.health.v1.Health/Check \
  -H 'Content-Type: application/grpc-web-text' \
  -H 'Accept: application/grpc-web-text' \
  -d 'AAAAAAA='
AAAAAAIIAQ==gAAAABBncnBjLXN0YXR1czogMA0K
```

H2C (HTTP2 upgraded from HTTP1.1) works: :heavy_check_mark:

```shell
$ curl --http2 127.0.0.1:7070/api/grpc.health.v1.Health/Check \
  -H 'Content-Type: application/grpc-web-text' \
  -H 'Accept: application/grpc-web-text' \
  -d 'AAAAAAA='
AAAAAAIIAQ==gAAAABBncnBjLXN0YXR1czogMA0K
```

HTTP2 (without upgrade from HTTP1.1) does not work: :x:

```shell
$ curl --http2-prior-knowledge 127.0.0.1:7070/api/grpc.health.v1.Health/Check \
  -H 'Content-Type: application/grpc-web-text' \
  -H 'Accept: application/grpc-web-text' \
  -d 'AAAAAAA='
invalid gRPC request content-type "application/grpc-web-text"
```

This patch fixes it: :heavy_check_mark:

```shell
$ curl --http2-prior-knowledge 127.0.0.1:7070/api/grpc.health.v1.Health/Check \
  -H 'Content-Type: application/grpc-web-text' \
  -H 'Accept: application/grpc-web-text' \
  -d 'AAAAAAA='
AAAAAAIIAQ==gAAAABBncnBjLXN0YXR1czogMA0K
```

gRPC-Web requests can use HTTP2, and most modern browsers actually use it if the host supports it.

This latest case happens if the reverse proxy (e.g. Envoy) forwards HTTP2 to HTTP2. Until now, we had been using NGINX in the demo which downgrades the request to HTTP1.1, so the issue had not been surfaced.

This should unblock advanced use cases with mixed client protocols (HTTP1.1/HTTP2/H2C, gRPC/gRPC-Web).