### PR TITLE
pkg/query: Fix how inlined functions are determined to be root

### DIFF
--- a/pkg/query/flamegraph_arrow.go
+++ b/pkg/query/flamegraph_arrow.go
@@ -228,6 +228,8 @@ func generateFlamegraphArrowRecord(ctx context.Context, mem memory.Allocator, tr
 			stacktraces:
 				// just like locations, pprof stores lines in reverse order.
 				for k := int(llOffsetEnd - 1); k >= int(llOffsetStart); k-- {
+					isRoot = isLocationRoot && !(aggregateLabels && len(sampleLabels) > 0) && k == int(llOffsetEnd-1)
+
 					// We only want to compare the rows if this is the root, and we don't aggregate the labels.
 					if isRoot {
 						fb.compareRows = copyChildren(fb.compareRows, fb.rootsRow[unsafeString(lsbytes)])


### PR DESCRIPTION
I haven't been able to write a test yet that ensures we don't break this again, but I can verify with customer data that this works as intended now.