### PR TITLE
pkg/debuginfo: Save sources upload without extension

### DIFF
--- a/pkg/debuginfo/store.go
+++ b/pkg/debuginfo/store.go
@@ -429,7 +429,7 @@ func objectPath(buildID string, typ debuginfopb.DebuginfoType) string {
 	case debuginfopb.DebuginfoType_DEBUGINFO_TYPE_EXECUTABLE:
 		return path.Join(buildID, "executable")
 	case debuginfopb.DebuginfoType_DEBUGINFO_TYPE_SOURCES:
-		return path.Join(buildID, "sources.tar.gz")
+		return path.Join(buildID, "sources")
 	default:
 		return path.Join(buildID, "debuginfo")
 	}


### PR DESCRIPTION
This allows us to rather base the decision of what file tyte is being used by looking at the magic number rather than limiting ourselves just to tarballs.