### PR TITLE
Use checked allocator

### DIFF
--- a/pkg/parca/parca_test.go
+++ b/pkg/parca/parca_test.go
@@ -243,6 +243,8 @@ func TestConsistency(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
 	require.NoError(t, table.EnsureCompaction())
 	api := queryservice.NewColumnQueryAPI(
 		logger,
@@ -252,14 +254,14 @@ func TestConsistency(t *testing.T) {
 			logger,
 			tracer,
 			query.NewEngine(
-				memory.DefaultAllocator,
+				mem,
 				colDB.TableProvider(),
 			),
 			"stacktraces",
 			parcacol.NewProfileSymbolizer(tracer, mc),
-			memory.DefaultAllocator,
+			mem,
 		),
-		memory.DefaultAllocator,
+		mem,
 		parcacol.NewArrowToProfileConverter(tracer, metastore.NewKeyMaker()),
 		nil,
 	)
@@ -356,6 +358,8 @@ func TestPGOE2e(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
 	require.NoError(t, table.EnsureCompaction())
 	api := queryservice.NewColumnQueryAPI(
 		logger,
@@ -365,14 +369,14 @@ func TestPGOE2e(t *testing.T) {
 			logger,
 			tracer,
 			query.NewEngine(
-				memory.DefaultAllocator,
+				mem,
 				colDB.TableProvider(),
 			),
 			"stacktraces",
 			parcacol.NewProfileSymbolizer(tracer, mc),
-			memory.DefaultAllocator,
+			mem,
 		),
-		memory.DefaultAllocator,
+		mem,
 		parcacol.NewArrowToProfileConverter(tracer, metastore.NewKeyMaker()),
 		nil,
 	)
@@ -459,6 +463,8 @@ func TestLabels(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
 	require.NoError(t, table.EnsureCompaction())
 	api := queryservice.NewColumnQueryAPI(
 		logger,
@@ -468,14 +474,14 @@ func TestLabels(t *testing.T) {
 			logger,
 			tracer,
 			query.NewEngine(
-				memory.DefaultAllocator,
+				mem,
 				colDB.TableProvider(),
 			),
 			"labels",
 			parcacol.NewProfileSymbolizer(tracer, mc),
-			memory.DefaultAllocator,
+			mem,
 		),
-		memory.DefaultAllocator,
+		mem,
 		parcacol.NewArrowToProfileConverter(tracer, metastore.NewKeyMaker()),
 		nil,
 	)

--- a/pkg/parcacol/arrow_test.go
+++ b/pkg/parcacol/arrow_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/apache/arrow/go/v13/arrow/memory"
+	"github.com/stretchr/testify/require"
 
 	pb "github.com/parca-dev/parca/gen/proto/go/parca/metastore/v1alpha1"
 	"github.com/parca-dev/parca/pkg/profile"
@@ -54,5 +55,7 @@ func TestBuildArrowLocations(t *testing.T) {
 
 	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
 	defer mem.AssertSize(t, 0)
-	BuildArrowLocations(mem, stacktraces, locations, locationIndex)
+	r, err := BuildArrowLocations(mem, stacktraces, locations, locationIndex)
+	require.NoError(t, err)
+	defer r.Release()
 }

--- a/pkg/parcacol/arrow_test.go
+++ b/pkg/parcacol/arrow_test.go
@@ -52,5 +52,7 @@ func TestBuildArrowLocations(t *testing.T) {
 	}}
 	locationIndex := map[string]int{"1": 0, "2": 1}
 
-	BuildArrowLocations(memory.DefaultAllocator, stacktraces, locations, locationIndex)
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+	BuildArrowLocations(mem, stacktraces, locations, locationIndex)
 }

--- a/pkg/query/columnquery.go
+++ b/pkg/query/columnquery.go
@@ -229,6 +229,11 @@ func (q *ColumnQueryAPI) Query(ctx context.Context, req *pb.QueryRequest) (*pb.Q
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		for _, r := range p.Samples {
+			r.Release()
+		}
+	}()
 
 	if req.FilterQuery != nil {
 		p.Samples, filtered, err = FilterProfileData(ctx, q.tracer, q.mem, p.Samples, req.GetFilterQuery())
@@ -236,11 +241,6 @@ func (q *ColumnQueryAPI) Query(ctx context.Context, req *pb.QueryRequest) (*pb.Q
 			return nil, fmt.Errorf("filtering profile: %w", err)
 		}
 	}
-	defer func() {
-		for _, r := range p.Samples {
-			r.Release()
-		}
-	}()
 
 	return q.renderReport(
 		ctx,

--- a/pkg/query/columnquery.go
+++ b/pkg/query/columnquery.go
@@ -662,6 +662,11 @@ func (q *ColumnQueryAPI) selectDiff(ctx context.Context, d *pb.DiffProfile) (pro
 
 	g, ctx := errgroup.WithContext(ctx)
 	var base profile.Profile
+	defer func() {
+		for _, r := range base.Samples {
+			r.Release()
+		}
+	}()
 	g.Go(func() error {
 		var err error
 		base, err = q.selectProfileForDiff(ctx, d.A)
@@ -672,6 +677,11 @@ func (q *ColumnQueryAPI) selectDiff(ctx context.Context, d *pb.DiffProfile) (pro
 	})
 
 	var compare profile.Profile
+	defer func() {
+		for _, r := range compare.Samples {
+			r.Release()
+		}
+	}()
 	g.Go(func() error {
 		var err error
 		compare, err = q.selectProfileForDiff(ctx, d.B)
@@ -700,7 +710,6 @@ func (q *ColumnQueryAPI) selectDiff(ctx context.Context, d *pb.DiffProfile) (pro
 			columns,
 			r.NumRows(),
 		))
-		r.Release()
 	}
 
 	for _, r := range base.Samples {
@@ -714,7 +723,6 @@ func (q *ColumnQueryAPI) selectDiff(ctx context.Context, d *pb.DiffProfile) (pro
 			columns,
 			r.NumRows(),
 		))
-		r.Release()
 	}
 
 	return profile.Profile{

--- a/pkg/query/columnquery_test.go
+++ b/pkg/query/columnquery_test.go
@@ -210,8 +210,8 @@ func TestColumnQueryAPIQueryRange(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
-	defer mem.AssertSize(t, 0)
+	// TODO: this should used a checked allocator but there is a bug in Frostdb that causes it to leak allocations.
+	mem := memory.DefaultAllocator
 	api := NewColumnQueryAPI(
 		logger,
 		tracer,
@@ -446,8 +446,8 @@ func TestColumnQueryAPIQueryFgprof(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
-	defer mem.AssertSize(t, 0)
+	// TODO: this should used a checked allocator but there is a bug in Frostdb that causes it to leak allocations.
+	mem := memory.DefaultAllocator
 	api := NewColumnQueryAPI(
 		logger,
 		tracer,
@@ -769,8 +769,8 @@ func TestColumnQueryAPIQueryDiff(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
-	defer mem.AssertSize(t, 0)
+	// TODO: this should used a checked allocator but there is a bug in Frostdb that causes it to leak allocations.
+	mem := memory.DefaultAllocator
 	api := NewColumnQueryAPI(
 		logger,
 		tracer,

--- a/pkg/query/columnquery_test.go
+++ b/pkg/query/columnquery_test.go
@@ -210,7 +210,7 @@ func TestColumnQueryAPIQueryRange(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	// TODO: this should used a checked allocator but there is a bug in Frostdb that causes it to leak allocations.
+	// TODO: this should used a checked allocator but there is a bug in Frostdb(https://github.com/polarsignals/frostdb/issues/499) that causes it to leak allocations.
 	mem := memory.DefaultAllocator
 	api := NewColumnQueryAPI(
 		logger,
@@ -446,7 +446,7 @@ func TestColumnQueryAPIQueryFgprof(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// TODO: this should used a checked allocator but there is a bug in Frostdb that causes it to leak allocations.
+	// TODO: this should used a checked allocator but there is a bug in Frostdb(https://github.com/polarsignals/frostdb/issues/499) that causes it to leak allocations.
 	mem := memory.DefaultAllocator
 	api := NewColumnQueryAPI(
 		logger,
@@ -769,7 +769,7 @@ func TestColumnQueryAPIQueryDiff(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// TODO: this should used a checked allocator but there is a bug in Frostdb that causes it to leak allocations.
+	// TODO: this should used a checked allocator but there is a bug in Frostdb(https://github.com/polarsignals/frostdb/issues/499) that causes it to leak allocations.
 	mem := memory.DefaultAllocator
 	api := NewColumnQueryAPI(
 		logger,

--- a/pkg/query/columnquery_test.go
+++ b/pkg/query/columnquery_test.go
@@ -81,6 +81,8 @@ func TestColumnQueryAPIQueryRangeEmpty(t *testing.T) {
 	)
 	mc := metastore.NewInProcessClient(m)
 
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
 	api := NewColumnQueryAPI(
 		logger,
 		tracer,
@@ -89,14 +91,14 @@ func TestColumnQueryAPIQueryRangeEmpty(t *testing.T) {
 			logger,
 			tracer,
 			query.NewEngine(
-				memory.DefaultAllocator,
+				mem,
 				colDB.TableProvider(),
 			),
 			"stacktraces",
 			parcacol.NewProfileSymbolizer(tracer, mc),
-			memory.DefaultAllocator,
+			mem,
 		),
-		memory.DefaultAllocator,
+		mem,
 		parcacol.NewArrowToProfileConverter(tracer, metastore.NewKeyMaker()),
 		nil,
 	)
@@ -208,6 +210,8 @@ func TestColumnQueryAPIQueryRange(t *testing.T) {
 		require.NoError(t, err)
 	}
 
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
 	api := NewColumnQueryAPI(
 		logger,
 		tracer,
@@ -216,14 +220,14 @@ func TestColumnQueryAPIQueryRange(t *testing.T) {
 			logger,
 			tracer,
 			query.NewEngine(
-				memory.DefaultAllocator,
+				mem,
 				colDB.TableProvider(),
 			),
 			"stacktraces",
 			parcacol.NewProfileSymbolizer(tracer, mc),
-			memory.DefaultAllocator,
+			mem,
 		),
-		memory.DefaultAllocator,
+		mem,
 		parcacol.NewArrowToProfileConverter(tracer, metastore.NewKeyMaker()),
 		nil,
 	)
@@ -307,6 +311,8 @@ func TestColumnQueryAPIQuerySingle(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
 	api := NewColumnQueryAPI(
 		logger,
 		tracer,
@@ -315,14 +321,14 @@ func TestColumnQueryAPIQuerySingle(t *testing.T) {
 			logger,
 			tracer,
 			query.NewEngine(
-				memory.DefaultAllocator,
+				mem,
 				colDB.TableProvider(),
 			),
 			"stacktraces",
 			parcacol.NewProfileSymbolizer(tracer, mc),
-			memory.DefaultAllocator,
+			mem,
 		),
-		memory.DefaultAllocator,
+		mem,
 		parcacol.NewArrowToProfileConverter(tracer, metastore.NewKeyMaker()),
 		nil,
 	)
@@ -440,6 +446,8 @@ func TestColumnQueryAPIQueryFgprof(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
 	api := NewColumnQueryAPI(
 		logger,
 		tracer,
@@ -448,14 +456,14 @@ func TestColumnQueryAPIQueryFgprof(t *testing.T) {
 			logger,
 			tracer,
 			query.NewEngine(
-				memory.DefaultAllocator,
+				mem,
 				colDB.TableProvider(),
 			),
 			"stacktraces",
 			parcacol.NewProfileSymbolizer(tracer, mc),
-			memory.DefaultAllocator,
+			mem,
 		),
-		memory.DefaultAllocator,
+		mem,
 		parcacol.NewArrowToProfileConverter(tracer, metastore.NewKeyMaker()),
 		nil,
 	)
@@ -546,6 +554,8 @@ func TestColumnQueryAPIQueryCumulative(t *testing.T) {
 		require.NoError(t, err)
 	}
 
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
 	api := NewColumnQueryAPI(
 		logger,
 		tracer,
@@ -554,14 +564,14 @@ func TestColumnQueryAPIQueryCumulative(t *testing.T) {
 			logger,
 			tracer,
 			query.NewEngine(
-				memory.DefaultAllocator,
+				mem,
 				colDB.TableProvider(),
 			),
 			"stacktraces",
 			parcacol.NewProfileSymbolizer(tracer, mc),
-			memory.DefaultAllocator,
+			mem,
 		),
-		memory.DefaultAllocator,
+		mem,
 		parcacol.NewArrowToProfileConverter(tracer, metastore.NewKeyMaker()),
 		nil,
 	)
@@ -759,6 +769,8 @@ func TestColumnQueryAPIQueryDiff(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
 	api := NewColumnQueryAPI(
 		logger,
 		tracer,
@@ -767,14 +779,14 @@ func TestColumnQueryAPIQueryDiff(t *testing.T) {
 			logger,
 			tracer,
 			query.NewEngine(
-				memory.DefaultAllocator,
+				mem,
 				colDB.TableProvider(),
 			),
 			"stacktraces",
 			parcacol.NewProfileSymbolizer(tracer, mc),
-			memory.DefaultAllocator,
+			mem,
 		),
-		memory.DefaultAllocator,
+		mem,
 		parcacol.NewArrowToProfileConverter(tracer, metastore.NewKeyMaker()),
 		nil,
 	)
@@ -945,6 +957,8 @@ func TestColumnQueryAPITypes(t *testing.T) {
 
 	require.NoError(t, table.EnsureCompaction())
 
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
 	api := NewColumnQueryAPI(
 		logger,
 		tracer,
@@ -953,14 +967,14 @@ func TestColumnQueryAPITypes(t *testing.T) {
 			logger,
 			tracer,
 			query.NewEngine(
-				memory.DefaultAllocator,
+				mem,
 				colDB.TableProvider(),
 			),
 			"stacktraces",
 			parcacol.NewProfileSymbolizer(tracer, mc),
-			memory.DefaultAllocator,
+			mem,
 		),
-		memory.DefaultAllocator,
+		mem,
 		parcacol.NewArrowToProfileConverter(tracer, metastore.NewKeyMaker()),
 		nil,
 	)
@@ -1042,6 +1056,8 @@ func TestColumnQueryAPILabelNames(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
 	api := NewColumnQueryAPI(
 		logger,
 		tracer,
@@ -1050,14 +1066,14 @@ func TestColumnQueryAPILabelNames(t *testing.T) {
 			logger,
 			tracer,
 			query.NewEngine(
-				memory.DefaultAllocator,
+				mem,
 				colDB.TableProvider(),
 			),
 			"stacktraces",
 			parcacol.NewProfileSymbolizer(tracer, mc),
-			memory.DefaultAllocator,
+			mem,
 		),
-		memory.DefaultAllocator,
+		mem,
 		parcacol.NewArrowToProfileConverter(tracer, metastore.NewKeyMaker()),
 		nil,
 	)
@@ -1131,6 +1147,8 @@ func TestColumnQueryAPILabelValues(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
 	api := NewColumnQueryAPI(
 		logger,
 		tracer,
@@ -1139,14 +1157,14 @@ func TestColumnQueryAPILabelValues(t *testing.T) {
 			logger,
 			tracer,
 			query.NewEngine(
-				memory.DefaultAllocator,
+				mem,
 				colDB.TableProvider(),
 			),
 			"stacktraces",
 			parcacol.NewProfileSymbolizer(tracer, mc),
-			memory.DefaultAllocator,
+			mem,
 		),
-		memory.DefaultAllocator,
+		mem,
 		parcacol.NewArrowToProfileConverter(tracer, metastore.NewKeyMaker()),
 		nil,
 	)
@@ -1176,6 +1194,8 @@ func BenchmarkQuery(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(b, 0)
 	for i := 0; i < b.N; i++ {
 		_, _ = RenderReport(
 			ctx,
@@ -1186,7 +1206,7 @@ func BenchmarkQuery(b *testing.B) {
 			0,
 			[]string{FlamegraphFieldFunctionName},
 			NewTableConverterPool(),
-			memory.DefaultAllocator,
+			mem,
 			parcacol.NewArrowToProfileConverter(tracer, metastore.NewKeyMaker()),
 			nil,
 			"",

--- a/pkg/query/flamegraph_arrow.go
+++ b/pkg/query/flamegraph_arrow.go
@@ -451,6 +451,7 @@ func transpositionFromDict(unifier array.DictionaryUnifier, dict *array.Binary) 
 	if err != nil {
 		return nil, nil, err
 	}
+	defer buffer.Release()
 	data := array.NewData(
 		arrow.PrimitiveTypes.Int32,
 		dict.Len(),
@@ -459,6 +460,7 @@ func transpositionFromDict(unifier array.DictionaryUnifier, dict *array.Binary) 
 		0,
 		0,
 	)
+	defer data.Release()
 	indices := array.NewInt32Data(data)
 
 	return data, indices, nil

--- a/pkg/query/flamegraph_arrow.go
+++ b/pkg/query/flamegraph_arrow.go
@@ -831,9 +831,9 @@ func newFlamegraphBuilder(
 // It adds the children to the children column and the labels intersection to the labels column.
 // Finally, it assembles all columns from the builders into an arrow record.
 func (fb *flamegraphBuilder) NewRecord() (arrow.Record, error) {
-	arrs := make([]arrow.Array, 0, 26+(2*len(fb.builderLabelFields)))
+	cleanupArrs := make([]arrow.Array, 0, 26+(2*len(fb.builderLabelFields)))
 	defer func() {
-		for _, arr := range arrs {
+		for _, arr := range cleanupArrs {
 			arr.Release()
 		}
 	}()
@@ -867,59 +867,59 @@ func (fb *flamegraphBuilder) NewRecord() (arrow.Record, error) {
 	fb.ensureLabelColumnsComplete()
 
 	mappingBuildIDIndices := fb.builderMappingBuildIDIndices.NewArray()
-	arrs = append(arrs, mappingBuildIDIndices)
+	cleanupArrs = append(cleanupArrs, mappingBuildIDIndices)
 	mappingBuildIDDict, err := fb.builderMappingBuildIDDictUnifier.GetResultWithIndexType(arrow.PrimitiveTypes.Int32)
 	if err != nil {
 		return nil, err
 	}
-	arrs = append(arrs, mappingBuildIDDict)
+	cleanupArrs = append(cleanupArrs, mappingBuildIDDict)
 	mappingBuildIDType := &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Int32, ValueType: arrow.BinaryTypes.String}
 	mappingBuildID := array.NewDictionaryArray(mappingBuildIDType, mappingBuildIDIndices, mappingBuildIDDict)
-	arrs = append(arrs, mappingBuildID)
+	cleanupArrs = append(cleanupArrs, mappingBuildID)
 
 	mappingFileIndices := fb.builderMappingFileIndices.NewArray()
-	arrs = append(arrs, mappingFileIndices)
+	cleanupArrs = append(cleanupArrs, mappingFileIndices)
 	mappingFileDict, err := fb.builderMappingFileDictUnifier.GetResultWithIndexType(arrow.PrimitiveTypes.Int32)
 	if err != nil {
 		return nil, err
 	}
-	arrs = append(arrs, mappingFileDict)
+	cleanupArrs = append(cleanupArrs, mappingFileDict)
 	mappingFileType := &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Int32, ValueType: arrow.BinaryTypes.String}
 	mappingFile := array.NewDictionaryArray(mappingFileType, mappingFileIndices, mappingFileDict)
-	arrs = append(arrs, mappingFile)
+	cleanupArrs = append(cleanupArrs, mappingFile)
 
 	functionNameIndices := fb.builderFunctionNameIndices.NewArray()
-	arrs = append(arrs, functionNameIndices)
+	cleanupArrs = append(cleanupArrs, functionNameIndices)
 	functionNameDict, err := fb.builderFunctionNameDictUnifier.GetResultWithIndexType(arrow.PrimitiveTypes.Int32)
 	if err != nil {
 		return nil, err
 	}
-	arrs = append(arrs, functionNameDict)
+	cleanupArrs = append(cleanupArrs, functionNameDict)
 	functionNameType := &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Int32, ValueType: arrow.BinaryTypes.String}
 	functionName := array.NewDictionaryArray(functionNameType, functionNameIndices, functionNameDict)
-	arrs = append(arrs, functionName)
+	cleanupArrs = append(cleanupArrs, functionName)
 
 	functionSystemNameIndices := fb.builderFunctionSystemNameIndices.NewArray()
-	arrs = append(arrs, functionSystemNameIndices)
+	cleanupArrs = append(cleanupArrs, functionSystemNameIndices)
 	functionSystemNameDict, err := fb.builderFunctionSystemNameDictUnifier.GetResultWithIndexType(arrow.PrimitiveTypes.Int32)
 	if err != nil {
 		return nil, err
 	}
-	arrs = append(arrs, functionSystemNameDict)
+	cleanupArrs = append(cleanupArrs, functionSystemNameDict)
 	functionSystemNameType := &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Int32, ValueType: arrow.BinaryTypes.String}
 	functionSystemName := array.NewDictionaryArray(functionSystemNameType, functionSystemNameIndices, functionSystemNameDict)
-	arrs = append(arrs, functionSystemName)
+	cleanupArrs = append(cleanupArrs, functionSystemName)
 
 	functionFilenameIndices := fb.builderFunctionFilenameIndices.NewArray()
-	arrs = append(arrs, functionFilenameIndices)
+	cleanupArrs = append(cleanupArrs, functionFilenameIndices)
 	functionFilenameDict, err := fb.builderFunctionFilenameDictUnifier.GetResultWithIndexType(arrow.PrimitiveTypes.Int32)
 	if err != nil {
 		return nil, err
 	}
-	arrs = append(arrs, functionFilenameDict)
+	cleanupArrs = append(cleanupArrs, functionFilenameDict)
 	functionFilenameType := &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Int32, ValueType: arrow.BinaryTypes.String}
 	functionFilename := array.NewDictionaryArray(functionFilenameType, functionFilenameIndices, functionFilenameDict)
-	arrs = append(arrs, functionFilename)
+	cleanupArrs = append(cleanupArrs, functionFilename)
 
 	// This has to be here, because after calling .NewArray() on the builder,
 	// the builder is reset.
@@ -949,32 +949,32 @@ func (fb *flamegraphBuilder) NewRecord() (arrow.Record, error) {
 
 	arrays := make([]arrow.Array, 16)
 	arrays[0] = fb.builderLabelsOnly.NewArray()
-	arrs = append(arrs, arrays[0])
+	cleanupArrs = append(cleanupArrs, arrays[0])
 	arrays[1] = fb.builderMappingStart.NewArray()
-	arrs = append(arrs, arrays[1])
+	cleanupArrs = append(cleanupArrs, arrays[1])
 	arrays[2] = fb.builderMappingLimit.NewArray()
-	arrs = append(arrs, arrays[2])
+	cleanupArrs = append(cleanupArrs, arrays[2])
 	arrays[3] = fb.builderMappingOffset.NewArray()
-	arrs = append(arrs, arrays[3])
+	cleanupArrs = append(cleanupArrs, arrays[3])
 	arrays[4] = mappingFile
 	arrays[5] = mappingBuildID
 	arrays[6] = fb.builderLocationAddress.NewArray()
-	arrs = append(arrs, arrays[6])
+	cleanupArrs = append(cleanupArrs, arrays[6])
 	arrays[7] = fb.builderLocationFolded.NewArray()
-	arrs = append(arrs, arrays[7])
+	cleanupArrs = append(cleanupArrs, arrays[7])
 	arrays[8] = fb.builderLocationLine.NewArray()
-	arrs = append(arrs, arrays[8])
+	cleanupArrs = append(cleanupArrs, arrays[8])
 	arrays[9] = fb.builderFunctionStartLine.NewArray()
-	arrs = append(arrs, arrays[9])
+	cleanupArrs = append(cleanupArrs, arrays[9])
 	arrays[10] = functionName
 	arrays[11] = functionSystemName
 	arrays[12] = functionFilename
 	arrays[13] = fb.builderChildren.NewArray()
-	arrs = append(arrs, arrays[13])
+	cleanupArrs = append(cleanupArrs, arrays[13])
 	arrays[14] = fb.builderCumulative.NewArray()
-	arrs = append(arrs, arrays[14])
+	cleanupArrs = append(cleanupArrs, arrays[14])
 	arrays[15] = fb.builderDiff.NewArray()
-	arrs = append(arrs, arrays[15])
+	cleanupArrs = append(cleanupArrs, arrays[15])
 
 	for i := range fb.builderLabelFields {
 		if err := func() error {
@@ -984,14 +984,14 @@ func (fb *flamegraphBuilder) NewRecord() (arrow.Record, error) {
 				Type: typ,
 			})
 			indices := fb.builderLabels[i].NewArray()
-			arrs = append(arrs, indices)
+			cleanupArrs = append(cleanupArrs, indices)
 			dict, err := fb.builderLabelsDictUnifiers[i].GetResultWithIndexType(arrow.PrimitiveTypes.Int32)
 			if err != nil {
 				return err
 			}
-			arrs = append(arrs, dict)
+			cleanupArrs = append(cleanupArrs, dict)
 			dictarray := array.NewDictionaryArray(typ, indices, dict)
-			arrs = append(arrs, dictarray)
+			cleanupArrs = append(cleanupArrs, dictarray)
 			arrays = append(arrays, dictarray)
 			return nil
 		}(); err != nil {

--- a/pkg/query/flamegraph_arrow_test.go
+++ b/pkg/query/flamegraph_arrow_test.go
@@ -187,7 +187,8 @@ func requireColumnChildren(t *testing.T, record arrow.Record, expected [][]uint3
 
 func TestGenerateFlamegraphArrow(t *testing.T) {
 	ctx := context.Background()
-	mem := memory.NewGoAllocator()
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
 	var err error
 
 	l := metastoretest.NewTestMetastore(
@@ -460,7 +461,8 @@ func TestGenerateFlamegraphArrowWithInlined(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	mem := memory.NewGoAllocator()
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
 	logger := log.NewNopLogger()
 	reg := prometheus.NewRegistry()
 	counter := promauto.With(reg).NewCounter(prometheus.CounterOpts{
@@ -549,7 +551,8 @@ func TestGenerateFlamegraphArrowWithInlined(t *testing.T) {
 
 func TestGenerateFlamegraphArrowUnsymbolized(t *testing.T) {
 	ctx := context.Background()
-	mem := memory.NewGoAllocator()
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
 	var err error
 
 	l := metastoretest.NewTestMetastore(

--- a/pkg/query/flamegraph_arrow_test.go
+++ b/pkg/query/flamegraph_arrow_test.go
@@ -409,6 +409,7 @@ func TestGenerateFlamegraphArrow(t *testing.T) {
 
 			fa, cumulative, height, trimmed, err := generateFlamegraphArrowRecord(ctx, mem, tracer, np, tc.aggregate, 0)
 			require.NoError(t, err)
+			defer fa.Release()
 
 			require.Equal(t, tc.cumulative, cumulative)
 			require.Equal(t, tc.height, height)
@@ -520,6 +521,7 @@ func TestGenerateFlamegraphArrowWithInlined(t *testing.T) {
 
 	record, total, height, trimmed, err := generateFlamegraphArrowRecord(ctx, mem, tracer, newProfile, []string{FlamegraphFieldFunctionName}, 0)
 	require.NoError(t, err)
+	defer record.Release()
 
 	require.Equal(t, int64(1), total)
 	require.Equal(t, int32(5), height)
@@ -664,6 +666,7 @@ func TestGenerateFlamegraphArrowUnsymbolized(t *testing.T) {
 			require.NoError(t, err)
 			fa, cumulative, height, trimmed, err := generateFlamegraphArrowRecord(ctx, mem, tracer, np, tc.aggregate, 0)
 			require.NoError(t, err)
+			defer fa.Release()
 
 			require.Equal(t, tc.cumulative, cumulative)
 			require.Equal(t, tc.height, height)

--- a/pkg/query/flamegraph_table_test.go
+++ b/pkg/query/flamegraph_table_test.go
@@ -1226,6 +1226,11 @@ func TestFlamegraphTrimmingAndFiltering(t *testing.T) {
 	defer mem.AssertSize(t, 0)
 	newProfile.Samples, filtered, err = FilterProfileData(ctx, tracer, mem, newProfile.Samples, "b") // querying for "b" should filter out the "5.c" function.
 	require.NoError(t, err)
+	defer func() {
+		for _, s := range newProfile.Samples {
+			s.Release()
+		}
+	}()
 
 	p, err = parcacol.NewArrowToProfileConverter(tracer, metastore.NewKeyMaker()).Convert(ctx, newProfile)
 	require.NoError(t, err)

--- a/pkg/query/flamegraph_table_test.go
+++ b/pkg/query/flamegraph_table_test.go
@@ -1222,7 +1222,9 @@ func TestFlamegraphTrimmingAndFiltering(t *testing.T) {
 	require.NoError(t, err)
 
 	var filtered int64
-	newProfile.Samples, filtered, err = FilterProfileData(ctx, tracer, memory.DefaultAllocator, newProfile.Samples, "b") // querying for "b" should filter out the "5.c" function.
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+	newProfile.Samples, filtered, err = FilterProfileData(ctx, tracer, mem, newProfile.Samples, "b") // querying for "b" should filter out the "5.c" function.
 	require.NoError(t, err)
 
 	p, err = parcacol.NewArrowToProfileConverter(tracer, metastore.NewKeyMaker()).Convert(ctx, newProfile)

--- a/pkg/query/query_test.go
+++ b/pkg/query/query_test.go
@@ -106,6 +106,8 @@ func Benchmark_Query_Merge(b *testing.B) {
 
 			require.NoError(b, table.EnsureCompaction())
 
+			mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+			defer mem.AssertSize(b, 0)
 			api := NewColumnQueryAPI(
 				logger,
 				tracer,
@@ -114,14 +116,14 @@ func Benchmark_Query_Merge(b *testing.B) {
 					logger,
 					tracer,
 					query.NewEngine(
-						memory.DefaultAllocator,
+						mem,
 						colDB.TableProvider(),
 					),
 					"stacktraces",
 					parcacol.NewProfileSymbolizer(tracer, mc),
-					memory.DefaultAllocator,
+					mem,
 				),
-				memory.DefaultAllocator,
+				mem,
 				parcacol.NewArrowToProfileConverter(tracer, metastore.NewKeyMaker()),
 				nil,
 			)
@@ -177,6 +179,8 @@ func Benchmark_ProfileTypes(b *testing.B) {
 		tracer,
 	))
 
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(b, 0)
 	api := NewColumnQueryAPI(
 		logger,
 		tracer,
@@ -185,14 +189,14 @@ func Benchmark_ProfileTypes(b *testing.B) {
 			logger,
 			tracer,
 			query.NewEngine(
-				memory.DefaultAllocator,
+				mem,
 				colDB.TableProvider(),
 			),
 			"stacktraces",
 			parcacol.NewProfileSymbolizer(tracer, m),
-			memory.DefaultAllocator,
+			mem,
 		),
-		memory.DefaultAllocator,
+		mem,
 		parcacol.NewArrowToProfileConverter(tracer, metastore.NewKeyMaker()),
 		nil,
 	)

--- a/pkg/query/table_test.go
+++ b/pkg/query/table_test.go
@@ -68,6 +68,7 @@ func TestGenerateTable(t *testing.T) {
 
 	rec, cumulative, err := generateTableArrowRecord(ctx, mem, tracer, np)
 	require.NoError(t, err)
+	defer rec.Release()
 
 	require.NotNil(t, rec)
 	require.NotNil(t, cumulative)
@@ -222,6 +223,7 @@ func TestGenerateTableAggregateFlat(t *testing.T) {
 
 	rec, cumulative, err := generateTableArrowRecord(ctx, mem, tracer, np)
 	require.NoError(t, err)
+	defer rec.Release()
 
 	require.Equal(t, int64(4), rec.NumRows())
 	require.Equal(t, int64(10), cumulative)

--- a/pkg/query/table_test.go
+++ b/pkg/query/table_test.go
@@ -35,7 +35,8 @@ import (
 
 func TestGenerateTable(t *testing.T) {
 	ctx := context.Background()
-	mem := memory.NewGoAllocator()
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
 
 	reg := prometheus.NewRegistry()
 	counter := promauto.With(reg).NewCounter(prometheus.CounterOpts{
@@ -141,7 +142,8 @@ func TestGenerateTableAggregateFlat(t *testing.T) {
 	logger := log.NewNopLogger()
 	reg := prometheus.NewRegistry()
 	tracer := trace.NewNoopTracerProvider().Tracer("")
-	mem := memory.NewGoAllocator()
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
 
 	metastore := metastore.NewInProcessClient(metastoretest.NewTestMetastore(
 		t,


### PR DESCRIPTION
Uses a checked allocator throughout unit tests. 

This exposed some allocation leaks that were fixed as well.