### PR TITLE
Improve flamegraph rendering performance

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -247,3 +247,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.3.0 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+replace github.com/apache/arrow/go/v13 => github.com/brancz/arrow/go/v13 v13.0.0-20230822143732-dc4d10fb562d

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/nanmu42/limitio v1.0.0
 	github.com/oklog/run v1.1.0
 	github.com/parquet-go/parquet-go v0.17.0
-	github.com/polarsignals/frostdb v0.0.0-20230821093112-02bf1156bc12
+	github.com/polarsignals/frostdb v0.0.0-20230822164836-f16400a97239
 	github.com/prometheus/client_golang v1.16.0
 	github.com/prometheus/common v0.44.0
 	github.com/prometheus/prometheus v0.46.0

--- a/go.sum
+++ b/go.sum
@@ -766,8 +766,8 @@ github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6J
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/polarsignals/frostdb v0.0.0-20230821093112-02bf1156bc12 h1:W7FTAcqvJq1tuCqNezsfgSTxold2R3ywfgseA7YVxvE=
-github.com/polarsignals/frostdb v0.0.0-20230821093112-02bf1156bc12/go.mod h1:PAwdMGKDDXIXxnJ9BJPiD5wTfXXoVtpcfcwWJk/ULSo=
+github.com/polarsignals/frostdb v0.0.0-20230822164836-f16400a97239 h1:PiOOqzmvFSLT5iN/0hvFLG7W0JoMj7pSUkmYfB8Y5jA=
+github.com/polarsignals/frostdb v0.0.0-20230822164836-f16400a97239/go.mod h1:PAwdMGKDDXIXxnJ9BJPiD5wTfXXoVtpcfcwWJk/ULSo=
 github.com/polarsignals/wal v0.0.0-20230809145250-99ef415c5a6c h1:fVYVdHe8YeIXkmYr+JRNtrobo53lYthop0jXqS6Xamk=
 github.com/polarsignals/wal v0.0.0-20230809145250-99ef415c5a6c/go.mod h1:EVDHAAe+7GQ33A1/x+/gE+sBPN4toQ0XG5RoLD49xr8=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=

--- a/go.sum
+++ b/go.sum
@@ -87,8 +87,6 @@ github.com/aliyun/aliyun-oss-go-sdk v2.2.2+incompatible/go.mod h1:T/Aws4fEfogEE9
 github.com/andybalholm/brotli v1.0.5 h1:8uQZIdzKmjc/iuPu7O2ioW48L81FgatrcpfFmiq/cCs=
 github.com/andybalholm/brotli v1.0.5/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
-github.com/apache/arrow/go/v13 v13.0.0-20230820205410-6357c9f2419d h1:qkzYYjz8XpLTY7N//pPlkFB9hOgiTLfNUEHuLEu7RfY=
-github.com/apache/arrow/go/v13 v13.0.0-20230820205410-6357c9f2419d/go.mod h1:W69eByFNO0ZR30q1/7Sr9d83zcVZmF2MiP3fFYAWJOc=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
@@ -143,6 +141,8 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/bits-and-blooms/bitset v1.2.0 h1:Kn4yilvwNtMACtf1eYDlG8H77R07mZSPbMjLyS07ChA=
 github.com/bits-and-blooms/bitset v1.2.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
+github.com/brancz/arrow/go/v13 v13.0.0-20230822143732-dc4d10fb562d h1:h40GXENjnzfm2O86PeVDExGoGeTri28VyrGOf6+9Spo=
+github.com/brancz/arrow/go/v13 v13.0.0-20230822143732-dc4d10fb562d/go.mod h1:W69eByFNO0ZR30q1/7Sr9d83zcVZmF2MiP3fFYAWJOc=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/bytedance/sonic v1.9.1 h1:6iJ6NqdoxCDr6mbY8h18oSO+cShGSMRGCEo7F2h0x8s=
 github.com/bytedance/sonic v1.9.1/go.mod h1:i736AoUSYt75HyZLoJW9ERYxcy6eaN6h4BZXU064P/U=

