### PR TITLE
Revert "compress the flamegraph record with lz4 (#3459)"

### DIFF
--- a/pkg/query/flamegraph_arrow.go
+++ b/pkg/query/flamegraph_arrow.go
@@ -66,7 +66,6 @@ func GenerateFlamegraphArrow(ctx context.Context, mem memory.Allocator, tracer t
 	w := ipc.NewWriter(&buf,
 		ipc.WithSchema(record.Schema()),
 		ipc.WithAllocator(mem),
-		ipc.WithLZ4(),
 	)
 
 	if err = w.Write(record); err != nil {


### PR DESCRIPTION
This reverts commit aa604de41d8556b046b806609e186bf2d966e1ea.

Sadly Arrow JS doesn't support lz4 compression (yet):
https://github.com/apache/arrow/issues/24833
https://github.com/apache/arrow/pull/13076