### PR TITLE
feat(snap): bind /var/lib/parca to $SNAP_DATA/var/lib/parca

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -78,6 +78,9 @@ snapcrafts:
           - network
           - home
           - etc-parca
+    layout:
+      /var/lib/parca:
+        bind: $SNAP_DATA/var/lib/parca
     plugs:
       etc-parca:
         interface: system-files


### PR DESCRIPTION
This PR essentially binds `/var/lib/parca` to `$SNAP_DATA/var/lib/parca` for the snap package, which should stop permission denied errors like this one:

```
2023-08-07T17:26:39Z parca.parca-svc[4743]: level=error name=parca ts=2023-08-07T17:26:39.488885923Z caller=server.go:321 msg="finished call" protocol=grpc grpc.component=server grpc.service=parca.debuginfo.v1alpha1.DebuginfoService grpc.method=InitiateUpload grpc.method_type=unary peer.address=10.224.9.68:47984 grpc.start_time=2023-08-07T17:26:09Z grpc.request.deadline=2023-08-07T17:28:09Z grpc.code=Unknown grpc.error="mark debuginfo upload as uploading via gRPC: write debuginfo metadata to object storage: mkdir /var/lib/parca: read-only file system" grpc.time_ms=30000.62
```

Details of the feature here: https://snapcraft.io/docs/snap-layouts