### PR TITLE
feat(snap): add config options to send profiles to a remote store

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -34,9 +34,17 @@ if [[ -z "$storage_persist" ]]; then
     snapctl set enable-persistence=false
 fi
 
-port="$(snapctl get port)"
-if [[ -z "$port" ]]; then
-    snapctl set port=7070
+# Address to bind HTTP server to.
+http_address="$(snapctl get http-address)"
+if [[ -z "$http_address" ]]; then
+    # Older versions of the snap exposed the port option.
+    # Migrate that to http-address if it was set.
+    port="$(snapctl get port)"
+    if [[ -n "${port}" ]]; then
+        snapctl set http-address=":${port}"
+    else
+        snapctl set http-address=":7070"
+    fi
 fi
 
 # gRPC address to send profiles and symbols to.

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -39,5 +39,23 @@ if [[ -z "$port" ]]; then
     snapctl set port=7070
 fi
 
+# gRPC address to send profiles and symbols to.
+remote_store="$(snapctl get remote-store-address)"
+if [[ -z "$remote_store" ]]; then
+    snapctl set remote-store-address="grpc.polarsignals.com:443"
+fi
+
+# Send gRPC requests via plaintext instead of TLS
+remote_store_insecure="$(snapctl get remote-store-insecure)"
+if [[ -z "$remote_store_insecure" ]]; then
+    snapctl set remote-store-insecure=false
+fi
+
+# Set the bearer token for the remote store
+remote_store_token="$(snapctl get remote-store-bearer-token)"
+if [[ -z "$remote_store_token" ]]; then
+    snapctl set remote-store-bearer-token=""
+fi
+
 mkdir -p "${SNAP_DATA}/profiles"
 cp -pnr "${SNAP}/usr/share/parca/example-config.yaml" "${SNAP_DATA}/parca.yaml"

--- a/snap/parca-wrapper
+++ b/snap/parca-wrapper
@@ -22,7 +22,7 @@ set -euo pipefail
 storage_active_memory="$(snapctl get storage-active-memory)"
 log_level="$(snapctl get log-level)"
 storage_persist="$(snapctl get enable-persistence)"
-port="$(snapctl get port)"
+http_address="$(snapctl get http-address)"
 
 store="$(snapctl get remote-store-address)"
 insecure="$(snapctl get remote-store-insecure)"
@@ -32,7 +32,7 @@ token="$(snapctl get remote-store-bearer-token)"
 opts=(
     "--config-path=${SNAP_DATA}/parca.yaml"
     "--log-level=${log_level}"
-    "--port=:${port}"
+    "--http-address=${http_address}"
 )
 
 # If there is a token set for a store, then enable sending profiles to a remote store.
@@ -46,7 +46,7 @@ if [[ -n "${token}" ]]; then
     )
 else
     # Only configure persistence and storage if we're not sending to a remote store.
-    
+
     # Switch out command line options depending on whether the user has
     # specified storage-persist=true
     if [[ "${storage_persist}" == "true" ]]; then

--- a/snap/parca-wrapper
+++ b/snap/parca-wrapper
@@ -24,6 +24,10 @@ log_level="$(snapctl get log-level)"
 storage_persist="$(snapctl get enable-persistence)"
 port="$(snapctl get port)"
 
+store="$(snapctl get remote-store-address)"
+insecure="$(snapctl get remote-store-insecure)"
+token="$(snapctl get remote-store-bearer-token)"
+
 # Start building an array of command line options
 opts=(
     "--config-path=${SNAP_DATA}/parca.yaml"
@@ -31,18 +35,31 @@ opts=(
     "--port=:${port}"
 )
 
-# Switch out command line options depending on whether the user has
-# specified storage-persist=true
-if [[ "${storage_persist}" == "true" ]]; then
+# If there is a token set for a store, then enable sending profiles to a remote store.
+# Ensure we set the mode to scraper only in this instance.
+if [[ -n "${token}" ]]; then
     opts+=(
-        "--enable-persistence=true"
-        "--storage-path=${SNAP_DATA}/profiles"
+        "--store-address=${store}"
+        "--bearer-token=${token}"
+        "--insecure=${insecure}"
+        "--mode=scraper-only"
     )
 else
-    opts+=(
-        "--enable-persistence=false"
-        "--storage-active-memory=${storage_active_memory}"
-    )
+    # Only configure persistence and storage if we're not sending to a remote store.
+    
+    # Switch out command line options depending on whether the user has
+    # specified storage-persist=true
+    if [[ "${storage_persist}" == "true" ]]; then
+        opts+=(
+            "--enable-persistence=true"
+            "--storage-path=${SNAP_DATA}/profiles"
+        )
+    else
+        opts+=(
+            "--enable-persistence=false"
+            "--storage-active-memory=${storage_active_memory}"
+        )
+    fi
 fi
 
 # Run parca with the gathered arguments


### PR DESCRIPTION
Add a config option to the Parca snap to simplify the onboarding to Parca Cloud.

This change introduces a new snap config option named remote-store-bearer-token, and sets the default store address to grpc.polarsignals.com:443.

When a token is set, any other config about storage persistence or memory is ignored, and Parca's mode is set to `scraper-only`.

