### PR TITLE
ui: Flamegraph crash fix

### DIFF
--- a/ui/packages/shared/utilities/src/bigint.spec.ts
+++ b/ui/packages/shared/utilities/src/bigint.spec.ts
@@ -55,4 +55,12 @@ describe('bigint scaleLinear', () => {
     expect(scale(0n)).toBe(0);
     expect(scale(20n)).toBe(10);
   });
+
+  it('scale works with decimal values to range', () => {
+    const scale = scaleLinear([0n, 100n], [0, 51.5]);
+    expect(scale(50n)).toBe(25.5);
+    expect(scale(100n)).toBe(51);
+    expect(scale(0n)).toBe(0);
+    expect(scale(20n)).toBe(10.2);
+  });
 });

--- a/ui/packages/shared/utilities/src/bigint.ts
+++ b/ui/packages/shared/utilities/src/bigint.ts
@@ -32,7 +32,7 @@ export const scaleLinear = (
   const [domainMin, domainMax] = domain;
   const [rangeMin, rangeMax] = range;
   const domainRange = domainMax - domainMin;
-  const rangeRange = BigInt(Math.round(rangeMax - rangeMin));
+  const rangeRange = BigInt(Math.floor(rangeMax - rangeMin));
 
   // rate * 100000 to retain the decimal places in BigInt format, then divide by 100000 to get the final result
   const multiple = 100000;

--- a/ui/packages/shared/utilities/src/bigint.ts
+++ b/ui/packages/shared/utilities/src/bigint.ts
@@ -32,7 +32,7 @@ export const scaleLinear = (
   const [domainMin, domainMax] = domain;
   const [rangeMin, rangeMax] = range;
   const domainRange = domainMax - domainMin;
-  const rangeRange = BigInt(rangeMax - rangeMin);
+  const rangeRange = BigInt(Math.round(rangeMax - rangeMin));
 
   // rate * 100000 to retain the decimal places in BigInt format, then divide by 100000 to get the final result
   const multiple = 100000;


### PR DESCRIPTION
Fix for `RangeError: The number 1562.0240478515625 cannot be converted to a BigInt because it is not an integer` error that happens when the font size of the page is increased/decreased in the browser when the flame graph is already loaded. 