### PR TITLE
parca: add --storage-snapshot-trigger-size

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ Flags:
                                 Defaults to 512MB.
       --storage-path="data"     Path to storage directory.
       --storage-enable-wal      Enables write ahead log for profile storage.
+      --storage-snapshot-trigger-size=134217728
+                                Number of bytes to trigger a snapshot. Defaults
+                                to 1/4 of active memory. This is only used if
+                                enable-wal is set.
       --storage-row-group-size=8192
                                 Number of rows in each row group during
                                 compaction and persistence. Setting to <= 0


### PR DESCRIPTION
Parca would previously not snapshot frostdb data. This commit enables snapshotting by default each 1/4 of maximum active memroy and exposes a flag to tune this snapshot trigger size further. This allows recovery to be much faster than replaying all writes from the WAL.

Users that would previously see the parca server take a long time to start or have the impression that the server was hung indefinitely during startup will benefit from this commit.

Fixes #3430 