### PR TITLE
pkg/query: Improve flamegraph performance through dictionary unification

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/nanmu42/limitio v1.0.0
 	github.com/oklog/run v1.1.0
 	github.com/parquet-go/parquet-go v0.17.0
-	github.com/polarsignals/frostdb v0.0.0-20230803182517-de942d0ce46e
+	github.com/polarsignals/frostdb v0.0.0-20230821093112-02bf1156bc12
 	github.com/prometheus/client_golang v1.16.0
 	github.com/prometheus/common v0.44.0
 	github.com/prometheus/prometheus v0.46.0
@@ -201,7 +201,7 @@ require (
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/polarsignals/wal v0.0.0-20230509073041-6731e243de20 // indirect
+	github.com/polarsignals/wal v0.0.0-20230809145250-99ef415c5a6c // indirect
 	github.com/prometheus/client_model v0.4.0 // indirect
 	github.com/prometheus/procfs v0.11.0 // indirect
 	github.com/rivo/uniseg v0.3.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -763,10 +763,10 @@ github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6J
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/polarsignals/frostdb v0.0.0-20230803182517-de942d0ce46e h1:z0GLh8sWFe0pAxSO5m/RTh1uwjCs1l8KrjvDgmXRqDQ=
-github.com/polarsignals/frostdb v0.0.0-20230803182517-de942d0ce46e/go.mod h1:bSg8tVn6RPtw9t45ehCrywh7OYA3pmHbh8LhzJbZSmU=
-github.com/polarsignals/wal v0.0.0-20230509073041-6731e243de20 h1:YverywcwPHYj5iQq1/Zy/EihWVyw2F0S7j52FvGWK4w=
-github.com/polarsignals/wal v0.0.0-20230509073041-6731e243de20/go.mod h1:EVDHAAe+7GQ33A1/x+/gE+sBPN4toQ0XG5RoLD49xr8=
+github.com/polarsignals/frostdb v0.0.0-20230821093112-02bf1156bc12 h1:W7FTAcqvJq1tuCqNezsfgSTxold2R3ywfgseA7YVxvE=
+github.com/polarsignals/frostdb v0.0.0-20230821093112-02bf1156bc12/go.mod h1:PAwdMGKDDXIXxnJ9BJPiD5wTfXXoVtpcfcwWJk/ULSo=
+github.com/polarsignals/wal v0.0.0-20230809145250-99ef415c5a6c h1:fVYVdHe8YeIXkmYr+JRNtrobo53lYthop0jXqS6Xamk=
+github.com/polarsignals/wal v0.0.0-20230809145250-99ef415c5a6c/go.mod h1:EVDHAAe+7GQ33A1/x+/gE+sBPN4toQ0XG5RoLD49xr8=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
 github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=

--- a/pkg/query/flamegraph_arrow_test.go
+++ b/pkg/query/flamegraph_arrow_test.go
@@ -42,6 +42,7 @@ import (
 )
 
 type flamegraphRow struct {
+	LabelsOnly         bool
 	MappingStart       uint64
 	MappingLimit       uint64
 	MappingOffset      uint64
@@ -61,6 +62,7 @@ type flamegraphRow struct {
 }
 
 type flamegraphColumns struct {
+	labelsOnly          []bool
 	mappingStart        []uint64
 	mappingLimit        []uint64
 	mappingOffset       []uint64
@@ -82,6 +84,7 @@ type flamegraphColumns struct {
 func rowsToColumn(rows []flamegraphRow) flamegraphColumns {
 	columns := flamegraphColumns{}
 	for _, row := range rows {
+		columns.labelsOnly = append(columns.labelsOnly, row.LabelsOnly)
 		columns.mappingStart = append(columns.mappingStart, row.MappingStart)
 		columns.mappingLimit = append(columns.mappingLimit, row.MappingLimit)
 		columns.mappingOffset = append(columns.mappingOffset, row.MappingOffset)
@@ -117,15 +120,17 @@ func requireColumn(t *testing.T, r arrow.Record, field string, expected any) {
 	}
 }
 
-func requireColumnDict(t *testing.T, r arrow.Record, field string, expected any) {
+func requireColumnBinaryDict(t *testing.T, r arrow.Record, field string, expected any) {
 	dict := r.Column(r.Schema().FieldIndices(field)[0]).(*array.Dictionary)
 
 	switch expected.(type) {
 	case []string:
-		mappingFilesString := dict.Dictionary().(*array.String)
+		mappingFilesString := dict.Dictionary().(*array.Binary)
 		mappingFiles := make([]string, r.NumRows())
 		for i := 0; i < int(r.NumRows()); i++ {
-			mappingFiles[i] = mappingFilesString.Value(dict.GetValueIndex(i))
+			if dict.IsValid(i) {
+				mappingFiles[i] = string(mappingFilesString.Value(dict.GetValueIndex(i)))
+			}
 		}
 		require.Equal(t, expected, mappingFiles)
 	}
@@ -290,7 +295,7 @@ func TestGenerateFlamegraphArrow(t *testing.T) {
 		height:     5,
 		trimmed:    0, // TODO
 		rows: []flamegraphRow{
-			{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0, LocationFolded: false, LocationLine: 0, FunctionStartLine: 0, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 10, Labels: nil, Children: []uint32{1, 3, 7, 11}},                               // 0
+			{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: "", MappingBuildID: "", LocationAddress: 0, LocationFolded: false, LocationLine: 0, FunctionStartLine: 0, FunctionName: "", FunctionSystemName: "", FunctionFilename: "", Cumulative: 10, Labels: nil, Children: []uint32{1, 3, 7, 11}},                                      // 0
 			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationFolded: false, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 2, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{2}},  // 1
 			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationFolded: false, LocationLine: 2, FunctionStartLine: 2, FunctionName: "2", FunctionSystemName: "2", FunctionFilename: "2", Cumulative: 2, Labels: map[string]string{"goroutine": "1"}, Children: nil},          // 2
 			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationFolded: false, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 1, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{4}},  // 3
@@ -314,7 +319,7 @@ func TestGenerateFlamegraphArrow(t *testing.T) {
 		height:     5,
 		trimmed:    0, // TODO
 		rows: []flamegraphRow{
-			{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0, LocationFolded: false, LocationLine: 0, FunctionStartLine: 0, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 10, Labels: nil, Children: []uint32{1}},           // 0
+			{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: "", MappingBuildID: "", LocationAddress: 0, LocationFolded: false, LocationLine: 0, FunctionStartLine: 0, FunctionName: "", FunctionSystemName: "", FunctionFilename: "", Cumulative: 10, Labels: nil, Children: []uint32{1}},                  // 0
 			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationFolded: false, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 10, Labels: nil, Children: []uint32{2}},   // 1
 			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationFolded: false, LocationLine: 2, FunctionStartLine: 2, FunctionName: "2", FunctionSystemName: "2", FunctionFilename: "2", Cumulative: 10, Labels: nil, Children: []uint32{3}},   // 2
 			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationFolded: false, LocationLine: 3, FunctionStartLine: 3, FunctionName: "3", FunctionSystemName: "3", FunctionFilename: "3", Cumulative: 8, Labels: nil, Children: []uint32{4, 5}}, // 3
@@ -329,24 +334,24 @@ func TestGenerateFlamegraphArrow(t *testing.T) {
 		height:     6,
 		trimmed:    0, // TODO
 		rows: []flamegraphRow{
-			{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0, LocationFolded: false, LocationLine: 0, FunctionStartLine: 0, FunctionName: `{"goroutine":"1"}`, FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 10, Labels: nil, Children: []uint32{1, 6, 10}}, // 0
+			{LabelsOnly: true, MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: "", MappingBuildID: "", LocationAddress: 0, LocationFolded: false, LocationLine: 0, FunctionStartLine: 0, FunctionName: "", FunctionSystemName: "", FunctionFilename: "", Cumulative: 10, Labels: nil, Children: []uint32{1, 6, 10}}, // 0
 			// all of these have the same labels, so they are aggregated
-			{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0, LocationFolded: false, LocationLine: 0, FunctionStartLine: 0, FunctionName: `{"goroutine":"1"}`, FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 3, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{2}}, // 1
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationFolded: false, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 3, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{3}},         // 2
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationFolded: false, LocationLine: 2, FunctionStartLine: 2, FunctionName: "2", FunctionSystemName: "2", FunctionFilename: "2", Cumulative: 3, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{4}},         // 3
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationFolded: false, LocationLine: 3, FunctionStartLine: 3, FunctionName: "3", FunctionSystemName: "3", FunctionFilename: "3", Cumulative: 1, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{5}},         // 4
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa5, LocationFolded: false, LocationLine: 5, FunctionStartLine: 5, FunctionName: "5", FunctionSystemName: "5", FunctionFilename: "5", Cumulative: 1, Labels: map[string]string{"goroutine": "1"}, Children: nil},                 // 5
+			{LabelsOnly: true, MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: "", MappingBuildID: "", LocationAddress: 0, LocationFolded: false, LocationLine: 0, FunctionStartLine: 0, FunctionName: "", FunctionSystemName: "", FunctionFilename: "", Cumulative: 3, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{2}}, // 1
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationFolded: false, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 3, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{3}},    // 2
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationFolded: false, LocationLine: 2, FunctionStartLine: 2, FunctionName: "2", FunctionSystemName: "2", FunctionFilename: "2", Cumulative: 3, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{4}},    // 3
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationFolded: false, LocationLine: 3, FunctionStartLine: 3, FunctionName: "3", FunctionSystemName: "3", FunctionFilename: "3", Cumulative: 1, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{5}},    // 4
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa5, LocationFolded: false, LocationLine: 5, FunctionStartLine: 5, FunctionName: "5", FunctionSystemName: "5", FunctionFilename: "5", Cumulative: 1, Labels: map[string]string{"goroutine": "1"}, Children: nil},            // 5
 			// all of these have no labels, so they are kept separate
 			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationFolded: false, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 3, Labels: nil, Children: []uint32{7}}, // 6
 			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationFolded: false, LocationLine: 2, FunctionStartLine: 2, FunctionName: "2", FunctionSystemName: "2", FunctionFilename: "2", Cumulative: 3, Labels: nil, Children: []uint32{8}}, // 7
 			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationFolded: false, LocationLine: 3, FunctionStartLine: 3, FunctionName: "3", FunctionSystemName: "3", FunctionFilename: "3", Cumulative: 3, Labels: nil, Children: []uint32{9}}, // 8
 			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa4, LocationFolded: false, LocationLine: 4, FunctionStartLine: 4, FunctionName: "4", FunctionSystemName: "4", FunctionFilename: "4", Cumulative: 3, Labels: nil, Children: nil},         // 9
 			// the same stack as the second stack, but a different pprof label
