### PR TITLE
ui/packages/profile/Table: Check functionname for empty string

### DIFF
--- a/ui/packages/shared/profile/src/Table/index.tsx
+++ b/ui/packages/shared/profile/src/Table/index.tsx
@@ -273,7 +273,7 @@ export const RowName = (table: ArrowTable, row: number): string => {
     mapping = `[${getLastItem(mappingFile) ?? ''}]`;
   }
   const functionName: string | null = table.getChild('function_name')?.get(row) ?? '';
-  if (functionName !== null) {
+  if (functionName !== null && functionName !== '') {
     return `${mapping} ${functionName}`;
   }
 


### PR DESCRIPTION
Turns out the function names are actually empty strings here and not null.
Checking for null probably doesn't hurt, so I left that in too.
