### PR TITLE
ci: Only run govulncheck on go/lint

### DIFF
--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -15,10 +15,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: true
 
-env:
-  # renovate: datasource=go depName=github.com/golangci/golangci-lint
-  GOLANGCI_LINT_VERSION: v1.53.3
-
 jobs:
   skip-check:
     name: Skip check
@@ -82,8 +78,5 @@ jobs:
       - name: Format
         run: make go/fmt && git diff --exit-code
 
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@639cd343e1d3b897ff35927a75193d57cfcba299 # v3.6.0
-        with:
-          version: ${{ env.GOLANGCI_LINT_VERSION }}
-          args: --timeout 5m
+      - name: Lint
+        run: make go/lint

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,9 @@ clean:
 .PHONY: go/deps
 go/deps:
 	go mod tidy
+
+.PHONY: go/deps-check
+go/deps-check:
 	govulncheck ./...
 
 .PHONY: go/build
@@ -76,7 +79,7 @@ go/fmt: gofumpt
 	$(GOFUMPT) -l -w $(shell go list -f {{.Dir}} ./... | grep -v gen/proto)
 
 .PHONY: go/lint
-go/lint:
+go/lint: go/deps-check
 	golangci-lint run
 
 .PHONY: check-license


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

#3472 caused unexpected CI failures: 
- https://github.com/parca-dev/parca/actions/runs/5613158920/job/15208568702?pr=3487
- https://github.com/parca-dev/parca/actions/runs/5613158924/job/15208563093?pr=3487

This should fix the issues 🤞 
