### PR TITLE
pkg/query/flamegraph_arrow: Cast strings to bytes

### DIFF
--- a/pkg/query/flamegraph_arrow.go
+++ b/pkg/query/flamegraph_arrow.go
@@ -417,13 +417,13 @@ func (fb *flamegraphBuilder) appendRow(
 			}
 		case FlamegraphFieldMappingFile:
 			if location.Mapping != nil && location.Mapping.File != "" {
-				_ = fb.builderMappingFile.AppendString(location.Mapping.File)
+				_ = fb.builderMappingFile.Append(stringToBytes(location.Mapping.File))
 			} else {
 				fb.builderMappingFile.AppendNull()
 			}
 		case FlamegraphFieldMappingBuildID:
 			if location.Mapping != nil && location.Mapping.BuildId != "" {
-				_ = fb.builderMappingBuildID.AppendString(location.Mapping.BuildId)
+				_ = fb.builderMappingBuildID.Append(stringToBytes(location.Mapping.BuildId))
 			} else {
 				fb.builderMappingBuildID.AppendNull()
 			}
@@ -443,19 +443,19 @@ func (fb *flamegraphBuilder) appendRow(
 			}
 		case FlamegraphFieldFunctionName:
 			if line.Function != nil {
-				_ = fb.builderFunctionName.AppendString(line.Function.Name)
+				_ = fb.builderFunctionName.Append(stringToBytes(line.Function.Name))
 			} else {
 				fb.builderFunctionName.AppendNull()
 			}
 		case FlamegraphFieldFunctionSystemName:
 			if line.Function != nil {
-				_ = fb.builderFunctionSystemName.AppendString(line.Function.SystemName)
+				_ = fb.builderFunctionSystemName.Append(stringToBytes(line.Function.SystemName))
 			} else {
 				fb.builderFunctionSystemName.AppendNull()
 			}
 		case FlamegraphFieldFunctionFileName:
 			if line.Function != nil {
-				_ = fb.builderFunctionFileName.AppendString(line.Function.Filename)
+				_ = fb.builderFunctionFileName.Append(stringToBytes(line.Function.Filename))
 			} else {
 				fb.builderFunctionFileName.AppendNull()
 			}


### PR DESCRIPTION
Arrow casts this internal but apparently copies the string to bytes. This codes uses the stringToBytes helper which does not copy using the `unsafe.StringData` API.

```
name      old time/op    new time/op    delta
Query-24     440µs ± 6%     398µs ± 8%  -9.59%  (p=0.032 n=5+5)

name      old alloc/op   new alloc/op   delta
Query-24     470kB ± 0%     460kB ± 0%  -2.12%  (p=0.008 n=5+5)

name      old allocs/op  new allocs/op  delta
Query-24     2.79k ± 0%     2.53k ± 0%  -9.25%  (p=0.008 n=5+5)
```
