### PR TITLE
pkg/query/flamegraph_arrow: Trim children if below trim threshold

### DIFF
--- a/ui/packages/shared/profile/src/ProfileView/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileView/index.tsx
@@ -25,7 +25,13 @@ import {
   type DropResult,
 } from 'react-beautiful-dnd';
 
-import {Callgraph as CallgraphType, Flamegraph, QueryServiceClient, Top} from '@parca/client';
+import {
+  Callgraph as CallgraphType,
+  Flamegraph,
+  FlamegraphArrow,
+  QueryServiceClient,
+  Top,
+} from '@parca/client';
 import {
   Button,
   Card,
@@ -54,7 +60,7 @@ type NavigateFunction = (path: string, queryParams: any, options?: {replace?: bo
 export interface FlamegraphData {
   loading: boolean;
   data?: Flamegraph;
-  table?: Table<any>;
+  arrow?: FlamegraphArrow;
   total?: bigint;
   filtered?: bigint;
   error?: any;
@@ -232,7 +238,7 @@ export const ProfileView = ({
   }): JSX.Element => {
     switch (type) {
       case 'icicle': {
-        return flamegraphData?.table !== undefined || flamegraphData.data !== undefined ? (
+        return flamegraphData?.arrow !== undefined || flamegraphData.data !== undefined ? (
           <ConditionalWrapper<ProfilerProps>
             condition={perf?.onRender != null}
             WrapperComponent={Profiler}
@@ -244,7 +250,7 @@ export const ProfileView = ({
             <ProfileIcicleGraph
               curPath={curPath}
               setNewCurPath={setNewCurPath}
-              table={flamegraphData.table}
+              arrow={flamegraphData.arrow}
               graph={flamegraphData.data}
               total={total}
               filtered={filtered}

--- a/ui/packages/shared/profile/src/ProfileViewWithData.tsx
+++ b/ui/packages/shared/profile/src/ProfileViewWithData.tsx
@@ -155,9 +155,9 @@ export const ProfileViewWithData = ({
           flamegraphResponse?.report.oneofKind === 'flamegraph'
             ? flamegraphResponse?.report?.flamegraph
             : undefined,
-        table:
+        arrow:
           flamegraphResponse?.report.oneofKind === 'flamegraphArrow'
-            ? tableFromIPC(flamegraphResponse?.report?.flamegraphArrow.record)
+            ? flamegraphResponse?.report?.flamegraphArrow
             : undefined,
         total: BigInt(flamegraphResponse?.total ?? '0'),
         filtered: BigInt(flamegraphResponse?.filtered ?? '0'),


### PR DESCRIPTION
To get rid of entries in the flame graph that are smaller than a pixel (and thus can't be rendered) the code iterates over all rows and checks a row's children cumulative values against its own cumulative value. If the difference is so drastic we remove that child.

Not yet implemented is rewriting the arrow record after trimming. Given the little overhead we can always improve the rendering by trimming too small children. Based on some heuristic (like if more than 1% is trimmed) we may consider recreating the arrow record with just the necessary rows. This would mostly be a bandwidth optimization.

The differences with the added code won't be noticeable for now.
```
name      old time/op    new time/op    delta
Query-24    24.7ms ± 4%    25.7ms ± 8%    ~     (p=0.421 n=5+5)

name      old alloc/op   new alloc/op   delta
Query-24    14.1MB ± 0%    14.2MB ± 0%  +0.30%  (p=0.032 n=5+5)

name      old allocs/op  new allocs/op  delta
Query-24      119k ± 0%      120k ± 0%    ~     (p=0.095 n=5+5)
```