--- a/pkg/profile/reader.go
+++ b/pkg/profile/reader.go
@@ -27,7 +27,7 @@ type LabelColumn struct {
 
 type Reader struct {
 	Profile       Profile
-	RecordReaders []RecordReader
+	RecordReaders []*RecordReader
 }
 
 type RecordReader struct {
@@ -74,7 +74,7 @@ func NewReader(p Profile) Reader {
 	return r
 }
 
-func NewRecordReader(ar arrow.Record) RecordReader {
+func NewRecordReader(ar arrow.Record) *RecordReader {
 	schema := ar.Schema()
 
 	labelFields := make([]arrow.Field, 0, schema.NumFields())
@@ -120,7 +120,7 @@ func NewRecordReader(ar arrow.Record) RecordReader {
 	valueColumn := ar.Column(labelNum + 1).(*array.Int64)
 	diffColumn := ar.Column(labelNum + 2).(*array.Int64)
 
-	return RecordReader{
+	return &RecordReader{
 		Record:                     ar,
 		LabelFields:                labelFields,
 		LabelColumns:               labelColumns,

--- a/pkg/query/flamegraph_arrow.go
+++ b/pkg/query/flamegraph_arrow.go
@@ -289,7 +289,7 @@ func generateFlamegraphArrowRecord(ctx context.Context, mem memory.Allocator, tr
 }
 
 func (fb *flamegraphBuilder) labelsEqual(
-	r profile.RecordReader,
+	r *profile.RecordReader,
 	t *transpositions,
 	recordLabelIndex map[string]int,
 	sampleIndex int,
@@ -305,7 +305,7 @@ func (fb *flamegraphBuilder) labelsEqual(
 }
 
 func (fb *flamegraphBuilder) labelEqual(
-	r profile.RecordReader,
+	r *profile.RecordReader,
 	t *transpositions,
 	recordLabelIndex map[string]int,
 	sampleIndex int,
@@ -376,7 +376,7 @@ func (t *transpositions) Release() {
 	}
 }
 
-func (fb *flamegraphBuilder) newTranspositions(r profile.RecordReader) (*transpositions, error) {
+func (fb *flamegraphBuilder) newTranspositions(r *profile.RecordReader) (*transpositions, error) {
 	mappingIDIndicesData, mappingIDIndices, err := transpositionFromDict(fb.builderMappingBuildIDDictUnifier, r.MappingBuildIDDict)
 	if err != nil {
 		return nil, fmt.Errorf("unify and transpose mapping build id dict: %w", err)
@@ -504,7 +504,7 @@ func (fb *flamegraphBuilder) labelExists(labelFieldName string) bool {
 
 // mergeSymbolizedRows compares the symbolized fields by function name and labels and merges them if they equal.
 func (fb *flamegraphBuilder) mergeSymbolizedRows(
-	r profile.RecordReader,
+	r *profile.RecordReader,
 	t *transpositions,
 	recordLabelIndex map[string]int,
 	aggregateFields map[string]struct{},
@@ -541,7 +541,7 @@ func (fb *flamegraphBuilder) mergeSymbolizedRows(
 
 // mergeUnsymbolizedRows compares the addresses only and ignores potential function names as they are not available.
 func (fb *flamegraphBuilder) mergeUnsymbolizedRows(
-	r profile.RecordReader,
+	r *profile.RecordReader,
 	t *transpositions,
 	aggregateLabels bool,
 	recordLabelIndex map[string]int,
@@ -569,7 +569,7 @@ func (fb *flamegraphBuilder) mergeUnsymbolizedRows(
 }
 
 func (fb *flamegraphBuilder) intersectLabels(
-	r profile.RecordReader,
+	r *profile.RecordReader,
 	t *transpositions,
 	recordLabelIndex map[string]int,
 	sampleIndex int,
@@ -585,7 +585,7 @@ func (fb *flamegraphBuilder) intersectLabels(
 }
 
 func (fb *flamegraphBuilder) equalField(
-	r profile.RecordReader,
+	r *profile.RecordReader,
 	t *transpositions,
 	recordLabelIndex map[string]int,
 	fieldName string,
@@ -953,7 +953,7 @@ func (fb *flamegraphBuilder) Release() {
 }
 
 func (fb *flamegraphBuilder) appendRow(
-	r profile.RecordReader,
+	r *profile.RecordReader,
 	t *transpositions,
 	recordLabelIndex map[string]int,
 	sampleRow, locationRow, lineRow int,
@@ -1057,7 +1057,7 @@ func (fb *flamegraphBuilder) appendRow(
 }
 
 func (fb *flamegraphBuilder) AppendLabelRow(
-	r profile.RecordReader,
+	r *profile.RecordReader,
 	t *transpositions,
 	recordLabelIndex map[string]int,
 	row int,
@@ -1110,7 +1110,7 @@ func (fb *flamegraphBuilder) AppendLabelRow(
 }
 
 // addRowValues updates the existing row's values and potentially adding existing values on top.
-func (fb *flamegraphBuilder) addRowValues(r profile.RecordReader, row, sampleRow int) {
+func (fb *flamegraphBuilder) addRowValues(r *profile.RecordReader, row, sampleRow int) {
 	fb.builderCumulative.Add(row, r.Value.Value(sampleRow))
 	if r.Diff.Value(sampleRow) != 0 {
 		fb.builderDiff.Add(row, r.Diff.Value(sampleRow))


### PR DESCRIPTION
With these changes we can render ~800k unique stacks within ~2s. There's still more that can be done, but I felt like this would be a good check in.

All these changes have already been verified to be working as expected by running them on Polar Signals Cloud for some time.