### PR TITLE
ci: fix snap test - s/port/http-address/g

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -166,9 +166,9 @@ jobs:
           curl ${CURL_OPTS[@]} http://localhost:7070/
           curl ${CURL_OPTS[@]} http://localhost:7070/metrics
 
-      - name: Configure snap - port
+      - name: Configure snap - http-address
         run: |
-          sudo snap set parca port=8080
+          sudo snap set parca http-address=":8080"
           sudo snap restart parca
 
           # Set some options to allow retries while Parca comes back up


### PR DESCRIPTION
Latest PR that merged broke the snap tests - this should fix that.

I didn't catch this because the skip-check meant the CI tests didn't run on the original PR. I'll take a look at that in a while :)