-			{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0, LocationFolded: false, LocationLine: 0, FunctionStartLine: 0, FunctionName: `{"goroutine":"2"}`, FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 4, Labels: map[string]string{"goroutine": "2"}, Children: []uint32{11}}, // 10
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationFolded: false, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 4, Labels: map[string]string{"goroutine": "2"}, Children: []uint32{12}},         // 11
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationFolded: false, LocationLine: 2, FunctionStartLine: 2, FunctionName: "2", FunctionSystemName: "2", FunctionFilename: "2", Cumulative: 4, Labels: map[string]string{"goroutine": "2"}, Children: []uint32{13}},         // 12
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationFolded: false, LocationLine: 3, FunctionStartLine: 3, FunctionName: "3", FunctionSystemName: "3", FunctionFilename: "3", Cumulative: 4, Labels: map[string]string{"goroutine": "2"}, Children: []uint32{14}},         // 13
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa5, LocationFolded: false, LocationLine: 5, FunctionStartLine: 5, FunctionName: "5", FunctionSystemName: "5", FunctionFilename: "5", Cumulative: 4, Labels: map[string]string{"goroutine": "2"}, Children: nil},                  // 14
+			{LabelsOnly: true, MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: "", MappingBuildID: "", LocationAddress: 0, LocationFolded: false, LocationLine: 0, FunctionStartLine: 0, FunctionName: "", FunctionSystemName: "", FunctionFilename: "", Cumulative: 4, Labels: map[string]string{"goroutine": "2"}, Children: []uint32{11}}, // 10
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationFolded: false, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 4, Labels: map[string]string{"goroutine": "2"}, Children: []uint32{12}},    // 11
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationFolded: false, LocationLine: 2, FunctionStartLine: 2, FunctionName: "2", FunctionSystemName: "2", FunctionFilename: "2", Cumulative: 4, Labels: map[string]string{"goroutine": "2"}, Children: []uint32{13}},    // 12
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationFolded: false, LocationLine: 3, FunctionStartLine: 3, FunctionName: "3", FunctionSystemName: "3", FunctionFilename: "3", Cumulative: 4, Labels: map[string]string{"goroutine": "2"}, Children: []uint32{14}},    // 13
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa5, LocationFolded: false, LocationLine: 5, FunctionStartLine: 5, FunctionName: "5", FunctionSystemName: "5", FunctionFilename: "5", Cumulative: 4, Labels: map[string]string{"goroutine": "2"}, Children: nil},             // 14
 		},
 	}, {
 		name:      "aggregate-mapping-file",
@@ -357,7 +362,7 @@ func TestGenerateFlamegraphArrow(t *testing.T) {
 		trimmed:    0, // TODO
 		rows: []flamegraphRow{
 			// This aggregates all the rows with the same mapping file, meaning that we only keep one flamegraphRow per stack depth in this example.
-			{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0, LocationFolded: false, LocationLine: 0, FunctionStartLine: 0, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 10, Labels: nil, Children: []uint32{1}},         // 0
+			{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: "", MappingBuildID: "", LocationAddress: 0, LocationFolded: false, LocationLine: 0, FunctionStartLine: 0, FunctionName: "", FunctionSystemName: "", FunctionFilename: "", Cumulative: 10, Labels: nil, Children: []uint32{1}},                // 0
 			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationFolded: false, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 10, Labels: nil, Children: []uint32{2}}, // 1
 			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationFolded: false, LocationLine: 2, FunctionStartLine: 2, FunctionName: "2", FunctionSystemName: "2", FunctionFilename: "2", Cumulative: 10, Labels: nil, Children: []uint32{3}}, // 2
 			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationFolded: false, LocationLine: 3, FunctionStartLine: 3, FunctionName: "3", FunctionSystemName: "3", FunctionFilename: "3", Cumulative: 8, Labels: nil, Children: []uint32{4}},  // 3
