### PR TITLE
flamegraph_arrow: Inject artifical label node

### DIFF
--- a/pkg/query/flamegraph_arrow.go
+++ b/pkg/query/flamegraph_arrow.go
@@ -86,6 +86,11 @@ func generateFlamegraphArrowRecord(ctx context.Context, mem memory.Allocator, tr
 	for _, f := range aggregate {
 		aggregateFields[f] = struct{}{}
 	}
+	// this is a helper as it's frequently accessed below
+	aggregateLabels := false
+	if _, found := aggregateFields[FlamegraphFieldLabels]; found {
+		aggregateLabels = true
+	}
 
 	totalRows := int64(0)
 	for _, r := range p.Samples {
@@ -264,26 +269,24 @@ func generateFlamegraphArrowRecord(ctx context.Context, mem memory.Allocator, tr
 				}
 			}
 
-			sampleLabelsKey := ""
 			if _, aggregateLabels := aggregateFields[FlamegraphFieldLabels]; aggregateLabels && len(sampleLabels) > 0 {
 				lsbytes = lsbytes[:0]
 				lsbytes = MarshalStringMap(lsbytes, sampleLabels)
-				sampleLabelsKey = bytesToString(lsbytes)
 
 				sampleLabelRow := row
-				if _, ok := rootsRow[sampleLabelsKey]; ok {
-					sampleLabelRow = rootsRow[sampleLabelsKey][0]
+				if _, ok := rootsRow[unsafeString(lsbytes)]; ok {
+					sampleLabelRow = rootsRow[unsafeString(lsbytes)][0]
 					compareRows = compareRows[:0] //  reset the compare rows
 					// We want to compare against this found label root's children.
-					rootRow := rootsRow[sampleLabelsKey][0]
+					rootRow := rootsRow[unsafeString(lsbytes)][0]
 					compareRows = append(compareRows, fb.children[rootRow]...)
 					fb.addRowValues(r, sampleLabelRow, i) // adds the cumulative and diff values to the existing row
 				} else {
-					err := fb.AppendLabelRow(r, sampleLabelRow, sampleLabelsKey, sampleLabels, i)
+					err := fb.AppendLabelRow(r, sampleLabelRow, unsafeString(lsbytes), sampleLabels, i)
 					if err != nil {
 						return nil, 0, 0, 0, fmt.Errorf("failed to inject label row: %w", err)
 					}
-					rootsRow[sampleLabelsKey] = []int{sampleLabelRow}
+					rootsRow[unsafeString(lsbytes)] = []int{sampleLabelRow}
 				}
 				fb.parent.Set(sampleLabelRow)
 				row = fb.builderCumulative.Len()
@@ -295,19 +298,24 @@ func generateFlamegraphArrowRecord(ctx context.Context, mem memory.Allocator, tr
 			for j := int(end - 1); j >= int(beg); j-- {
 				// If the location has no lines, it's not symbolized.
 				// We work with the location address instead.
-				isRoot := isRoot(int(end), j)
 
-				if isLeaf(int(beg), j) {
+				// This returns whether this location is a root of a stacktrace.
+				isLocationRoot := isLocationRoot(int(end), j)
+				// Depending on whether we aggregate the labels (and thus inject node labels), we either compare the rows or not.
+				isRoot := isLocationRoot && !(aggregateLabels && len(sampleLabels) > 0)
+
+				if isLocationLeaf(int(beg), j) {
 					cumulative += r.Value.Value(i)
 				}
 
 				llOffsetStart, llOffsetEnd := r.Lines.ValueOffsets(j)
 				if !r.Lines.IsValid(j) || llOffsetEnd-llOffsetStart <= 0 {
+					// We only want to compare the rows if this is the root, and we don't aggregate the labels.
 					if isRoot {
 						compareRows = compareRows[:0] //  reset the compare rows
-						compareRows = append(compareRows, rootsRow[sampleLabelsKey]...)
+						compareRows = append(compareRows, rootsRow[unsafeString(lsbytes)]...)
 						// append this row afterward to not compare to itself
-						// fb.parent.Reset()
+						fb.parent.Reset()
 					}
 
 					// We compare the location address to the existing rows.
@@ -334,7 +342,7 @@ func generateFlamegraphArrowRecord(ctx context.Context, mem memory.Allocator, tr
 
 					if isRoot {
 						// We aren't merging this root, so we'll keep track of it as a new one.
-						rootsRow[sampleLabelsKey] = append(rootsRow[sampleLabelsKey], row)
+						rootsRow[unsafeString(lsbytes)] = append(rootsRow[unsafeString(lsbytes)], row)
 					}
 
 					err := fb.appendRow(r, sampleLabels, i, j, -1, row)
@@ -350,9 +358,10 @@ func generateFlamegraphArrowRecord(ctx context.Context, mem memory.Allocator, tr
 			stacktraces:
 				// just like locations, pprof stores lines in reverse order.
 				for k := int(llOffsetEnd - 1); k >= int(llOffsetStart); k-- {
-					if isRoot && sampleLabelsKey == "" {
+					// We only want to compare the rows if this is the root, and we don't aggregate the labels.
+					if isRoot {
 						compareRows = compareRows[:0] //  reset the compare rows
-						compareRows = append(compareRows, rootsRow[sampleLabelsKey]...)
+						compareRows = append(compareRows, rootsRow[unsafeString(lsbytes)]...)
 						// append this row afterward to not compare to itself
 						fb.parent.Reset()
 					}
@@ -386,9 +395,9 @@ func generateFlamegraphArrowRecord(ctx context.Context, mem memory.Allocator, tr
 						compareRows = compareRows[:0]
 					}
 
-					if isRoot && sampleLabelsKey == "" {
+					if isRoot {
 						// We aren't merging this root, so we'll keep track of it as a new one.
-						rootsRow[sampleLabelsKey] = append(rootsRow[sampleLabelsKey], row)
+						rootsRow[unsafeString(lsbytes)] = append(rootsRow[unsafeString(lsbytes)], row)
 					}
 
 					err := fb.appendRow(r, sampleLabels, i, j, k, row)
@@ -644,7 +653,10 @@ func (fb *flamegraphBuilder) AppendLabelRow(r profile.RecordReader, row int, lab
 	fb.builderLocationLine.AppendNull()
 	fb.builderFunctionStartLine.AppendNull()
 
-	_ = fb.builderFunctionName.AppendString(labelKey)
+	err := fb.builderFunctionName.AppendString(labelKey)
+	if err != nil {
+		return err
+	}
 
 	fb.builderFunctionSystemName.AppendNull()
 	fb.builderFunctionFileName.AppendNull()
@@ -665,11 +677,11 @@ func (fb *flamegraphBuilder) addRowValues(r profile.RecordReader, row, sampleRow
 	}
 }
 
-func isRoot(end, i int) bool {
+func isLocationRoot(end, i int) bool {
 	return i == end-1
 }
 
-func isLeaf(beg, i int) bool {
+func isLocationLeaf(beg, i int) bool {
 	return i == beg
 }
 
@@ -712,7 +724,7 @@ keys:
 	return intersection
 }
 
-func bytesToString(b []byte) string {
+func unsafeString(b []byte) string {
 	if len(b) == 0 {
 		return ""
 	}

--- a/pkg/query/flamegraph_arrow.go
+++ b/pkg/query/flamegraph_arrow.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"unsafe"
 
 	"github.com/apache/arrow/go/v13/arrow"
 	"github.com/apache/arrow/go/v13/arrow/array"
@@ -173,9 +174,10 @@ func generateFlamegraphArrowRecord(ctx context.Context, mem memory.Allocator, tr
 	cumulative := int64(0)
 	// This keeps track of the max depth of our flame graph.
 	maxHeight := int32(0)
-	// This keeps track of the root rows.
+	// This keeps track of the root rows indexed by the labels string.
+	// If the stack trace has no labels, we use the empty string as the key.
 	// This will be the root row's children, which is always our row 0 in flame graphs.
-	rootsRow := []int{}
+	rootsRow := map[string][]int{}
 
 	// these change with every iteration below
 	row := fb.builderCumulative.Len()
@@ -240,6 +242,7 @@ func generateFlamegraphArrowRecord(ctx context.Context, mem memory.Allocator, tr
 			}
 		}
 
+		lsbytes := make([]byte, 0, 512)
 		for i := 0; i < int(r.Record.NumRows()); i++ {
 			beg, end := r.Locations.ValueOffsets(i)
 
@@ -261,6 +264,31 @@ func generateFlamegraphArrowRecord(ctx context.Context, mem memory.Allocator, tr
 				}
 			}
 
+			sampleLabelsKey := ""
+			if _, aggregateLabels := aggregateFields[FlamegraphFieldLabels]; aggregateLabels && len(sampleLabels) > 0 {
+				lsbytes = lsbytes[:0]
+				lsbytes = MarshalStringMap(lsbytes, sampleLabels)
+				sampleLabelsKey = bytesToString(lsbytes)
+
+				sampleLabelRow := row
+				if _, ok := rootsRow[sampleLabelsKey]; ok {
+					sampleLabelRow = rootsRow[sampleLabelsKey][0]
+					compareRows = compareRows[:0] //  reset the compare rows
+					// We want to compare against this found label root's children.
+					rootRow := rootsRow[sampleLabelsKey][0]
+					compareRows = append(compareRows, fb.children[rootRow]...)
+					fb.addRowValues(r, sampleLabelRow, i) // adds the cumulative and diff values to the existing row
+				} else {
+					err := fb.AppendLabelRow(r, sampleLabelRow, sampleLabelsKey, sampleLabels, i)
+					if err != nil {
+						return nil, 0, 0, 0, fmt.Errorf("failed to inject label row: %w", err)
+					}
+					rootsRow[sampleLabelsKey] = []int{sampleLabelRow}
+				}
+				fb.parent.Set(sampleLabelRow)
+				row = fb.builderCumulative.Len()
+			}
+
 			// every new sample resets the childRow to -1 indicating that we start with a leaf again.
 			// pprof stores locations in reverse order, thus we loop over locations in reverse order.
 		locations:
@@ -277,9 +305,9 @@ func generateFlamegraphArrowRecord(ctx context.Context, mem memory.Allocator, tr
 				if !r.Lines.IsValid(j) || llOffsetEnd-llOffsetStart <= 0 {
 					if isRoot {
 						compareRows = compareRows[:0] //  reset the compare rows
-						compareRows = append(compareRows, rootsRow...)
+						compareRows = append(compareRows, rootsRow[sampleLabelsKey]...)
 						// append this row afterward to not compare to itself
-						fb.parent.Reset()
+						// fb.parent.Reset()
 					}
 
 					// We compare the location address to the existing rows.
@@ -306,7 +334,7 @@ func generateFlamegraphArrowRecord(ctx context.Context, mem memory.Allocator, tr
 
 					if isRoot {
 						// We aren't merging this root, so we'll keep track of it as a new one.
-						rootsRow = append(rootsRow, row)
+						rootsRow[sampleLabelsKey] = append(rootsRow[sampleLabelsKey], row)
 					}
 
 					err := fb.appendRow(r, sampleLabels, i, j, -1, row)
@@ -322,9 +350,9 @@ func generateFlamegraphArrowRecord(ctx context.Context, mem memory.Allocator, tr
 			stacktraces:
 				// just like locations, pprof stores lines in reverse order.
 				for k := int(llOffsetEnd - 1); k >= int(llOffsetStart); k-- {
-					if isRoot {
+					if isRoot && sampleLabelsKey == "" {
 						compareRows = compareRows[:0] //  reset the compare rows
-						compareRows = append(compareRows, rootsRow...)
+						compareRows = append(compareRows, rootsRow[sampleLabelsKey]...)
 						// append this row afterward to not compare to itself
 						fb.parent.Reset()
 					}
@@ -345,6 +373,7 @@ func generateFlamegraphArrowRecord(ctx context.Context, mem memory.Allocator, tr
 								fb.labels[cr] = append(fb.labels[cr], sampleLabels)
 							}
 
+							// TODO: Use fb.addRowValues() here
 							// All fields match, so we can aggregate this new row with the existing one.
 							fb.builderCumulative.Add(cr, r.Value.Value(i))
 							// Continue with this row as the parent for the next iteration and compare to its children.
@@ -357,9 +386,9 @@ func generateFlamegraphArrowRecord(ctx context.Context, mem memory.Allocator, tr
 						compareRows = compareRows[:0]
 					}
 
-					if isRoot {
+					if isRoot && sampleLabelsKey == "" {
 						// We aren't merging this root, so we'll keep track of it as a new one.
-						rootsRow = append(rootsRow, row)
+						rootsRow[sampleLabelsKey] = append(rootsRow[sampleLabelsKey], row)
 					}
 
 					err := fb.appendRow(r, sampleLabels, i, j, k, row)
@@ -384,8 +413,10 @@ func generateFlamegraphArrowRecord(ctx context.Context, mem memory.Allocator, tr
 	for i := 0; i < fb.builderCumulative.Len(); i++ {
 		if i == 0 {
 			builderChildren.Append(true)
-			for _, child := range rootsRow {
-				fb.builderChildrenValues.Append(uint32(child))
+			for _, sampleLabelChildren := range rootsRow {
+				for _, child := range sampleLabelChildren {
+					fb.builderChildrenValues.Append(uint32(child))
+				}
 			}
 			continue
 		}
@@ -588,6 +619,52 @@ func (fb *flamegraphBuilder) appendRow(
 	return nil
 }
 
+func (fb *flamegraphBuilder) AppendLabelRow(r profile.RecordReader, row int, labelKey string, labels map[string]string, sampleRow int) error {
+	fb.labels[row] = []map[string]string{labels}
+
+	if len(fb.children) == row {
+		// We need to grow the children slice, so we'll do that here.
+		// We'll double the capacity of the slice.
+		newChildren := make([][]int, len(fb.children)*2)
+		copy(newChildren, fb.children)
+		fb.children = newChildren
+	}
+	// Add this label row to the root row's children.
+	fb.children[0] = append(fb.children[0], row)
+	//// Add the next row as child of this label row.
+	//fb.children[row] = append(fb.children[row], row+1)
+
+	fb.builderMappingStart.AppendNull()
+	fb.builderMappingLimit.AppendNull()
+	fb.builderMappingOffset.AppendNull()
+	fb.builderMappingFile.AppendNull()
+	fb.builderMappingBuildID.AppendNull()
+	fb.builderLocationAddress.AppendNull()
+	fb.builderLocationFolded.AppendNull()
+	fb.builderLocationLine.AppendNull()
+	fb.builderFunctionStartLine.AppendNull()
+
+	_ = fb.builderFunctionName.AppendString(labelKey)
+
+	fb.builderFunctionSystemName.AppendNull()
+	fb.builderFunctionFileName.AppendNull()
+
+	// Append both cumulative and diff values and overwrite them below.
+	fb.builderCumulative.Append(0)
+	fb.builderDiff.AppendNull()
+	fb.addRowValues(r, row, sampleRow)
+
+	return nil
+}
+
+// addRowValues updates the existing row's values and potentially adding existing values on top.
+func (fb *flamegraphBuilder) addRowValues(r profile.RecordReader, row, sampleRow int) {
+	fb.builderCumulative.Add(row, r.Value.Value(sampleRow))
+	if r.Diff.Value(sampleRow) != 0 {
+		fb.builderDiff.Add(row, r.Diff.Value(sampleRow))
+	}
+}
+
 func isRoot(end, i int) bool {
 	return i == end-1
 }
@@ -633,4 +710,11 @@ keys:
 	}
 
 	return intersection
+}
+
+func bytesToString(b []byte) string {
+	if len(b) == 0 {
+		return ""
+	}
+	return unsafe.String(unsafe.SliceData(b), len(b))
 }

--- a/ui/packages/shared/profile/src/GraphTooltipArrow/Content.tsx
+++ b/ui/packages/shared/profile/src/GraphTooltipArrow/Content.tsx
@@ -22,7 +22,6 @@ import {
   FIELD_CUMULATIVE,
   FIELD_DIFF,
   FIELD_FUNCTION_FILE_NAME,
-  FIELD_FUNCTION_NAME,
   FIELD_FUNCTION_START_LINE,
   FIELD_LABELS,
   FIELD_LOCATION_ADDRESS,
@@ -30,6 +29,7 @@ import {
   FIELD_MAPPING_BUILD_ID,
   FIELD_MAPPING_FILE,
 } from '../ProfileIcicleGraph/IcicleGraphArrow';
+import {nodeLabel} from '../ProfileIcicleGraph/IcicleGraphArrow/utils';
 import {hexifyAddress, truncateString, truncateStringReverse} from '../utils';
 import {ExpandOnHover} from './ExpandOnHoverValue';
 
@@ -41,6 +41,7 @@ interface GraphTooltipArrowContentProps {
   total: bigint;
   totalUnfiltered: bigint;
   row: number | null;
+  level: number;
   isFixed: boolean;
 }
 
@@ -54,6 +55,7 @@ const GraphTooltipArrowContent = ({
   total,
   totalUnfiltered,
   row,
+  level,
   isFixed,
 }: GraphTooltipArrowContentProps): React.JSX.Element => {
   const [isCopied, setIsCopied] = useState<boolean>(false);
@@ -63,7 +65,6 @@ const GraphTooltipArrowContent = ({
   }
 
   const locationAddress: bigint = table.getChild(FIELD_LOCATION_ADDRESS)?.get(row) ?? 0n;
-  const functionName: string = table.getChild(FIELD_FUNCTION_NAME)?.get(row) ?? '';
   const cumulative: bigint = table.getChild(FIELD_CUMULATIVE)?.get(row) ?? 0n;
   const diff: bigint = table.getChild(FIELD_DIFF)?.get(row) ?? 0n;
 
@@ -82,6 +83,9 @@ const GraphTooltipArrowContent = ({
   const diffValueText = diffSign + valueFormatter(diff, unit, 1);
   const diffPercentageText = diffSign + (diffRatio * 100).toFixed(2) + '%';
   const diffText = `${diffValueText} (${diffPercentageText})`;
+
+  const name = nodeLabel(table, row, level, false);
+  console.log(level, row, name);
 
   const getTextForCumulative = (hoveringNodeCumulative: bigint): string => {
     const filtered =
@@ -103,9 +107,9 @@ const GraphTooltipArrowContent = ({
                   <p>root</p>
                 ) : (
                   <>
-                    {functionName !== '' ? (
-                      <CopyToClipboard onCopy={onCopy} text={functionName}>
-                        <button className="cursor-pointer text-left">{functionName}</button>
+                    {name !== '' ? (
+                      <CopyToClipboard onCopy={onCopy} text={name}>
+                        <button className="cursor-pointer text-left">{name}</button>
                       </CopyToClipboard>
                     ) : (
                       <>

--- a/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/IcicleGraphNodes.tsx
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/IcicleGraphNodes.tsx
@@ -45,6 +45,7 @@ interface IcicleGraphNodesProps {
   curPath: string[];
   setCurPath: (path: string[]) => void;
   setHoveringRow: (row: number | null) => void;
+  setHoveringLevel: (level: number | null) => void;
   path: string[];
   xScale: (value: bigint) => number;
   searchString?: string;
@@ -66,6 +67,7 @@ export const IcicleGraphNodes = React.memo(function IcicleGraphNodesNoMemo({
   path,
   setCurPath,
   setHoveringRow,
+  setHoveringLevel,
   curPath,
   sortBy,
   searchString,
@@ -81,7 +83,7 @@ export const IcicleGraphNodes = React.memo(function IcicleGraphNodesNoMemo({
   childRows =
     curPath.length === 0
       ? childRows
-      : childRows.filter(c => nodeLabel(table, c, false) === curPath[0]);
+      : childRows.filter(c => nodeLabel(table, c, level, false) === curPath[0]);
 
   let childrenCumulative = BigInt(0);
   const childrenElements: ReactNode[] = [];
@@ -103,6 +105,7 @@ export const IcicleGraphNodes = React.memo(function IcicleGraphNodesNoMemo({
         path={path}
         setCurPath={setCurPath}
         setHoveringRow={setHoveringRow}
+        setHoveringLevel={setHoveringLevel}
         level={level}
         curPath={curPath}
         total={total}
@@ -136,6 +139,7 @@ interface IcicleNodeProps {
   total: bigint;
   setCurPath: (path: string[]) => void;
   setHoveringRow: (row: number | null) => void;
+  setHoveringLevel: (level: number | null) => void;
   xScale: (value: bigint) => number;
   isRoot?: boolean;
   searchString?: string;
@@ -171,6 +175,7 @@ export const IcicleNode = React.memo(function IcicleNodeNoMemo({
   isRoot = false,
   searchString,
   setHoveringRow,
+  setHoveringLevel,
   sortBy,
   darkMode,
   compareMode,
@@ -246,8 +251,8 @@ export const IcicleNode = React.memo(function IcicleNodeNoMemo({
     functionName,
   });
   const name = useMemo(() => {
-    return isRoot ? 'root' : nodeLabel(table, row, binaries.length > 1);
-  }, [table, row, isRoot, binaries]);
+    return isRoot ? 'root' : nodeLabel(table, row, level, binaries.length > 1);
+  }, [table, row, level, isRoot, binaries]);
   const nextPath = path.concat([name]);
   const isFaded = curPath.length > 0 && name !== curPath[curPath.length - 1];
   const styles = isFaded ? fadedIcicleRectStyles : icicleRectStyles;
@@ -277,11 +282,13 @@ export const IcicleNode = React.memo(function IcicleNodeNoMemo({
   const onMouseEnter = (): void => {
     if (isShiftDown) return;
     setHoveringRow(row);
+    setHoveringLevel(level);
   };
 
   const onMouseLeave = (): void => {
     if (isShiftDown) return;
     setHoveringRow(null);
+    setHoveringLevel(null);
   };
 
   return (
@@ -331,6 +338,7 @@ export const IcicleNode = React.memo(function IcicleNodeNoMemo({
           curPath={nextCurPath}
           setCurPath={setCurPath}
           setHoveringRow={setHoveringRow}
+          setHoveringLevel={setHoveringLevel}
           searchString={searchString}
           sortBy={sortBy}
           darkMode={darkMode}

--- a/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/index.tsx
@@ -80,6 +80,7 @@ export const IcicleGraphArrow = memo(function IcicleGraphArrow({
 
   const [height, setHeight] = useState(0);
   const [hoveringRow, setHoveringRow] = useState<number | null>(null);
+  const [hoveringLevel, setHoveringLevel] = useState<number | null>(null);
   const svg = useRef(null);
   const ref = useRef<SVGGElement>(null);
 
@@ -190,6 +191,7 @@ export const IcicleGraphArrow = memo(function IcicleGraphArrow({
               isRoot={true}
               searchString={currentSearchString}
               setHoveringRow={setHoveringRow}
+              setHoveringLevel={setHoveringLevel}
               sortBy={sortBy}
               darkMode={isDarkMode}
               compareMode={compareMode}
@@ -228,6 +230,7 @@ export const IcicleGraphArrow = memo(function IcicleGraphArrow({
         <GraphTooltipArrowContent
           table={table}
           row={hoveringRow}
+          level={hoveringLevel ?? 0}
           isFixed={false}
           total={total}
           totalUnfiltered={total + filtered}

--- a/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/utils.ts
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/utils.ts
@@ -19,9 +19,20 @@ import {getLastItem} from '@parca/utilities';
 import {hexifyAddress} from '../../utils';
 import {FIELD_FUNCTION_NAME, FIELD_LOCATION_ADDRESS, FIELD_MAPPING_FILE} from './index';
 
-export function nodeLabel(table: Table<any>, row: number, showBinaryName: boolean): string {
+export function nodeLabel(
+  table: Table<any>,
+  row: number,
+  level: number,
+  showBinaryName: boolean
+): string {
   const functionName: string | null = table.getChild(FIELD_FUNCTION_NAME)?.get(row);
   if (functionName !== null && functionName !== '') {
+    if (level === 1 && functionName.startsWith('{') && functionName.endsWith('}')) {
+      return Object.entries(JSON.parse(functionName))
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([k, v]) => `${k}="${v as string}"`)
+        .join(', ');
+    }
     return functionName;
   }
 


### PR DESCRIPTION
On the backend, we check every sample for its pprof labels.
If it has pprof labels we either inject a artifical node into the stack containing the pprof labels as JSON for the function name, or we merge the stack into the already existing same pprof label node. 

In the frontend, instead of showing `{"thread_name":"foo"}` we're going to parse the JSON and display it as `thread_name="foo"` in a Prometheus fashion. Given that each injected pprof label node is unique the drilling down into the icicle graph by function name now works flawlessly again. :+1: 

![Screenshot from 2023-07-27 20-12-51](https://github.com/parca-dev/parca/assets/872251/01f23da0-4b95-4204-a90e-dcb246a9cf30)



