### PR TITLE
ui: Fixes the bug where flamegraph goes blank for some instrumented profiles 

### DIFF
--- a/ui/packages/shared/utilities/src/bigint.spec.ts
+++ b/ui/packages/shared/utilities/src/bigint.spec.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {abs, divide, scaleLinear} from './bigint';
+import {abs, divide, lowestNumberWithSameNumberOfDigits, scaleLinear} from './bigint';
 
 describe('bigint divide', () => {
   it('divides two bigints and returns a number', () => {
@@ -62,5 +62,22 @@ describe('bigint scaleLinear', () => {
     expect(scale(100n)).toBe(51);
     expect(scale(0n)).toBe(0);
     expect(scale(20n)).toBe(10.2);
+  });
+});
+
+describe('lowestNumberWithSameNumberOfDigits', () => {
+  it('returns the lowest number with the same number of digits', () => {
+    expect(lowestNumberWithSameNumberOfDigits(1)).toBe(1);
+    expect(lowestNumberWithSameNumberOfDigits(8)).toBe(1);
+    expect(lowestNumberWithSameNumberOfDigits(10)).toBe(10);
+    expect(lowestNumberWithSameNumberOfDigits(99)).toBe(10);
+    expect(lowestNumberWithSameNumberOfDigits(100)).toBe(100);
+    expect(lowestNumberWithSameNumberOfDigits(600)).toBe(100);
+    expect(lowestNumberWithSameNumberOfDigits(999)).toBe(100);
+    expect(lowestNumberWithSameNumberOfDigits(1000)).toBe(1000);
+    expect(lowestNumberWithSameNumberOfDigits(6000)).toBe(1000);
+    expect(lowestNumberWithSameNumberOfDigits(9999)).toBe(1000);
+    expect(lowestNumberWithSameNumberOfDigits(10000)).toBe(10000);
+    expect(lowestNumberWithSameNumberOfDigits(9007199254740991)).toBe(1000000000000000);
   });
 });

--- a/ui/packages/shared/utilities/src/bigint.ts
+++ b/ui/packages/shared/utilities/src/bigint.ts
@@ -14,8 +14,17 @@
 /**
  * Divides two bigints and returns a number with two decimal places
  */
+
+export const lowestNumberWithSameNumberOfDigits = (a: number): number => {
+  const digits = Math.floor(Math.log10(a)) + 1;
+  return 10 ** (digits - 1);
+};
+
+const MULTIPLE = lowestNumberWithSameNumberOfDigits(Number.MAX_SAFE_INTEGER);
+const MULTIPLE_BIGINT = BigInt(MULTIPLE);
+
 export const divide = (a: bigint, b: bigint): number => {
-  return Number((a * 1000000n) / b) / 1000000;
+  return Number((a * MULTIPLE_BIGINT) / b) / MULTIPLE;
 };
 
 /**
@@ -25,20 +34,18 @@ export const abs = (a: bigint): bigint => {
   return a < 0n ? -a : a;
 };
 
-export const scaleLinear = (
-  domain: [bigint, bigint],
-  range: [number, number]
-): ((x: bigint) => number) => {
+export type ScaleFunction = (x: bigint) => number;
+
+export const scaleLinear = (domain: [bigint, bigint], range: [number, number]): ScaleFunction => {
   const [domainMin, domainMax] = domain;
   const [rangeMin, rangeMax] = range;
   const domainRange = domainMax - domainMin;
   const rangeRange = BigInt(Math.floor(rangeMax - rangeMin));
 
-  // rate * 100000 to retain the decimal places in BigInt format, then divide by 100000 to get the final result
-  const multiple = 100000;
-  const rate = BigInt(Math.round(divide(rangeRange, domainRange) * multiple));
+  // rate * MULTIPLE to retain the decimal places in BigInt format, then divide by MULTIPLE to get the final result
+  const rate = BigInt(Math.round(divide(rangeRange, domainRange) * MULTIPLE));
 
   return x => {
-    return Number(BigInt(rangeMin) + (x - domainMin) * rate) / multiple;
+    return Number(BigInt(rangeMin) + (x - domainMin) * rate) / MULTIPLE;
   };
 };


### PR DESCRIPTION
Root cause: This happens when the `linearScales`'s domain range is so high compared to the device width range, making the `rate` a `0`, so no nodes in the flame graph are rendered. 

Fixed it by increasing the multiple to the same number of digits as `Number.MAX_SAFE_INTEGER`, so that the `rate` is not rounded off to `0`. 