### PR TITLE
add startline to function when symbolizing elf

### DIFF
--- a/pkg/symbol/addr2line/dwarf_test.go
+++ b/pkg/symbol/addr2line/dwarf_test.go
@@ -45,7 +45,8 @@ func TestDwarfSymbolizer(t *testing.T) {
 	}
 
 	require.Equal(t, &metastorev1alpha1.Function{
-		Name:     "top2",
-		Filename: "src/basic-cpp.cpp",
+		Name:      "top2",
+		Filename:  "src/basic-cpp.cpp",
+		StartLine: 8,
 	}, gotLines[0].Function)
 }

--- a/pkg/symbol/elfutils/debuginfofile.go
+++ b/pkg/symbol/elfutils/debuginfofile.go
@@ -95,12 +95,19 @@ func (f *debugInfoFile) SourceLines(addr uint64) ([]profile.LocationLine, error)
 	if !ok {
 		name = ""
 	}
+
+	declLine, ok := tr.Entry.Val(dwarf.AttrDeclLine).(int64)
+	if !ok {
+		declLine = 0
+	}
+
 	file, line := findLineInfo(f.lineEntries[cu.Offset], tr.Ranges)
 	lines = append(lines, profile.LocationLine{
 		Line: line,
 		Function: f.demangler.Demangle(&pb.Function{
-			Name:     name,
-			Filename: file,
+			Name:      name,
+			Filename:  file,
+			StartLine: declLine,
 		}),
 	})
 
@@ -114,12 +121,18 @@ func (f *debugInfoFile) SourceLines(addr uint64) ([]profile.LocationLine, error)
 			name = getFunctionName(abstractOrigin)
 		}
 
+		declLine, ok := ch.Entry.Val(dwarf.AttrDeclLine).(int64)
+		if !ok {
+			declLine = 0
+		}
+
 		file, line := findLineInfo(f.lineEntries[cu.Offset], ch.Ranges)
 		lines = append(lines, profile.LocationLine{
 			Line: line,
 			Function: f.demangler.Demangle(&pb.Function{
-				Name:     name,
-				Filename: file,
+				Name:      name,
+				Filename:  file,
+				StartLine: declLine,
 			}),
 		})
 	}


### PR DESCRIPTION
Adds the `StartLine` to the profile Function during symbolization. This is needed to support pgo https://go.dev/doc/pgo#alternative-sources

> [Function.start_line](https://github.com/google/pprof/blob/76d1ae5aea2b3f738f2058d17533b747a1a5cd01/proto/profile.proto#L215) must be set. This is the line number of the start of the function. i.e., the line containing the func keyword. The Go compiler uses this field to compute line offsets of samples (Location.Line.line - Function.start_line). Note that many existing pprof converters omit this field.

Tested using pprof that was collected by parca-agent & downloaded from pacra UI.

Before:
```
$ go build  -gcflags="all=-N -l" -o bin/ -pgo ~/Downloads/profile_before.pb ./my/test
# internal/coverage/rtcov
compile: /home/albertlockett/Downloads/profile(1).pb: PGO error: profile missing Function.start_line data (Go version of profiled application too old? Go 1.20+ automatically adds this to profiles)
# internal/goos
compile: /home/albertlockett/Downloads/profile(1).pb: PGO error: profile missing Function.start_line data (Go version of profiled application too old? Go 1.20+ automatically adds this to profiles)
# internal/goarch
compile: /home/albertlockett/Downloads/profile(1).pb: PGO error: profile missing Function.start_line data (Go version of profiled application too old? Go 1.20+ automatically adds this to profiles)
# internal/goexperiment
```

After:
```
$ go build  -gcflags="all=-N -l" -o bin/ -pgo ~/Downloads/profile_after ./my/test
# no problems
```