@@ -380,7 +385,7 @@ func TestGenerateFlamegraphArrow(t *testing.T) {
 			require.Equal(t, tc.height, height)
 			require.Equal(t, tc.trimmed, trimmed)
 			require.Equal(t, int64(len(tc.rows)), fa.NumRows())
-			require.Equal(t, int64(16), fa.NumCols())
+			require.Equal(t, int64(17), fa.NumCols())
 
 			// Convert the numRows to columns for easier access when testing below.
 			columns := rowsToColumn(tc.rows)
@@ -388,15 +393,15 @@ func TestGenerateFlamegraphArrow(t *testing.T) {
 			requireColumn(t, fa, FlamegraphFieldMappingStart, columns.mappingStart)
 			requireColumn(t, fa, FlamegraphFieldMappingLimit, columns.mappingLimit)
 			requireColumn(t, fa, FlamegraphFieldMappingOffset, columns.mappingOffset)
-			requireColumnDict(t, fa, FlamegraphFieldMappingFile, columns.mappingFiles)
-			requireColumnDict(t, fa, FlamegraphFieldMappingBuildID, columns.mappingBuildIDs)
+			requireColumnBinaryDict(t, fa, FlamegraphFieldMappingFile, columns.mappingFiles)
+			requireColumnBinaryDict(t, fa, FlamegraphFieldMappingBuildID, columns.mappingBuildIDs)
 			requireColumn(t, fa, FlamegraphFieldLocationAddress, columns.locationAddresses)
 			requireColumn(t, fa, FlamegraphFieldLocationFolded, columns.locationFolded)
 			requireColumn(t, fa, FlamegraphFieldLocationLine, columns.locationLines)
 			requireColumn(t, fa, FlamegraphFieldFunctionStartLine, columns.functionStartLines)
-			requireColumnDict(t, fa, FlamegraphFieldFunctionName, columns.functionNames)
-			requireColumnDict(t, fa, FlamegraphFieldFunctionSystemName, columns.functionSystemNames)
-			requireColumnDict(t, fa, FlamegraphFieldFunctionFileName, columns.functionFileNames)
+			requireColumnBinaryDict(t, fa, FlamegraphFieldFunctionName, columns.functionNames)
+			requireColumnBinaryDict(t, fa, FlamegraphFieldFunctionSystemName, columns.functionSystemNames)
+			requireColumnBinaryDict(t, fa, FlamegraphFieldFunctionFileName, columns.functionFileNames)
 			requireColumn(t, fa, FlamegraphFieldCumulative, columns.cumulative)
 			requireColumn(t, fa, FlamegraphFieldDiff, columns.diff)
 			requireColumnChildren(t, fa, columns.children)
@@ -485,11 +490,11 @@ func TestGenerateFlamegraphArrowWithInlined(t *testing.T) {
 	require.Equal(t, int32(5), height)
 	require.Equal(t, int64(0), trimmed)
 
-	require.Equal(t, int64(16), record.NumCols())
+	require.Equal(t, int64(17), record.NumCols())
 	require.Equal(t, int64(5), record.NumRows())
 
 	rows := []flamegraphRow{
-		{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0, LocationFolded: false, LocationLine: 0, FunctionStartLine: 0, FunctionName: "net.(*netFD).accept", FunctionSystemName: "net.(*netFD).accept", FunctionFilename: "net/fd_unix.go", Cumulative: 1, Labels: nil, Children: []uint32{1}},                                                           // 0
+		{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0, LocationFolded: false, LocationLine: 0, FunctionStartLine: 0, FunctionName: "", FunctionSystemName: "", FunctionFilename: "", Cumulative: 1, Labels: nil, Children: []uint32{1}},                                                                                                               // 0
 		{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationFolded: false, LocationLine: 173, FunctionStartLine: 0, FunctionName: "net.(*netFD).accept", FunctionSystemName: "net.(*netFD).accept", FunctionFilename: "net/fd_unix.go", Cumulative: 1, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{2}},                 // 1
 		{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationFolded: false, LocationLine: 402, FunctionStartLine: 0, FunctionName: "internal/poll.(*pollDesc).waitRead", FunctionSystemName: "internal/poll.(*pollDesc).waitRead", FunctionFilename: "internal/poll/fd_poll_runtime.go", Cumulative: 1, Labels: nil, Children: []uint32{3}}, // 2
 		{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationFolded: false, LocationLine: 89, FunctionStartLine: 0, FunctionName: "internal/poll.(*FD).Accept", FunctionSystemName: "internal/poll.(*FD).Accept", FunctionFilename: "internal/poll/fd_unix.go", Cumulative: 1, Labels: nil, Children: []uint32{4}},                          // 3
@@ -502,9 +507,9 @@ func TestGenerateFlamegraphArrowWithInlined(t *testing.T) {
 	requireColumn(t, record, FlamegraphFieldLocationFolded, columns.locationFolded)
 	requireColumn(t, record, FlamegraphFieldLocationLine, columns.locationLines)
 	requireColumn(t, record, FlamegraphFieldFunctionStartLine, columns.functionStartLines)
-	requireColumnDict(t, record, FlamegraphFieldFunctionName, columns.functionNames)
-	requireColumnDict(t, record, FlamegraphFieldFunctionSystemName, columns.functionSystemNames)
-	requireColumnDict(t, record, FlamegraphFieldFunctionFileName, columns.functionFileNames)
+	requireColumnBinaryDict(t, record, FlamegraphFieldFunctionName, columns.functionNames)
+	requireColumnBinaryDict(t, record, FlamegraphFieldFunctionSystemName, columns.functionSystemNames)
+	requireColumnBinaryDict(t, record, FlamegraphFieldFunctionFileName, columns.functionFileNames)
 	requireColumn(t, record, FlamegraphFieldCumulative, columns.cumulative)
 	requireColumnChildren(t, record, columns.children)
 }
@@ -593,7 +598,7 @@ func TestGenerateFlamegraphArrowUnsymbolized(t *testing.T) {
 			height:     5,
 			trimmed:    0, // TODO
 			rows: []flamegraphRow{
-				{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0, LocationFolded: false, LocationLine: 0, Cumulative: 6, Children: []uint32{1}},            // 0
+				{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: "", MappingBuildID: "", LocationAddress: 0, LocationFolded: false, LocationLine: 0, Cumulative: 6, Children: []uint32{1}},                // 0
 				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationFolded: false, LocationLine: 1, Cumulative: 6, Children: []uint32{2}},    // 1
 				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationFolded: false, LocationLine: 2, Cumulative: 6, Children: []uint32{3}},    // 2
 				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationFolded: false, LocationLine: 3, Cumulative: 4, Children: []uint32{4, 5}}, // 3
@@ -609,7 +614,7 @@ func TestGenerateFlamegraphArrowUnsymbolized(t *testing.T) {
 			height:     5,
 			trimmed:    0, // TODO
 			rows: []flamegraphRow{
-				{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0, LocationFolded: false, LocationLine: 0, Cumulative: 6, Children: []uint32{1}},            // 0
+				{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: "", MappingBuildID: "", LocationAddress: 0, LocationFolded: false, LocationLine: 0, Cumulative: 6, Children: []uint32{1}},                // 0
 				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationFolded: false, LocationLine: 1, Cumulative: 6, Children: []uint32{2}},    // 1
 				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationFolded: false, LocationLine: 2, Cumulative: 6, Children: []uint32{3}},    // 2
 				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationFolded: false, LocationLine: 3, Cumulative: 4, Children: []uint32{4, 5}}, // 3
@@ -628,7 +633,7 @@ func TestGenerateFlamegraphArrowUnsymbolized(t *testing.T) {
 			require.Equal(t, tc.height, height)
 			require.Equal(t, tc.trimmed, trimmed)
 			require.Equal(t, int64(len(tc.rows)), fa.NumRows())
-			require.Equal(t, int64(16), fa.NumCols())
+			require.Equal(t, int64(17), fa.NumCols())
 
 			// Convert the numRows to columns for easier access when testing below.
 			columns := rowsToColumn(tc.rows)
@@ -636,8 +641,8 @@ func TestGenerateFlamegraphArrowUnsymbolized(t *testing.T) {
 			requireColumn(t, fa, FlamegraphFieldMappingStart, columns.mappingStart)
 			requireColumn(t, fa, FlamegraphFieldMappingLimit, columns.mappingLimit)
 			requireColumn(t, fa, FlamegraphFieldMappingOffset, columns.mappingOffset)
-			requireColumnDict(t, fa, FlamegraphFieldMappingFile, columns.mappingFiles)
-			requireColumnDict(t, fa, FlamegraphFieldMappingBuildID, columns.mappingBuildIDs)
+			requireColumnBinaryDict(t, fa, FlamegraphFieldMappingFile, columns.mappingFiles)
+			requireColumnBinaryDict(t, fa, FlamegraphFieldMappingBuildID, columns.mappingBuildIDs)
 			requireColumn(t, fa, FlamegraphFieldLocationAddress, columns.locationAddresses)
 			requireColumn(t, fa, FlamegraphFieldLocationFolded, columns.locationFolded)
 			requireColumn(t, fa, FlamegraphFieldCumulative, columns.cumulative)

--- a/ui/packages/shared/profile/src/GraphTooltipArrow/Content.tsx
+++ b/ui/packages/shared/profile/src/GraphTooltipArrow/Content.tsx
@@ -182,7 +182,9 @@ const TooltipMetaInfo = ({
   const functionFilename: string = table.getChild(FIELD_FUNCTION_FILE_NAME)?.get(row) ?? '';
   const functionStartLine: bigint = table.getChild(FIELD_FUNCTION_START_LINE)?.get(row) ?? 0n;
   const pprofLabelPrefix = 'pprof_labels.';
-  const labelColumnNames = table.schema.fields.filter((field) => field.name.startsWith(pprofLabelPrefix));
+  const labelColumnNames = table.schema.fields.filter(field =>
+    field.name.startsWith(pprofLabelPrefix)
+  );
 
   const getTextForFile = (): string => {
     if (functionFilename === '') return '<unknown>';
@@ -195,18 +197,22 @@ const TooltipMetaInfo = ({
   };
   const file = getTextForFile();
 
-  const labelPairs = labelColumnNames.map((field, i) => [labelColumnNames[i].name.slice(pprofLabelPrefix.length), table.getChild(field.name)?.get(row) ?? '']).filter((value) => value[1] !== '')
-  const labels = labelPairs
-    .map(
-      (l): React.JSX.Element => (
-        <span
-          key={l[0]}
-          className="mr-3 inline-block rounded-lg bg-gray-200 px-2 py-1 text-xs font-bold text-gray-700 dark:bg-gray-700 dark:text-gray-400"
-        >
-          {`${l[0] as string}="${l[1] as string}"`}
-        </span>
-      )
-    );
+  const labelPairs = labelColumnNames
+    .map((field, i) => [
+      labelColumnNames[i].name.slice(pprofLabelPrefix.length),
+      table.getChild(field.name)?.get(row) ?? '',
+    ])
+    .filter(value => value[1] !== '');
+  const labels = labelPairs.map(
+    (l): React.JSX.Element => (
+      <span
+        key={l[0]}
+        className="mr-3 inline-block rounded-lg bg-gray-200 px-2 py-1 text-xs font-bold text-gray-700 dark:bg-gray-700 dark:text-gray-400"
+      >
+        {`${l[0] as string}="${l[1] as string}"`}
+      </span>
+    )
+  );
 
   return (
     <>

--- a/ui/packages/shared/profile/src/GraphTooltipArrow/Content.tsx
+++ b/ui/packages/shared/profile/src/GraphTooltipArrow/Content.tsx
@@ -181,7 +181,8 @@ const TooltipMetaInfo = ({
   const locationLine: bigint = table.getChild(FIELD_LOCATION_LINE)?.get(row) ?? 0n;
   const functionFilename: string = table.getChild(FIELD_FUNCTION_FILE_NAME)?.get(row) ?? '';
   const functionStartLine: bigint = table.getChild(FIELD_FUNCTION_START_LINE)?.get(row) ?? 0n;
-  const labelsString: string = table.getChild(FIELD_LABELS)?.get(row) ?? '{}';
+  const pprofLabelPrefix = 'pprof_labels.';
+  const labelColumnNames = table.schema.fields.filter((field) => field.name.startsWith(pprofLabelPrefix));
 
   const getTextForFile = (): string => {
     if (functionFilename === '') return '<unknown>';
@@ -194,17 +195,15 @@ const TooltipMetaInfo = ({
   };
   const file = getTextForFile();
 
-  const labels = Object.entries(JSON.parse(labelsString))
-    .sort((a, b) => {
-      return a[0].localeCompare(b[0]);
-    })
+  const labelPairs = labelColumnNames.map((field, i) => [labelColumnNames[i].name.slice(pprofLabelPrefix.length), table.getChild(field.name)?.get(row) ?? '']).filter((value) => value[1] !== '')
+  const labels = labelPairs
     .map(
       (l): React.JSX.Element => (
         <span
           key={l[0]}
           className="mr-3 inline-block rounded-lg bg-gray-200 px-2 py-1 text-xs font-bold text-gray-700 dark:bg-gray-700 dark:text-gray-400"
         >
-          {`${l[0]}="${l[1] as string}"`}
+          {`${l[0] as string}="${l[1] as string}"`}
         </span>
       )
     );
@@ -263,7 +262,7 @@ const TooltipMetaInfo = ({
           )}
         </td>
       </tr>
-      {labelsString !== '{}' && (
+      {labelPairs.length > 0 && (
         <tr>
           <td className="w-1/4">Labels</td>
           <td className="w-3/4 break-all">{labels}</td>

--- a/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/index.tsx
@@ -37,6 +37,7 @@ import ColorStackLegend from './ColorStackLegend';
 import {IcicleNode, RowHeight, mappingColors} from './IcicleGraphNodes';
 import {extractFeature} from './utils';
 
+export const FIELD_LABELS_ONLY = 'labels_only';
 export const FIELD_MAPPING_FILE = 'mapping_file';
 export const FIELD_MAPPING_BUILD_ID = 'mapping_build_id';
 export const FIELD_LOCATION_ADDRESS = 'location_address';

--- a/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/utils.ts
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/utils.ts
@@ -17,7 +17,13 @@ import {EVERYTHING_ELSE, FEATURE_TYPES, type Feature} from '@parca/store';
 import {getLastItem} from '@parca/utilities';
 
 import {hexifyAddress} from '../../utils';
-import {FIELD_FUNCTION_NAME, FIELD_LOCATION_ADDRESS, FIELD_MAPPING_FILE} from './index';
+import {
+  FIELD_FUNCTION_NAME,
+  FIELD_LABELS,
+  FIELD_LABELS_ONLY,
+  FIELD_LOCATION_ADDRESS,
+  FIELD_MAPPING_FILE,
+} from './index';
 
 export function nodeLabel(
   table: Table<any>,
@@ -26,14 +32,18 @@ export function nodeLabel(
   showBinaryName: boolean
 ): string {
   const functionName: string | null = table.getChild(FIELD_FUNCTION_NAME)?.get(row);
+  const labelsOnly: boolean | null = table.getChild(FIELD_LABELS_ONLY)?.get(row);
+  const labels: string | null = table.getChild(FIELD_LABELS)?.get(row);
+  console.log(labelsOnly, labels);
   if (functionName !== null && functionName !== '') {
-    if (level === 1 && functionName.startsWith('{') && functionName.endsWith('}')) {
-      return Object.entries(JSON.parse(functionName))
-        .sort(([a], [b]) => a.localeCompare(b))
-        .map(([k, v]) => `${k}="${v as string}"`)
-        .join(', ');
-    }
     return functionName;
+  }
+
+  if (level === 1 && labelsOnly !== null && labelsOnly && labels !== null && labels !== '') {
+    return Object.entries(JSON.parse(labels))
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([k, v]) => `${k}="${v as string}"`)
+      .join(', ');
   }
 
   let mappingString = '';

--- a/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/utils.ts
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/utils.ts
@@ -33,16 +33,16 @@ export function nodeLabel(
 ): string {
   const functionName: string | null = table.getChild(FIELD_FUNCTION_NAME)?.get(row);
   const labelsOnly: boolean | null = table.getChild(FIELD_LABELS_ONLY)?.get(row);
-  const labels: string | null = table.getChild(FIELD_LABELS)?.get(row);
-  console.log(labelsOnly, labels);
+  const pprofLabelPrefix = 'pprof_labels.';
+  const labelColumnNames = table.schema.fields.filter((field) => field.name.startsWith(pprofLabelPrefix));
   if (functionName !== null && functionName !== '') {
     return functionName;
   }
 
-  if (level === 1 && labelsOnly !== null && labelsOnly && labels !== null && labels !== '') {
-    return Object.entries(JSON.parse(labels))
+  if (level === 1 && labelsOnly !== null && labelsOnly) {
+    return labelColumnNames.map((field, i) => [labelColumnNames[i].name.slice(pprofLabelPrefix.length), table.getChild(field.name)?.get(row) ?? '']).filter((value) => value[1] !== '')
       .sort(([a], [b]) => a.localeCompare(b))
-      .map(([k, v]) => `${k}="${v as string}"`)
+      .map(([k, v]) => `${k as string}="${v as string}"`)
       .join(', ');
   }
 

--- a/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/utils.ts
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/utils.ts
@@ -34,14 +34,20 @@ export function nodeLabel(
   const functionName: string | null = table.getChild(FIELD_FUNCTION_NAME)?.get(row);
   const labelsOnly: boolean | null = table.getChild(FIELD_LABELS_ONLY)?.get(row);
   const pprofLabelPrefix = 'pprof_labels.';
-  const labelColumnNames = table.schema.fields.filter((field) => field.name.startsWith(pprofLabelPrefix));
+  const labelColumnNames = table.schema.fields.filter(field =>
+    field.name.startsWith(pprofLabelPrefix)
+  );
   if (functionName !== null && functionName !== '') {
     return functionName;
   }
 
   if (level === 1 && labelsOnly !== null && labelsOnly) {
-    return labelColumnNames.map((field, i) => [labelColumnNames[i].name.slice(pprofLabelPrefix.length), table.getChild(field.name)?.get(row) ?? '']).filter((value) => value[1] !== '')
-      .sort(([a], [b]) => a.localeCompare(b))
+    return labelColumnNames
+      .map((field, i) => [
+        labelColumnNames[i].name.slice(pprofLabelPrefix.length),
+        table.getChild(field.name)?.get(row) ?? '',
+      ])
+      .filter(value => value[1] !== '')
       .map(([k, v]) => `${k as string}="${v as string}"`)
       .join(', ');
   }


### PR DESCRIPTION
Previously we looked at each individual string to be inserted into the resulting flamegraph, which was very inefficient since strings occur many times over. That causes dictionary building to be inefficient, but also comparisons are done on strings rather than integers.

Changing this to use dictionary unification and transposing yielded a very good performance improvement:

```
$ benchstat old.txt new.txt
name                old time/op  new time/op  delta
ArrowFlamegraph-10  5.95ms ± 0%  3.38ms ± 0%  -43.28%  (p=0.008 n=5+5)
```