### PR TITLE
pkg/query: TestGenerateFlamegraphArrowWithInlined

### DIFF
--- a/pkg/query/flamegraph_arrow.go
+++ b/pkg/query/flamegraph_arrow.go
@@ -213,6 +213,7 @@ func generateFlamegraphArrowRecord(ctx context.Context, mem memory.Allocator, tr
 	// these change with every iteration below
 	row := builderCumulative.Len()
 	parent := parent(-1)
+	// compareRows are the rows that we compare to the current location against and potentially merge.
 	compareRows := []int{}
 
 	for _, s := range p.Samples {
@@ -221,10 +222,13 @@ func generateFlamegraphArrowRecord(ctx context.Context, mem memory.Allocator, tr
 		}
 
 		// every new sample resets the childRow to -1 indicating that we start with a leaf again.
+		// pprof stores locations in reverse order, thus we loop over locations in reverse order.
 		for i := len(s.Locations) - 1; i >= 0; i-- {
 			location := s.Locations[i]
 		stacktraces:
-			for _, line := range location.Lines {
+			// just like locations, pprof stores lines in reverse order.
+			for k := len(location.Lines) - 1; k >= 0; k-- {
+				line := location.Lines[k]
 				if isRoot(s.Locations, i) {
 					compareRows = compareRows[:0] //  reset the compare rows
 					compareRows = append(compareRows, rootsRow...)

--- a/pkg/query/flamegraph_arrow_test.go
+++ b/pkg/query/flamegraph_arrow_test.go
@@ -14,23 +14,129 @@
 package query
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"testing"
 
+	"github.com/apache/arrow/go/v13/arrow"
 	"github.com/apache/arrow/go/v13/arrow/array"
 	"github.com/apache/arrow/go/v13/arrow/memory"
 	"github.com/go-kit/log"
+	pprofprofile "github.com/google/pprof/profile"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/trace"
 
+	pprofpb "github.com/parca-dev/parca/gen/proto/go/google/pprof"
 	metastorepb "github.com/parca-dev/parca/gen/proto/go/parca/metastore/v1alpha1"
 	"github.com/parca-dev/parca/pkg/metastore"
 	"github.com/parca-dev/parca/pkg/metastoretest"
 	"github.com/parca-dev/parca/pkg/parcacol"
 	parcaprofile "github.com/parca-dev/parca/pkg/profile"
 )
+
+type flamegraphRow struct {
+	MappingStart       uint64
+	MappingLimit       uint64
+	MappingOffset      uint64
+	MappingFile        string
+	MappingBuildID     string
+	LocationAddress    uint64
+	LocationFolded     bool
+	LocationLine       int64
+	FunctionStartLine  int64
+	FunctionName       string
+	FunctionSystemName string
+	FunctionFilename   string
+	Labels             map[string]string
+	Children           []uint32
+	Cumulative         int64
+}
+
+type flamegraphColumns struct {
+	mappingStart        []uint64
+	mappingLimit        []uint64
+	mappingOffset       []uint64
+	mappingFiles        []string
+	mappingBuildIDs     []string
+	locationAddresses   []uint64
+	locationFolded      []bool
+	locationLines       []int64
+	functionStartLines  []int64
+	functionNames       []string
+	functionSystemNames []string
+	functionFileNames   []string
+	labels              []map[string]string
+	children            [][]uint32
+	cumulative          []int64
+}
+
+func rowsToColumn(rows []flamegraphRow) flamegraphColumns {
+	columns := flamegraphColumns{}
+	for _, row := range rows {
+		columns.mappingStart = append(columns.mappingStart, row.MappingStart)
+		columns.mappingLimit = append(columns.mappingLimit, row.MappingLimit)
+		columns.mappingOffset = append(columns.mappingOffset, row.MappingOffset)
+		columns.mappingFiles = append(columns.mappingFiles, row.MappingFile)
+		columns.mappingBuildIDs = append(columns.mappingBuildIDs, row.MappingBuildID)
+		columns.locationAddresses = append(columns.locationAddresses, row.LocationAddress)
+		columns.locationFolded = append(columns.locationFolded, row.LocationFolded)
+		columns.locationLines = append(columns.locationLines, row.LocationLine)
+		columns.functionStartLines = append(columns.functionStartLines, row.FunctionStartLine)
+		columns.functionNames = append(columns.functionNames, row.FunctionName)
+		columns.functionSystemNames = append(columns.functionSystemNames, row.FunctionSystemName)
+		columns.functionFileNames = append(columns.functionFileNames, row.FunctionFilename)
+		columns.labels = append(columns.labels, row.Labels)
+		columns.children = append(columns.children, row.Children)
+		columns.cumulative = append(columns.cumulative, row.Cumulative)
+	}
+	return columns
+}
+
+func requireColumn(t *testing.T, r arrow.Record, field string, expected any) {
+	switch expected.(type) {
+	case []int64:
+		require.Equal(t,
+			expected,
+			r.Column(r.Schema().FieldIndices(field)[0]).(*array.Int64).Int64Values(),
+		)
+	case []uint64:
+		require.Equal(t,
+			expected,
+			r.Column(r.Schema().FieldIndices(field)[0]).(*array.Uint64).Uint64Values(),
+		)
+	}
+}
+
+func requireColumnDict(t *testing.T, r arrow.Record, field string, expected any) {
+	dict := r.Column(r.Schema().FieldIndices(field)[0]).(*array.Dictionary)
+
+	switch expected.(type) {
+	case []string:
+		mappingFilesString := dict.Dictionary().(*array.String)
+		mappingFiles := make([]string, r.NumRows())
+		for i := 0; i < int(r.NumRows()); i++ {
+			mappingFiles[i] = mappingFilesString.Value(dict.GetValueIndex(i))
+		}
+		require.Equal(t, expected, mappingFiles)
+	}
+}
+
+func requireColumnChildren(t *testing.T, record arrow.Record, expected [][]uint32) {
+	children := make([][]uint32, record.NumRows())
+	list := record.Column(record.Schema().FieldIndices(FlamegraphFieldChildren)[0]).(*array.List)
+	listValues := list.ListValues().(*array.Uint32).Uint32Values()
+	for i := 0; i < int(record.NumRows()); i++ {
+		if !list.IsValid(i) {
+			children[i] = nil
+		} else {
+			start, end := list.ValueOffsets(i)
+			children[i] = listValues[start:end]
+		}
+	}
+	require.Equal(t, expected, children)
+}
 
 func TestGenerateFlamegraphArrow(t *testing.T) {
 	ctx := context.Background()
@@ -146,29 +252,11 @@ func TestGenerateFlamegraphArrow(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	type row struct {
-		MappingStart       uint64
-		MappingLimit       uint64
-		MappingOffset      uint64
-		MappingFile        string
-		MappingBuildID     string
-		LocationAddress    uint64
-		LocationFolded     bool
-		LocationLine       int64
-		FunctionStartLine  int64
-		FunctionName       string
-		FunctionSystemName string
-		FunctionFilename   string
-		Labels             map[string]string
-		Children           []uint32
-		Cumulative         int64
-	}
-
 	for _, tc := range []struct {
 		name      string
 		aggregate []string
 		// expectations
-		rows       []row
+		rows       []flamegraphRow
 		cumulative int64
 		height     int32
 		trimmed    int64
@@ -179,7 +267,7 @@ func TestGenerateFlamegraphArrow(t *testing.T) {
 		cumulative: 6,
 		height:     5,
 		trimmed:    0, // TODO
-		rows: []row{
+		rows: []flamegraphRow{
 			{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0, LocationFolded: false, LocationLine: 0, FunctionStartLine: 0, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 6, Labels: nil, Children: []uint32{1, 3, 7}},                                   // 0
 			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationFolded: false, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 2, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{2}}, // 1
 			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationFolded: false, LocationLine: 2, FunctionStartLine: 2, FunctionName: "2", FunctionSystemName: "2", FunctionFilename: "2", Cumulative: 2, Labels: nil, Children: nil},                                         // 2
@@ -199,7 +287,7 @@ func TestGenerateFlamegraphArrow(t *testing.T) {
 		cumulative: 6,
 		height:     5,
 		trimmed:    0, // TODO
-		rows: []row{
+		rows: []flamegraphRow{
 			{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0, LocationFolded: false, LocationLine: 0, FunctionStartLine: 0, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 6, Labels: nil, Children: []uint32{1}},                                         // 0
 			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationFolded: false, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 6, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{2}}, // 1
 			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationFolded: false, LocationLine: 2, FunctionStartLine: 2, FunctionName: "2", FunctionSystemName: "2", FunctionFilename: "2", Cumulative: 6, Labels: nil, Children: []uint32{3}},                                 // 2
@@ -214,7 +302,7 @@ func TestGenerateFlamegraphArrow(t *testing.T) {
 		cumulative: 6,
 		height:     5,
 		trimmed:    0, // TODO
-		rows: []row{
+		rows: []flamegraphRow{
 			{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0, LocationFolded: false, LocationLine: 0, FunctionStartLine: 0, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 6, Labels: nil, Children: []uint32{1, 5}}, // 0
 			// all of these have the same labels, so they are aggregated
 			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationFolded: false, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 3, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{2}}, // 1
@@ -234,8 +322,8 @@ func TestGenerateFlamegraphArrow(t *testing.T) {
 		cumulative: 6,
 		height:     5,
 		trimmed:    0, // TODO
-		rows: []row{
-			// This aggregates all the rows with the same mapping file, meaning that we only keep one row per stack depth in this example.
+		rows: []flamegraphRow{
+			// This aggregates all the rows with the same mapping file, meaning that we only keep one flamegraphRow per stack depth in this example.
 			{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0, LocationFolded: false, LocationLine: 0, FunctionStartLine: 0, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 6, Labels: nil, Children: []uint32{1}},                                         // 0
 			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationFolded: false, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 6, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{2}}, // 1
 			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationFolded: false, LocationLine: 2, FunctionStartLine: 2, FunctionName: "2", FunctionSystemName: "2", FunctionFilename: "2", Cumulative: 6, Labels: nil, Children: []uint32{3}},                                 // 2
@@ -254,113 +342,25 @@ func TestGenerateFlamegraphArrow(t *testing.T) {
 			require.Equal(t, int64(16), fa.NumCols())
 
 			// Convert the numRows to columns for easier access when testing below.
-			columns := struct {
-				mappingStart        []uint64
-				mappingLimit        []uint64
-				mappingOffset       []uint64
-				mappingFiles        []string
-				mappingBuildIDs     []string
-				locationAddresses   []uint64
-				locationFolded      []bool
-				locationLines       []int64
-				functionStartLines  []int64
-				functionNames       []string
-				functionSystemNames []string
-				functionFileNames   []string
-				labels              []map[string]string
-				children            [][]uint32
-				cumulative          []int64
-			}{}
-			for _, row := range tc.rows {
-				columns.mappingStart = append(columns.mappingStart, row.MappingStart)
-				columns.mappingLimit = append(columns.mappingLimit, row.MappingLimit)
-				columns.mappingOffset = append(columns.mappingOffset, row.MappingOffset)
-				columns.mappingFiles = append(columns.mappingFiles, row.MappingFile)
-				columns.mappingBuildIDs = append(columns.mappingBuildIDs, row.MappingBuildID)
-				columns.locationAddresses = append(columns.locationAddresses, row.LocationAddress)
-				columns.locationFolded = append(columns.locationFolded, row.LocationFolded)
-				columns.locationLines = append(columns.locationLines, row.LocationLine)
-				columns.functionStartLines = append(columns.functionStartLines, row.FunctionStartLine)
-				columns.functionNames = append(columns.functionNames, row.FunctionName)
-				columns.functionSystemNames = append(columns.functionSystemNames, row.FunctionSystemName)
-				columns.functionFileNames = append(columns.functionFileNames, row.FunctionFilename)
-				columns.labels = append(columns.labels, row.Labels)
-				columns.children = append(columns.children, row.Children)
-				columns.cumulative = append(columns.cumulative, row.Cumulative)
-			}
+			columns := rowsToColumn(tc.rows)
 
-			require.Equal(t,
-				columns.mappingStart,
-				fa.Column(fa.Schema().FieldIndices(FlamegraphFieldMappingStart)[0]).(*array.Uint64).Uint64Values(),
-			)
-			require.Equal(t,
-				columns.mappingLimit,
-				fa.Column(fa.Schema().FieldIndices(FlamegraphFieldMappingLimit)[0]).(*array.Uint64).Uint64Values(),
-			)
-			require.Equal(t,
-				columns.mappingOffset,
-				fa.Column(fa.Schema().FieldIndices(FlamegraphFieldMappingOffset)[0]).(*array.Uint64).Uint64Values(),
-			)
-
-			mappingFilesDict := fa.Column(fa.Schema().FieldIndices(FlamegraphFieldMappingFile)[0]).(*array.Dictionary)
-			mappingFilesString := mappingFilesDict.Dictionary().(*array.String)
-			mappingFiles := make([]string, fa.NumRows())
-			for i := 0; i < int(fa.NumRows()); i++ {
-				mappingFiles[i] = mappingFilesString.Value(mappingFilesDict.GetValueIndex(i))
-			}
-			require.Equal(t, columns.mappingFiles, mappingFiles)
-
-			mappingBuildIDDict := fa.Column(fa.Schema().FieldIndices(FlamegraphFieldMappingBuildID)[0]).(*array.Dictionary)
-			mappingBuildIDString := mappingBuildIDDict.Dictionary().(*array.String)
-			mappingBuildID := make([]string, fa.NumRows())
-			for i := 0; i < int(fa.NumRows()); i++ {
-				mappingBuildID[i] = mappingBuildIDString.Value(mappingBuildIDDict.GetValueIndex(i))
-			}
-			require.Equal(t, columns.mappingBuildIDs, mappingBuildID)
-
-			require.Equal(t,
-				columns.locationAddresses,
-				fa.Column(fa.Schema().FieldIndices(FlamegraphFieldLocationAddress)[0]).(*array.Uint64).Uint64Values(),
-			)
-
-			locationFolded := make([]bool, fa.NumRows())
-			for i := 0; i < int(fa.NumRows()); i++ {
-				locationFolded[i] = fa.Column(fa.Schema().FieldIndices(FlamegraphFieldLocationFolded)[0]).(*array.Boolean).Value(i)
-			}
-			require.Equal(t, columns.locationFolded, locationFolded)
-
-			require.Equal(t,
-				columns.locationLines,
-				fa.Column(fa.Schema().FieldIndices(FlamegraphFieldLocationLine)[0]).(*array.Int64).Int64Values(),
-			)
-
-			require.Equal(t,
-				columns.functionStartLines,
-				fa.Column(fa.Schema().FieldIndices(FlamegraphFieldFunctionStartLine)[0]).(*array.Int64).Int64Values(),
-			)
-
-			functionNameDict := fa.Column(fa.Schema().FieldIndices(FlamegraphFieldFunctionName)[0]).(*array.Dictionary)
-			functionNameString := functionNameDict.Dictionary().(*array.String)
-			functionSystemNameDict := fa.Column(fa.Schema().FieldIndices(FlamegraphFieldFunctionSystemName)[0]).(*array.Dictionary)
-			functionSystemNameString := functionSystemNameDict.Dictionary().(*array.String)
-			functionFileNameDict := fa.Column(fa.Schema().FieldIndices(FlamegraphFieldFunctionFileName)[0]).(*array.Dictionary)
-			functionFileNameString := functionFileNameDict.Dictionary().(*array.String)
-
-			functionNames := make([]string, fa.NumRows())
-			functionSystemNames := make([]string, fa.NumRows())
-			functionFileNames := make([]string, fa.NumRows())
-			for i := 0; i < int(fa.NumRows()); i++ {
-				functionNames[i] = functionNameString.Value(functionNameDict.GetValueIndex(i))
-				functionSystemNames[i] = functionSystemNameString.Value(functionSystemNameDict.GetValueIndex(i))
-				functionFileNames[i] = functionFileNameString.Value(functionFileNameDict.GetValueIndex(i))
-			}
-			require.Equal(t, columns.functionNames, functionNames)
-			require.Equal(t, columns.functionSystemNames, functionSystemNames)
-			require.Equal(t, columns.functionFileNames, functionFileNames)
+			requireColumn(t, fa, FlamegraphFieldMappingStart, columns.mappingStart)
+			requireColumn(t, fa, FlamegraphFieldMappingLimit, columns.mappingLimit)
+			requireColumn(t, fa, FlamegraphFieldMappingOffset, columns.mappingOffset)
+			requireColumnDict(t, fa, FlamegraphFieldMappingFile, columns.mappingFiles)
+			requireColumnDict(t, fa, FlamegraphFieldMappingBuildID, columns.mappingBuildIDs)
+			requireColumn(t, fa, FlamegraphFieldLocationAddress, columns.locationAddresses)
+			requireColumn(t, fa, FlamegraphFieldLocationFolded, columns.locationFolded)
+			requireColumn(t, fa, FlamegraphFieldLocationLine, columns.locationLines)
+			requireColumn(t, fa, FlamegraphFieldFunctionStartLine, columns.functionStartLines)
+			requireColumnDict(t, fa, FlamegraphFieldFunctionName, columns.functionNames)
+			requireColumnDict(t, fa, FlamegraphFieldFunctionSystemName, columns.functionSystemNames)
+			requireColumnDict(t, fa, FlamegraphFieldFunctionFileName, columns.functionFileNames)
+			requireColumn(t, fa, FlamegraphFieldCumulative, columns.cumulative)
+			requireColumnChildren(t, fa, columns.children)
 
 			labelsDict := fa.Column(fa.Schema().FieldIndices(FlamegraphFieldLabels)[0]).(*array.Dictionary)
 			labelsString := labelsDict.Dictionary().(*array.String)
-
 			pprofLabels := make([]map[string]string, fa.NumRows())
 			for i := 0; i < int(fa.NumRows()); i++ {
 				if labelsDict.IsNull(i) {
@@ -373,27 +373,112 @@ func TestGenerateFlamegraphArrow(t *testing.T) {
 			}
 			require.Equal(t, columns.labels, pprofLabels)
 
-			children := make([][]uint32, fa.NumRows())
-			list := fa.Column(fa.Schema().FieldIndices(FlamegraphFieldChildren)[0]).(*array.List)
-			listValues := list.ListValues().(*array.Uint32).Uint32Values()
-			for i := 0; i < int(fa.NumRows()); i++ {
-				if !list.IsValid(i) {
-					children[i] = nil
-				} else {
-					start, end := list.ValueOffsets(i)
-					children[i] = listValues[start:end]
-				}
-			}
-			require.Equal(t, columns.children, children)
-
-			require.Equal(t,
-				columns.cumulative,
-				fa.Column(fa.Schema().FieldIndices(FlamegraphFieldCumulative)[0]).(*array.Int64).Int64Values(),
-			)
 			require.Equal(t,
 				len(tc.rows),
 				fa.Column(fa.Schema().FieldIndices(FlamegraphFieldDiff)[0]).(*array.Int64).NullN(),
 			)
 		})
 	}
+}
+
+func TestGenerateFlamegraphArrowWithInlined(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	mem := memory.NewGoAllocator()
+	logger := log.NewNopLogger()
+	reg := prometheus.NewRegistry()
+	tracer := trace.NewNoopTracerProvider().Tracer("")
+
+	store := metastoretest.NewTestMetastore(t, logger, reg, tracer)
+
+	functions := []*pprofprofile.Function{
+		{ID: 1, Name: "net.(*netFD).accept", SystemName: "net.(*netFD).accept", Filename: "net/fd_unix.go"},
+		{ID: 2, Name: "internal/poll.(*FD).Accept", SystemName: "internal/poll.(*FD).Accept", Filename: "internal/poll/fd_unix.go"},
+		{ID: 3, Name: "internal/poll.(*pollDesc).waitRead", SystemName: "internal/poll.(*pollDesc).waitRead", Filename: "internal/poll/fd_poll_runtime.go"},
+		{ID: 4, Name: "internal/poll.(*pollDesc).wait", SystemName: "internal/poll.(*pollDesc).wait", Filename: "internal/poll/fd_poll_runtime.go"},
+	}
+	locations := []*pprofprofile.Location{
+		{ID: 1, Address: 0xa1, Line: []pprofprofile.Line{{Line: 173, Function: functions[0]}}},
+		{ID: 2, Address: 0xa2, Line: []pprofprofile.Line{
+			{Line: 89, Function: functions[1]},
+			{Line: 402, Function: functions[2]},
+		}},
+		{ID: 3, Address: 0xa3, Line: []pprofprofile.Line{{Line: 84, Function: functions[3]}}},
+	}
+	samples := []*pprofprofile.Sample{
+		{
+			Location: []*pprofprofile.Location{locations[2], locations[1], locations[0]},
+			Value:    []int64{1},
+		},
+	}
+	b := bytes.NewBuffer(nil)
+	err := (&pprofprofile.Profile{
+		SampleType: []*pprofprofile.ValueType{{Type: "alloc_space", Unit: "bytes"}},
+		PeriodType: &pprofprofile.ValueType{Type: "space", Unit: "bytes"},
+		Sample:     samples,
+		Location:   locations,
+		Function:   functions,
+	}).Write(b)
+	require.NoError(t, err)
+
+	p := &pprofpb.Profile{}
+	err = p.UnmarshalVT(MustDecompressGzip(t, b.Bytes()))
+	require.NoError(t, err)
+
+	metastore := metastore.NewInProcessClient(store)
+	normalizer := parcacol.NewNormalizer(metastore, true)
+	profiles, err := normalizer.NormalizePprof(ctx, "memory", map[string]string{}, p, false)
+	require.NoError(t, err)
+
+	symbolizedProfile, err := parcacol.NewArrowToProfileConverter(tracer, metastore).SymbolizeNormalizedProfile(ctx, profiles[0])
+	require.NoError(t, err)
+
+	record, total, height, trimmed, err := generateFlamegraphArrowRecord(ctx, mem, tracer, symbolizedProfile, []string{FlamegraphFieldFunctionName}, 0)
+	require.NoError(t, err)
+
+	require.Equal(t, int64(1), total)
+	require.Equal(t, int32(4), height)
+	require.Equal(t, int64(0), trimmed)
+
+	require.Equal(t, int64(16), record.NumCols())
+	require.Equal(t, int64(5), record.NumRows())
+
+	rows := []flamegraphRow{
+		{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0, LocationFolded: false, LocationLine: 0, FunctionStartLine: 0, FunctionName: "net.(*netFD).accept", FunctionSystemName: "net.(*netFD).accept", FunctionFilename: "net/fd_unix.go", Cumulative: 1, Labels: nil, Children: []uint32{1}},                                                           // 0
+		{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationFolded: false, LocationLine: 173, FunctionStartLine: 0, FunctionName: "net.(*netFD).accept", FunctionSystemName: "net.(*netFD).accept", FunctionFilename: "net/fd_unix.go", Cumulative: 1, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{2}},                 // 1
+		{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationFolded: false, LocationLine: 402, FunctionStartLine: 0, FunctionName: "internal/poll.(*pollDesc).waitRead", FunctionSystemName: "internal/poll.(*pollDesc).waitRead", FunctionFilename: "internal/poll/fd_poll_runtime.go", Cumulative: 1, Labels: nil, Children: []uint32{3}}, // 2
+		{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationFolded: false, LocationLine: 89, FunctionStartLine: 0, FunctionName: "internal/poll.(*FD).Accept", FunctionSystemName: "internal/poll.(*FD).Accept", FunctionFilename: "internal/poll/fd_unix.go", Cumulative: 1, Labels: nil, Children: []uint32{4}},                          // 3
+		{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationFolded: false, LocationLine: 84, FunctionStartLine: 0, FunctionName: "internal/poll.(*pollDesc).wait", FunctionSystemName: "internal/poll.(*pollDesc).wait", FunctionFilename: "internal/poll/fd_poll_runtime.go", Cumulative: 1, Labels: nil, Children: nil},                  // 4
+	}
+	columns := rowsToColumn(rows)
+
+	// mapping fields are all null here
+	requireColumn(t, record, FlamegraphFieldLocationAddress, columns.locationAddresses)
+	requireColumn(t, record, FlamegraphFieldLocationFolded, columns.locationFolded)
+	requireColumn(t, record, FlamegraphFieldLocationLine, columns.locationLines)
+	requireColumn(t, record, FlamegraphFieldFunctionStartLine, columns.functionStartLines)
+	requireColumnDict(t, record, FlamegraphFieldFunctionName, columns.functionNames)
+	requireColumnDict(t, record, FlamegraphFieldFunctionSystemName, columns.functionSystemNames)
+	requireColumnDict(t, record, FlamegraphFieldFunctionFileName, columns.functionFileNames)
+	requireColumn(t, record, FlamegraphFieldCumulative, columns.cumulative)
+	requireColumnChildren(t, record, columns.children)
+}
+
+func TestParents(t *testing.T) {
+	p := parent(-1)
+	require.Equal(t, -1, p.Get())
+	require.False(t, p.Has())
+	p.Reset()
+	require.Equal(t, -1, p.Get())
+	require.False(t, p.Has())
+	p.Set(1)
+	require.Equal(t, 1, p.Get())
+	require.True(t, p.Has())
+	p.Set(2)
+	require.Equal(t, 2, p.Get())
+	require.True(t, p.Has())
+	p.Reset()
+	require.Equal(t, -1, p.Get())
+	require.False(t, p.Has())
 }


### PR DESCRIPTION
Turns out we already inlined almost correctly. pprof just stores the lines in reverse order, just like the locations too. Flipping these around did the trick.

Comparing the arrow and table flame graphs the inlining seems fine now.
