### PR TITLE
pkg/query/flamegraph_arrow: Trim using breadth-first-search

### DIFF
--- a/pkg/query/flamegraph_arrow.go
+++ b/pkg/query/flamegraph_arrow.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"sort"
 	"unsafe"
 
 	"github.com/apache/arrow/go/v14/arrow"
@@ -272,6 +273,17 @@ func generateFlamegraphArrowRecord(ctx context.Context, mem memory.Allocator, tr
 	// the last row can also have the most height.
 	fb.maxHeight = max(fb.maxHeight, fb.height)
 
+	// We need to set the first row's cumulative and diff values.
+	// We unify the dictionaries unifiers and indices into actual dictionaries.
+	// These are need for trimming and compaction later on.
+	if err := fb.prepareNewRecord(); err != nil {
+		return nil, 0, 0, 0, fmt.Errorf("failed to prepare the new record: %w", err)
+	}
+
+	if err := fb.trim(ctx, tracer, trimFraction); err != nil {
+		return nil, 0, 0, 0, fmt.Errorf("failed to trim flame graph: %w", err)
+	}
+
 	_, spanNewRecord := tracer.Start(ctx, "NewRecord")
 	defer spanNewRecord.End()
 
@@ -281,7 +293,7 @@ func generateFlamegraphArrowRecord(ctx context.Context, mem memory.Allocator, tr
 	}
 	spanNewRecord.SetAttributes(attribute.Int64("rows", record.NumRows()))
 
-	return record, fb.cumulative, fb.maxHeight + 1, 0, nil
+	return record, fb.cumulative, fb.maxHeight + 1, fb.trimmed, nil
 }
 
 func (fb *flamegraphBuilder) labelsEqual(
@@ -494,6 +506,8 @@ func (fb *flamegraphBuilder) ensureLabelColumnsComplete() {
 }
 
 func (fb *flamegraphBuilder) addLabelColumn(field arrow.Field) {
+	// We need to make sure the field has an int32 index for now.
+	field.Type = &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Int32, ValueType: arrow.BinaryTypes.Binary}
 	fb.builderLabelsDictUnifiers = append(fb.builderLabelsDictUnifiers, array.NewBinaryDictionaryUnifier(fb.pool))
 	fb.builderLabels = append(fb.builderLabels, builder.NewOptInt32Builder(arrow.PrimitiveTypes.Int32))
 	fb.builderLabelFields = append(fb.builderLabelFields, field)
@@ -713,6 +727,8 @@ type flamegraphBuilder struct {
 	diff int64
 	// This keeps track of the max height of the flame graph.
 	maxHeight int32
+	// trimmed keeps track of the values that were trimmed from the flame graph.
+	trimmed int64
 	// parent keeps track of the parent of a row. This is used to build the children array.
 	parent parent
 	// This keeps track of a row's children and will be converted to an arrow array of lists at the end.
@@ -754,6 +770,15 @@ type flamegraphBuilder struct {
 	builderChildrenValues                *array.Uint32Builder
 	builderCumulative                    *builder.OptInt64Builder
 	builderDiff                          *builder.OptInt64Builder
+
+	// Only at the last step when preparing the new record these are populated.
+	// They are also used to create compacted dictionaries and after that replaced by them.
+	mappingBuildID     *array.Dictionary
+	mappingFile        *array.Dictionary
+	functionName       *array.Dictionary
+	functionSystemName *array.Dictionary
+	functionFilename   *array.Dictionary
+	labels             []*array.Dictionary
 
 	labelNameIndex map[string]int
 }
@@ -832,50 +857,47 @@ func newFlamegraphBuilder(
 	return fb, nil
 }
 
-// NewRecord returns a new record from the builders.
-// It adds the children to the children column and the labels intersection to the labels column.
-// Finally, it assembles all columns from the builders into an arrow record.
-func (fb *flamegraphBuilder) NewRecord() (arrow.Record, error) {
-	cleanupArrs := make([]arrow.Array, 0, 26+(2*len(fb.builderLabelFields)))
+func (fb *flamegraphBuilder) prepareNewRecord() error {
+	// TODO: Do we want to clean up the builders too?
+	cleanupArrs := make([]releasable, 0, 10)
 	defer func() {
 		for _, arr := range cleanupArrs {
 			arr.Release()
 		}
 	}()
+
 	// We have manually tracked the total cumulative value.
 	// Now we set/overwrite the cumulative value for the root row (which is always the 0 row in our flame graphs).
 	fb.builderCumulative.Set(0, fb.cumulative)
 	fb.builderDiff.Set(0, fb.diff)
 
-	// We have manually tracked each row's children.
-	// So now we need to iterate over all rows in the record and append their children.
-	// We cannot do this while building the rows as we need to append the children while iterating over the rows.
-	for i := 0; i < fb.builderCumulative.Len(); i++ {
-		if i == 0 {
-			fb.builderChildren.Append(true)
-			for _, sampleLabelChildren := range fb.rootsRow {
-				for _, child := range sampleLabelChildren {
-					fb.builderChildrenValues.Append(uint32(child))
-				}
-			}
-			continue
-		}
-		if len(fb.children[i]) == 0 {
-			fb.builderChildren.AppendNull() // leaf
-		} else {
-			fb.builderChildren.Append(true)
-			for _, child := range fb.children[i] {
-				fb.builderChildrenValues.Append(uint32(child))
-			}
+	// At this point we don't care for the individual label roots anymore.
+	// We have grouped by them and their metadata before.
+	// We can combine all of them into the final children root
+	// making our lives easier later on when trimming and then creating the arrow array.
+	fb.children[0] = nil
+
+	// TODO: This shouldn't be here. Either the new hashing is stable or it should be fixed in the tests.
+	rootsRowKeys := make([]uint64, 0, len(fb.rootsRow))
+	for k := range fb.rootsRow {
+		rootsRowKeys = append(rootsRowKeys, k)
+	}
+	sort.Slice(rootsRowKeys, func(i, j int) bool { return rootsRowKeys[i] < rootsRowKeys[j] })
+
+	for _, key := range rootsRowKeys {
+		for _, child := range fb.rootsRow[key] {
+			fb.children[0] = append(fb.children[0], child)
 		}
 	}
-	fb.ensureLabelColumnsComplete()
+
+	// We want to unify the dictionaries after having created the flame graph now.
+	// They are going to be trimmed and compacted in the next step.
 
 	mappingBuildIDIndices := fb.builderMappingBuildIDIndices.NewArray()
 	cleanupArrs = append(cleanupArrs, mappingBuildIDIndices)
 	mappingBuildIDDict, err := fb.builderMappingBuildIDDictUnifier.GetResultWithIndexType(arrow.PrimitiveTypes.Int32)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	cleanupArrs = append(cleanupArrs, mappingBuildIDDict)
 	mappingBuildIDType := &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Int32, ValueType: arrow.BinaryTypes.Binary}
@@ -886,7 +908,7 @@ func (fb *flamegraphBuilder) NewRecord() (arrow.Record, error) {
 	cleanupArrs = append(cleanupArrs, mappingFileIndices)
 	mappingFileDict, err := fb.builderMappingFileDictUnifier.GetResultWithIndexType(arrow.PrimitiveTypes.Int32)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	cleanupArrs = append(cleanupArrs, mappingFileDict)
 	mappingFileType := &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Int32, ValueType: arrow.BinaryTypes.Binary}
@@ -897,7 +919,7 @@ func (fb *flamegraphBuilder) NewRecord() (arrow.Record, error) {
 	cleanupArrs = append(cleanupArrs, functionNameIndices)
 	functionNameDict, err := fb.builderFunctionNameDictUnifier.GetResultWithIndexType(arrow.PrimitiveTypes.Int32)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	cleanupArrs = append(cleanupArrs, functionNameDict)
 	functionNameType := &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Int32, ValueType: arrow.BinaryTypes.Binary}
@@ -908,7 +930,7 @@ func (fb *flamegraphBuilder) NewRecord() (arrow.Record, error) {
 	cleanupArrs = append(cleanupArrs, functionSystemNameIndices)
 	functionSystemNameDict, err := fb.builderFunctionSystemNameDictUnifier.GetResultWithIndexType(arrow.PrimitiveTypes.Int32)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	cleanupArrs = append(cleanupArrs, functionSystemNameDict)
 	functionSystemNameType := &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Int32, ValueType: arrow.BinaryTypes.Binary}
@@ -919,12 +941,61 @@ func (fb *flamegraphBuilder) NewRecord() (arrow.Record, error) {
 	cleanupArrs = append(cleanupArrs, functionFilenameIndices)
 	functionFilenameDict, err := fb.builderFunctionFilenameDictUnifier.GetResultWithIndexType(arrow.PrimitiveTypes.Int32)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	cleanupArrs = append(cleanupArrs, functionFilenameDict)
 	functionFilenameType := &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Int32, ValueType: arrow.BinaryTypes.Binary}
 	functionFilename := array.NewDictionaryArray(functionFilenameType, functionFilenameIndices, functionFilenameDict)
 	cleanupArrs = append(cleanupArrs, functionFilename)
+
+	fb.mappingBuildID = mappingBuildID
+	fb.mappingFile = mappingFile
+	fb.functionName = functionName
+	fb.functionSystemName = functionSystemName
+	fb.functionFilename = functionFilename
+
+	fb.ensureLabelColumnsComplete()
+
+	// TODO: Fix possible leaks here as this isn't properly rebased
+	for i := range fb.builderLabels {
+		indices := fb.builderLabels[i].NewArray()
+		cleanupArrs = append(cleanupArrs, indices)
+		dict, err := fb.builderLabelsDictUnifiers[i].GetResultWithIndexType(arrow.PrimitiveTypes.Int32)
+		if err != nil {
+			return err
+		}
+		cleanupArrs = append(cleanupArrs, dict)
+		typ := &arrow.DictionaryType{IndexType: indices.DataType(), ValueType: dict.DataType()}
+		fb.labels = append(fb.labels, array.NewDictionaryArray(typ, indices, dict))
+	}
+
+	return nil
+}
+
+// NewRecord returns a new record from the builders.
+// It adds the children to the children column and the labels intersection to the labels column.
+// Finally, it assembles all columns from the builders into an arrow record.
+func (fb *flamegraphBuilder) NewRecord() (arrow.Record, error) {
+	cleanupArrs := make([]arrow.Array, 0, 16+(2*len(fb.builderLabelFields)))
+	defer func() {
+		for _, arr := range cleanupArrs {
+			arr.Release()
+		}
+	}()
+
+	// We have manually tracked each row's children.
+	// So now we need to iterate over all rows in the record and append their children.
+	// We cannot do this while building the rows as we need to append the children while iterating over the rows.
+	for i := 0; i < fb.builderCumulative.Len(); i++ {
+		if len(fb.children[i]) == 0 {
+			fb.builderChildren.AppendNull() // leaf
+		} else {
+			fb.builderChildren.Append(true)
+			for _, child := range fb.children[i] {
+				fb.builderChildrenValues.Append(uint32(child))
+			}
+		}
+	}
 
 	// This has to be here, because after calling .NewArray() on the builder,
 	// the builder is reset.
@@ -935,24 +1006,24 @@ func (fb *flamegraphBuilder) NewRecord() (arrow.Record, error) {
 		{Name: FlamegraphFieldMappingStart, Type: arrow.PrimitiveTypes.Uint64},
 		{Name: FlamegraphFieldMappingLimit, Type: arrow.PrimitiveTypes.Uint64},
 		{Name: FlamegraphFieldMappingOffset, Type: arrow.PrimitiveTypes.Uint64},
-		{Name: FlamegraphFieldMappingFile, Type: mappingFileType},
-		{Name: FlamegraphFieldMappingBuildID, Type: mappingBuildIDType},
+		{Name: FlamegraphFieldMappingFile, Type: fb.mappingFile.DataType()},
+		{Name: FlamegraphFieldMappingBuildID, Type: fb.mappingBuildID.DataType()},
 		// Location
 		{Name: FlamegraphFieldLocationAddress, Type: arrow.PrimitiveTypes.Uint64},
 		{Name: FlamegraphFieldLocationFolded, Type: arrow.FixedWidthTypes.Boolean},
 		{Name: FlamegraphFieldLocationLine, Type: arrow.PrimitiveTypes.Int64},
 		// Function
 		{Name: FlamegraphFieldFunctionStartLine, Type: arrow.PrimitiveTypes.Int64},
-		{Name: FlamegraphFieldFunctionName, Type: functionNameType},
-		{Name: FlamegraphFieldFunctionSystemName, Type: functionSystemNameType},
-		{Name: FlamegraphFieldFunctionFileName, Type: functionFilenameType},
+		{Name: FlamegraphFieldFunctionName, Type: fb.functionName.DataType()},
+		{Name: FlamegraphFieldFunctionSystemName, Type: fb.functionSystemName.DataType()},
+		{Name: FlamegraphFieldFunctionFileName, Type: fb.functionFilename.DataType()},
 		// Values
 		{Name: FlamegraphFieldChildren, Type: arrow.ListOf(arrow.PrimitiveTypes.Uint32)},
 		{Name: FlamegraphFieldCumulative, Type: arrow.PrimitiveTypes.Int64},
 		{Name: FlamegraphFieldDiff, Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	}
 
-	arrays := make([]arrow.Array, 16)
+	arrays := make([]arrow.Array, 16+len(fb.labels))
 	arrays[0] = fb.builderLabelsOnly.NewArray()
 	cleanupArrs = append(cleanupArrs, arrays[0])
 	arrays[1] = fb.builderMappingStart.NewArray()
@@ -961,8 +1032,8 @@ func (fb *flamegraphBuilder) NewRecord() (arrow.Record, error) {
 	cleanupArrs = append(cleanupArrs, arrays[2])
 	arrays[3] = fb.builderMappingOffset.NewArray()
 	cleanupArrs = append(cleanupArrs, arrays[3])
-	arrays[4] = mappingFile
-	arrays[5] = mappingBuildID
+	arrays[4] = fb.mappingFile
+	arrays[5] = fb.mappingBuildID
 	arrays[6] = fb.builderLocationAddress.NewArray()
 	cleanupArrs = append(cleanupArrs, arrays[6])
 	arrays[7] = fb.builderLocationFolded.NewArray()
@@ -971,9 +1042,9 @@ func (fb *flamegraphBuilder) NewRecord() (arrow.Record, error) {
 	cleanupArrs = append(cleanupArrs, arrays[8])
 	arrays[9] = fb.builderFunctionStartLine.NewArray()
 	cleanupArrs = append(cleanupArrs, arrays[9])
-	arrays[10] = functionName
-	arrays[11] = functionSystemName
-	arrays[12] = functionFilename
+	arrays[10] = fb.functionName
+	arrays[11] = fb.functionSystemName
+	arrays[12] = fb.functionFilename
 	arrays[13] = fb.builderChildren.NewArray()
 	cleanupArrs = append(cleanupArrs, arrays[13])
 	arrays[14] = fb.builderCumulative.NewArray()
@@ -981,33 +1052,16 @@ func (fb *flamegraphBuilder) NewRecord() (arrow.Record, error) {
 	arrays[15] = fb.builderDiff.NewArray()
 	cleanupArrs = append(cleanupArrs, arrays[15])
 
-	for i := range fb.builderLabelFields {
-		if err := func() error {
-			typ := &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Int32, ValueType: arrow.BinaryTypes.Binary}
-			fields = append(fields, arrow.Field{
-				Name: fb.builderLabelFields[i].Name,
-				Type: typ,
-			})
-			indices := fb.builderLabels[i].NewArray()
-			cleanupArrs = append(cleanupArrs, indices)
-			dict, err := fb.builderLabelsDictUnifiers[i].GetResultWithIndexType(arrow.PrimitiveTypes.Int32)
-			if err != nil {
-				return err
-			}
-			cleanupArrs = append(cleanupArrs, dict)
-			dictarray := array.NewDictionaryArray(typ, indices, dict)
-			cleanupArrs = append(cleanupArrs, dictarray)
-			arrays = append(arrays, dictarray)
-			return nil
-		}(); err != nil {
-			return nil, err
-		}
+	for i, field := range fb.builderLabelFields {
+		fields = append(fields, field)
+		arrays[16+i] = fb.labels[i]
 	}
 
 	return array.NewRecord(
 		arrow.NewSchema(fields, nil),
 		arrays,
-		int64(numRows)), nil
+		int64(numRows),
+	), nil
 }
 
 func (fb *flamegraphBuilder) Release() {
@@ -1176,8 +1230,6 @@ func (fb *flamegraphBuilder) AppendLabelRow(
 		copy(newChildren, fb.children)
 		fb.children = newChildren
 	}
-	// Add this label row to the root row's children.
-	fb.children[0] = append(fb.children[0], row)
 
 	fb.builderLabelsOnly.Append(true)
 	fb.builderMappingStart.AppendNull()
@@ -1207,6 +1259,234 @@ func (fb *flamegraphBuilder) addRowValues(r *profile.RecordReader, row, sampleRo
 	fb.builderDiff.Add(row, r.Diff.Value(sampleRow))
 }
 
+func (fb *flamegraphBuilder) trim(ctx context.Context, tracer trace.Tracer, threshold float32) error {
+	_, span := tracer.Start(ctx, "trim")
+	defer span.End()
+
+	releasers := make([]releasable, 0, 3)
+	defer func() {
+		for _, r := range releasers {
+			r.Release()
+		}
+	}()
+
+	trimmedLabelsOnly := array.NewBooleanBuilder(fb.pool)
+	trimmedLabelsExist := builder.NewOptBooleanBuilder(arrow.FixedWidthTypes.Boolean)
+	trimmedMappingStart := array.NewUint64Builder(fb.pool)
+	trimmedMappingLimit := array.NewUint64Builder(fb.pool)
+	trimmedMappingOffset := array.NewUint64Builder(fb.pool)
+	trimmedMappingFileIndices := array.NewInt32Builder(fb.pool)
+	trimmedMappingBuildIDIndices := array.NewInt32Builder(fb.pool)
+	trimmedLocationAddress := array.NewUint64Builder(fb.pool)
+	trimmedLocationFolded := builder.NewOptBooleanBuilder(arrow.FixedWidthTypes.Boolean)
+	trimmedLocationLine := builder.NewOptInt64Builder(arrow.PrimitiveTypes.Int64)
+	trimmedFunctionStartLine := builder.NewOptInt64Builder(arrow.PrimitiveTypes.Int64)
+	trimmedFunctionNameIndices := array.NewInt32Builder(fb.pool)
+	trimmedFunctionSystemNameIndices := array.NewInt32Builder(fb.pool)
+	trimmedFunctionFilenameIndices := array.NewInt32Builder(fb.pool)
+	trimmedCumulative := builder.NewOptInt64Builder(arrow.PrimitiveTypes.Int64)
+	trimmedDiff := builder.NewOptInt64Builder(arrow.PrimitiveTypes.Int64)
+
+	releasers = append(releasers,
+		trimmedMappingFileIndices,
+		trimmedMappingBuildIDIndices,
+		trimmedFunctionNameIndices,
+		trimmedFunctionSystemNameIndices,
+		trimmedFunctionFilenameIndices,
+	)
+
+	var trimmedLabelsIndices []*array.Int32Builder
+	for range fb.labels {
+		ib := array.NewInt32Builder(fb.pool)
+		trimmedLabelsIndices = append(trimmedLabelsIndices, ib)
+		releasers = append(releasers, ib)
+	}
+
+	trimmedChildren := make([][]int, len(fb.children))
+
+	// initialize the queue with the root rows' children. It usually has the most amount of children.
+	trimmingQueue := queue{elements: make([]trimmingElement, 0, len(fb.children[0]))}
+	trimmingQueue.push(trimmingElement{row: 0})
+
+	// keep processing new elements until the queue is empty
+	for trimmingQueue.len() > 0 {
+		// pop the first item from the queue
+		te := trimmingQueue.pop()
+
+		copyBoolBuilderValue(fb.builderLabelsOnly, trimmedLabelsOnly, te.row)
+		copyOptBooleanBuilderValue(fb.builderLabelsExist, trimmedLabelsExist, te.row)
+		copyUint64BuilderValue(fb.builderMappingStart, trimmedMappingStart, te.row)
+		copyUint64BuilderValue(fb.builderMappingLimit, trimmedMappingLimit, te.row)
+		copyUint64BuilderValue(fb.builderMappingOffset, trimmedMappingOffset, te.row)
+		appendDictionaryIndex(fb.mappingFile, trimmedMappingFileIndices, te.row)
+		appendDictionaryIndex(fb.mappingBuildID, trimmedMappingBuildIDIndices, te.row)
+		copyUint64BuilderValue(fb.builderLocationAddress, trimmedLocationAddress, te.row)
+		copyOptBooleanBuilderValue(fb.builderLocationFolded, trimmedLocationFolded, te.row)
+		copyOptInt64BuilderValue(fb.builderLocationLine, trimmedLocationLine, te.row)
+		copyOptInt64BuilderValue(fb.builderFunctionStartLine, trimmedFunctionStartLine, te.row)
+		appendDictionaryIndex(fb.functionName, trimmedFunctionNameIndices, te.row)
+		appendDictionaryIndex(fb.functionSystemName, trimmedFunctionSystemNameIndices, te.row)
+		appendDictionaryIndex(fb.functionFilename, trimmedFunctionFilenameIndices, te.row)
+		for i := range fb.labels {
+			appendDictionaryIndex(fb.labels[i], trimmedLabelsIndices[i], te.row)
+		}
+
+		// The following two will never be null.
+		cum := fb.builderCumulative.Value(te.row)
+		trimmedCumulative.Append(cum)
+		trimmedDiff.Append(fb.builderDiff.Value(te.row))
+
+		// This gets the newly inserted row's index.
+		// It is used further down as the children's parent value when added to the trimmingQueue.
+		row := trimmedCumulative.Len() - 1
+
+		// Add this new row as child to its parent if not the root row (index 0).
+		if row != 0 {
+			if len(trimmedChildren[te.parent]) == 0 {
+				trimmedChildren[te.parent] = []int{row}
+			} else {
+				trimmedChildren[te.parent] = append(trimmedChildren[te.parent], row)
+			}
+		}
+
+		cumThreshold := float32(cum) * threshold
+		for _, cr := range fb.children[te.row] {
+			if v := fb.builderCumulative.Value(cr); v > int64(cumThreshold) {
+				// this row is above the threshold, so we need to keep it
+				// add this row to the queue to check its children.
+				trimmingQueue.push(trimmingElement{row: cr, parent: row})
+			} else {
+				// this row is below the threshold, so we need to trim it
+				fb.trimmed += v
+			}
+		}
+	}
+
+	// Next we just keep the values in the dictionaries that we need after trimming.
+	var err error
+	trimmedMappingBuildIDIndicesArray := trimmedMappingBuildIDIndices.NewArray()
+	releasers = append(releasers, trimmedMappingBuildIDIndicesArray)
+	fb.mappingBuildID, err = compactDictionary(fb.pool, array.NewDictionaryArray(
+		&arrow.DictionaryType{IndexType: trimmedMappingBuildIDIndicesArray.DataType(), ValueType: fb.mappingBuildID.DataType()},
+		trimmedMappingBuildIDIndicesArray,
+		fb.mappingBuildID.Dictionary(),
+	))
+	if err != nil {
+		return err
+	}
+	trimmedMappingFileIndicesArray := trimmedMappingFileIndices.NewArray()
+	releasers = append(releasers, trimmedMappingFileIndicesArray)
+	fb.mappingFile, err = compactDictionary(fb.pool, array.NewDictionaryArray(
+		&arrow.DictionaryType{IndexType: trimmedMappingFileIndicesArray.DataType(), ValueType: fb.mappingFile.DataType()},
+		trimmedMappingFileIndicesArray,
+		fb.mappingFile.Dictionary(),
+	))
+	if err != nil {
+		return err
+	}
+	trimmedFunctionNameIndicesArray := trimmedFunctionNameIndices.NewArray()
+	releasers = append(releasers, trimmedFunctionNameIndicesArray)
+	fb.functionName, err = compactDictionary(fb.pool, array.NewDictionaryArray(
+		&arrow.DictionaryType{IndexType: trimmedFunctionNameIndices.Type(), ValueType: fb.functionName.DataType()},
+		trimmedFunctionNameIndicesArray,
+		fb.functionName.Dictionary(),
+	))
+	if err != nil {
+		return err
+	}
+	trimmedFunctionSystemNameIndicesArray := trimmedFunctionSystemNameIndices.NewArray()
+	releasers = append(releasers, trimmedFunctionSystemNameIndicesArray)
+	fb.functionSystemName, err = compactDictionary(fb.pool, array.NewDictionaryArray(
+		&arrow.DictionaryType{IndexType: trimmedFunctionSystemNameIndices.Type(), ValueType: fb.functionSystemName.DataType()},
+		trimmedFunctionSystemNameIndicesArray,
+		fb.functionSystemName.Dictionary(),
+	))
+	if err != nil {
+		return err
+	}
+	trimmedFunctionFilenameIndicesArray := trimmedFunctionFilenameIndices.NewArray()
+	releasers = append(releasers, trimmedFunctionFilenameIndicesArray)
+	fb.functionFilename, err = compactDictionary(fb.pool, array.NewDictionaryArray(
+		&arrow.DictionaryType{IndexType: trimmedFunctionFilenameIndices.Type(), ValueType: fb.functionFilename.DataType()},
+		trimmedFunctionFilenameIndicesArray,
+		fb.functionFilename.Dictionary(),
+	))
+	if err != nil {
+		return err
+	}
+
+	trimmedLabels := make([]*array.Dictionary, 0, len(fb.labels))
+	for i, index := range trimmedLabelsIndices {
+		trimmedIndexArray := index.NewArray()
+		releasers = append(releasers, trimmedIndexArray)
+		tl, err := compactDictionary(fb.pool, array.NewDictionaryArray(
+			&arrow.DictionaryType{IndexType: trimmedIndexArray.DataType(), ValueType: fb.labels[i].Dictionary().DataType()},
+			trimmedIndexArray,
+			fb.labels[i].Dictionary(),
+		))
+		if err != nil {
+			return err
+		}
+		trimmedLabels = append(trimmedLabels, tl)
+	}
+	fb.labels = trimmedLabels
+
+	fb.builderLabelsOnly = trimmedLabelsOnly
+	fb.builderLabelsExist = trimmedLabelsExist
+	fb.builderMappingStart = trimmedMappingStart
+	fb.builderMappingLimit = trimmedMappingLimit
+	fb.builderMappingOffset = trimmedMappingOffset
+	fb.builderLocationAddress = trimmedLocationAddress
+	fb.builderLocationFolded = trimmedLocationFolded
+	fb.builderLocationLine = trimmedLocationLine
+	fb.builderFunctionStartLine = trimmedFunctionStartLine
+	fb.builderCumulative = trimmedCumulative
+	fb.builderDiff = trimmedDiff
+	fb.children = trimmedChildren
+
+	return nil
+}
+
+func copyOptInt64BuilderValue(old, new *builder.OptInt64Builder, row int) {
+	if old.IsNull(row) {
+		new.AppendNull()
+		return
+	}
+	new.Append(old.Value(row))
+}
+
+func copyUint64BuilderValue(old, new *array.Uint64Builder, row int) {
+	if old.IsNull(row) {
+		new.AppendNull()
+		return
+	}
+	new.Append(old.Value(row))
+}
+
+func copyOptBooleanBuilderValue(old, new *builder.OptBooleanBuilder, row int) {
+	if old.IsNull(row) {
+		new.AppendNull()
+		return
+	}
+	new.AppendSingle(old.Value(row))
+}
+
+func copyBoolBuilderValue(old, new *array.BooleanBuilder, row int) {
+	if old.IsNull(row) {
+		new.AppendNull()
+		return
+	}
+	new.Append(old.Value(row))
+}
+
+func appendDictionaryIndex(dict *array.Dictionary, index *array.Int32Builder, row int) {
+	if dict.IsNull(row) {
+		index.AppendNull()
+		return
+	}
+	index.Append(int32(dict.GetValueIndex(row)))
+}
+
 func isLocationRoot(end, i int) bool {
 	return i == end-1
 }
@@ -1225,6 +1505,25 @@ func (p *parent) Reset() { *p = -1 }
 func (p *parent) Get() int { return int(*p) }
 
 func (p *parent) Has() bool { return *p > -1 }
+
+type trimmingElement struct {
+	row    int
+	parent int
+}
+
+// queue is a small wrapper around a []trimmingElement used as queue
+type queue struct{ elements []trimmingElement }
+
+func (q *queue) len() int { return len(q.elements) }
+
+func (q *queue) push(i trimmingElement) { q.elements = append(q.elements, i) }
+
+// pops the first element from the queue
+func (q *queue) pop() trimmingElement {
+	v := q.elements[0]
+	q.elements = q.elements[1:]
+	return v
+}
 
 func mapsIntersection(maps []map[string]string) map[string]string {
 	if len(maps) == 0 {
@@ -1259,4 +1558,91 @@ func unsafeString(b []byte) string {
 		return ""
 	}
 	return unsafe.String(unsafe.SliceData(b), len(b))
+}
+
+type releasable interface {
+	Release()
+}
+
+// compactDictionary copies only the needed values from the old dictionary to the new dictionary.
+// Once all needed values are copied, it updates the indices referencing those values in their new place.
+func compactDictionary(mem memory.Allocator, arr *array.Dictionary) (*array.Dictionary, error) {
+	releasers := make([]releasable, 0, 3)
+	releasers = append(releasers, arr)
+	defer func() {
+		for _, r := range releasers {
+			r.Release()
+		}
+	}()
+
+	newLen := 0
+	keepValues := make([]int, arr.Dictionary().Len())
+	for i := 0; i < arr.Indices().Len(); i++ {
+		if arr.IsValid(i) {
+			if keepValues[arr.GetValueIndex(i)] == 0 {
+				// keep track of how many values we need to keep to reserve the space upfront
+				newLen++
+			}
+			keepValues[arr.GetValueIndex(i)]++
+		}
+	}
+
+	// This maps the previous index (at the key/index in this slice) to the new index (at the value of the slice).
+	newValueIndices := make([]int, arr.Dictionary().Len())
+
+	var valueBuilder array.Builder
+	switch dict := arr.Dictionary().(type) {
+	case *array.String:
+		stringBuilder := array.NewStringBuilder(mem)
+		stringBuilder.Reserve(newLen)
+		for i, count := range keepValues {
+			if count == 0 {
+				continue
+			}
+			newValueIndices[i] = stringBuilder.Len()
+			stringBuilder.Append(dict.Value(i))
+		}
+		valueBuilder = stringBuilder
+		releasers = append(releasers, stringBuilder)
+	case *array.Binary:
+		binaryBuilder := array.NewBinaryBuilder(mem, arrow.BinaryTypes.Binary)
+		binaryBuilder.Reserve(newLen)
+		for i, count := range keepValues {
+			if count == 0 {
+				continue
+			}
+			newValueIndices[i] = binaryBuilder.Len()
+			binaryBuilder.Append(dict.Value(i))
+		}
+		valueBuilder = binaryBuilder
+		releasers = append(releasers, binaryBuilder)
+	default:
+		return nil, fmt.Errorf("unsupported dictionary type %T", arr.Dictionary())
+	}
+
+	// we know how many values we need to keep, so we can reserve the space upfront
+	indexBuilder := array.NewInt32Builder(mem)
+	indexBuilder.Reserve(arr.Indices().Len())
+	releasers = append(releasers, indexBuilder)
+
+	for i := 0; i < arr.Indices().Len(); i++ {
+		if arr.IsNull(i) {
+			indexBuilder.AppendNull()
+			continue
+		}
+		oldValueIndex := arr.GetValueIndex(i)
+		newValueIndex := newValueIndices[oldValueIndex]
+		indexBuilder.Append(int32(newValueIndex))
+	}
+
+	index := indexBuilder.NewArray()
+	values := valueBuilder.NewArray()
+
+	releasers = append(releasers, index, values)
+
+	return array.NewDictionaryArray(
+		&arrow.DictionaryType{IndexType: index.DataType(), ValueType: valueBuilder.Type()},
+		index,
+		values,
+	), nil
 }

--- a/pkg/query/flamegraph_arrow.go
+++ b/pkg/query/flamegraph_arrow.go
@@ -1020,7 +1020,9 @@ func (fb *flamegraphBuilder) NewRecord() (arrow.Record, error) {
 	arrays[3] = fb.builderMappingOffset.NewArray()
 	cleanupArrs = append(cleanupArrs, arrays[3])
 	arrays[4] = fb.mappingFile
+	cleanupArrs = append(cleanupArrs, arrays[4])
 	arrays[5] = fb.mappingBuildID
+	cleanupArrs = append(cleanupArrs, arrays[5])
 	arrays[6] = fb.builderLocationAddress.NewArray()
 	cleanupArrs = append(cleanupArrs, arrays[6])
 	arrays[7] = fb.builderLocationFolded.NewArray()
@@ -1030,8 +1032,11 @@ func (fb *flamegraphBuilder) NewRecord() (arrow.Record, error) {
 	arrays[9] = fb.builderFunctionStartLine.NewArray()
 	cleanupArrs = append(cleanupArrs, arrays[9])
 	arrays[10] = fb.functionName
+	cleanupArrs = append(cleanupArrs, arrays[10])
 	arrays[11] = fb.functionSystemName
+	cleanupArrs = append(cleanupArrs, arrays[11])
 	arrays[12] = fb.functionFilename
+	cleanupArrs = append(cleanupArrs, arrays[12])
 	arrays[13] = fb.builderChildren.NewArray()
 	cleanupArrs = append(cleanupArrs, arrays[13])
 	arrays[14] = fb.builderCumulative.NewArray()
@@ -1076,13 +1081,16 @@ func (fb *flamegraphBuilder) Release() {
 	fb.builderFunctionFilenameDictUnifier.Release()
 
 	fb.builderChildren.Release()
-	// fb.builderChildrenValues.Release()
+	// fb.builderChildrenValues is released with the above
 	fb.builderCumulative.Release()
 	fb.builderDiff.Release()
 
-	if fb.mappingBuildID != nil {
-		fb.mappingBuildID.Release()
-	}
+	fb.mappingBuildID.Release()
+	fb.mappingFile.Release()
+	fb.functionName.Release()
+	fb.functionSystemName.Release()
+	fb.functionFilename.Release()
+
 	fb.preparedMappingBuildID.Release()
 	fb.preparedMappingFile.Release()
 	fb.preparedFunctionName.Release()
@@ -1474,6 +1482,7 @@ func (fb *flamegraphBuilder) trim(ctx context.Context, tracer trace.Tracer, thre
 		fb.builderLabelsExist.Release()
 	}
 	fb.builderLabelsExist = trimmedLabelsExist
+	fb.builderLabelsExist.Retain()
 
 	if fb.builderMappingStart != nil {
 		fb.builderMappingStart.Release()
@@ -1499,26 +1508,31 @@ func (fb *flamegraphBuilder) trim(ctx context.Context, tracer trace.Tracer, thre
 		fb.builderLocationFolded.Release()
 	}
 	fb.builderLocationFolded = trimmedLocationFolded
+	fb.builderLocationFolded.Retain()
 
 	if fb.builderLocationLine != nil {
 		fb.builderLocationLine.Release()
 	}
 	fb.builderLocationLine = trimmedLocationLine
+	fb.builderLocationLine.Retain()
 
 	if fb.builderFunctionStartLine != nil {
 		fb.builderFunctionStartLine.Release()
 	}
 	fb.builderFunctionStartLine = trimmedFunctionStartLine
+	fb.builderFunctionStartLine.Retain()
 
 	if fb.builderCumulative != nil {
 		fb.builderCumulative.Release()
 	}
 	fb.builderCumulative = trimmedCumulative
+	fb.builderCumulative.Retain()
 
 	if fb.builderDiff != nil {
 		fb.builderDiff.Release()
 	}
 	fb.builderDiff = trimmedDiff
+	fb.builderDiff.Retain()
 
 	fb.children = trimmedChildren
 

--- a/pkg/query/flamegraph_arrow.go
+++ b/pkg/query/flamegraph_arrow.go
@@ -1020,9 +1020,7 @@ func (fb *flamegraphBuilder) NewRecord() (arrow.Record, error) {
 	arrays[3] = fb.builderMappingOffset.NewArray()
 	cleanupArrs = append(cleanupArrs, arrays[3])
 	arrays[4] = fb.mappingFile
-	cleanupArrs = append(cleanupArrs, arrays[4])
 	arrays[5] = fb.mappingBuildID
-	cleanupArrs = append(cleanupArrs, arrays[5])
 	arrays[6] = fb.builderLocationAddress.NewArray()
 	cleanupArrs = append(cleanupArrs, arrays[6])
 	arrays[7] = fb.builderLocationFolded.NewArray()
@@ -1032,11 +1030,8 @@ func (fb *flamegraphBuilder) NewRecord() (arrow.Record, error) {
 	arrays[9] = fb.builderFunctionStartLine.NewArray()
 	cleanupArrs = append(cleanupArrs, arrays[9])
 	arrays[10] = fb.functionName
-	cleanupArrs = append(cleanupArrs, arrays[10])
 	arrays[11] = fb.functionSystemName
-	cleanupArrs = append(cleanupArrs, arrays[11])
 	arrays[12] = fb.functionFilename
-	cleanupArrs = append(cleanupArrs, arrays[12])
 	arrays[13] = fb.builderChildren.NewArray()
 	cleanupArrs = append(cleanupArrs, arrays[13])
 	arrays[14] = fb.builderCumulative.NewArray()
@@ -1454,22 +1449,19 @@ func (fb *flamegraphBuilder) trim(ctx context.Context, tracer trace.Tracer, thre
 	}
 	fb.functionFilename = functionFilename
 
-	trimmedLabels := make([]*array.Dictionary, 0, len(fb.labels))
+	trimmedLabels := make([]*array.Dictionary, 0, len(trimmedLabelsIndices))
 	for i, index := range trimmedLabelsIndices {
 		trimmedIndexArray := index.NewArray()
 		releasers = append(releasers, trimmedIndexArray)
 		tl, err := compactDictionary(fb.pool, array.NewDictionaryArray(
-			&arrow.DictionaryType{IndexType: trimmedIndexArray.DataType(), ValueType: fb.labels[i].Dictionary().DataType()},
+			&arrow.DictionaryType{IndexType: trimmedIndexArray.DataType(), ValueType: fb.preparedLabels[i].Dictionary().DataType()},
 			trimmedIndexArray,
-			fb.labels[i].Dictionary(),
+			fb.preparedLabels[i].Dictionary(),
 		))
 		if err != nil {
 			return err
 		}
 		trimmedLabels = append(trimmedLabels, tl)
-	}
-	for i := range fb.labels {
-		fb.labels[i].Release()
 	}
 	fb.labels = trimmedLabels
 

--- a/pkg/query/flamegraph_arrow_test.go
+++ b/pkg/query/flamegraph_arrow_test.go
@@ -187,8 +187,7 @@ func requireColumnChildren(t *testing.T, record arrow.Record, expected [][]uint3
 func TestGenerateFlamegraphArrow(t *testing.T) {
 	ctx := context.Background()
 	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
-	defer mem.AssertSize(t, 0)
-	var err error
+	// defer mem.AssertSize(t, 0)
 
 	l := metastoretest.NewTestMetastore(
 		t,
@@ -321,23 +320,28 @@ func TestGenerateFlamegraphArrow(t *testing.T) {
 		// expectations
 		cumulative: 10,
 		height:     5,
-		trimmed:    0, // TODO
+		trimmed:    0,
 		rows: []flamegraphRow{
-			{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: "(null)", MappingBuildID: "(null)", LocationAddress: 0, LocationFolded: false, LocationLine: 0, FunctionStartLine: 0, FunctionName: "(null)", FunctionSystemName: "(null)", FunctionFilename: "(null)", Cumulative: 10, Labels: nil, Children: []uint32{1, 3, 7, 11}},        // 0
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationFolded: false, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 2, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{2}},  // 1
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationFolded: false, LocationLine: 2, FunctionStartLine: 2, FunctionName: "2", FunctionSystemName: "2", FunctionFilename: "2", Cumulative: 2, Labels: map[string]string{"goroutine": "1"}, Children: nil},          // 2
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationFolded: false, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 1, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{4}},  // 3
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationFolded: false, LocationLine: 2, FunctionStartLine: 2, FunctionName: "2", FunctionSystemName: "2", FunctionFilename: "2", Cumulative: 1, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{5}},  // 4
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationFolded: false, LocationLine: 3, FunctionStartLine: 3, FunctionName: "3", FunctionSystemName: "3", FunctionFilename: "3", Cumulative: 1, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{6}},  // 5
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa5, LocationFolded: false, LocationLine: 5, FunctionStartLine: 5, FunctionName: "5", FunctionSystemName: "5", FunctionFilename: "5", Cumulative: 1, Labels: map[string]string{"goroutine": "1"}, Children: nil},          // 6
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationFolded: false, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 3, Labels: nil, Children: []uint32{8}},                                  // 7
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationFolded: false, LocationLine: 2, FunctionStartLine: 2, FunctionName: "2", FunctionSystemName: "2", FunctionFilename: "2", Cumulative: 3, Labels: nil, Children: []uint32{9}},                                  // 8
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationFolded: false, LocationLine: 3, FunctionStartLine: 3, FunctionName: "3", FunctionSystemName: "3", FunctionFilename: "3", Cumulative: 3, Labels: nil, Children: []uint32{10}},                                 // 9
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa4, LocationFolded: false, LocationLine: 4, FunctionStartLine: 4, FunctionName: "4", FunctionSystemName: "4", FunctionFilename: "4", Cumulative: 3, Labels: nil, Children: nil},                                          // 10
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationFolded: false, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 4, Labels: map[string]string{"goroutine": "2"}, Children: []uint32{12}}, // 11
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationFolded: false, LocationLine: 2, FunctionStartLine: 2, FunctionName: "2", FunctionSystemName: "2", FunctionFilename: "2", Cumulative: 4, Labels: map[string]string{"goroutine": "2"}, Children: []uint32{13}}, // 12
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationFolded: false, LocationLine: 3, FunctionStartLine: 3, FunctionName: "3", FunctionSystemName: "3", FunctionFilename: "3", Cumulative: 4, Labels: map[string]string{"goroutine": "2"}, Children: []uint32{14}}, // 13
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa5, LocationFolded: false, LocationLine: 5, FunctionStartLine: 5, FunctionName: "5", FunctionSystemName: "5", FunctionFilename: "5", Cumulative: 4, Labels: map[string]string{"goroutine": "2"}, Children: nil},          // 14
+			// level 0 - root
+			{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0, LocationFolded: false, LocationLine: 0, FunctionStartLine: 0, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 10, Labels: nil, Children: []uint32{1, 2, 3, 4}}, // 0
+			// level 1
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationFolded: false, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 2, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{5}}, // 1
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationFolded: false, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 1, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{6}}, // 2
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationFolded: false, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 3, Labels: nil, Children: []uint32{7}},                                 // 3
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationFolded: false, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 4, Labels: map[string]string{"goroutine": "2"}, Children: []uint32{8}}, // 4
+			// level 2
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationFolded: false, LocationLine: 2, FunctionStartLine: 2, FunctionName: "2", FunctionSystemName: "2", FunctionFilename: "2", Cumulative: 2, Labels: map[string]string{"goroutine": "1"}, Children: nil},          // 5
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationFolded: false, LocationLine: 2, FunctionStartLine: 2, FunctionName: "2", FunctionSystemName: "2", FunctionFilename: "2", Cumulative: 1, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{9}},  // 6
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationFolded: false, LocationLine: 2, FunctionStartLine: 2, FunctionName: "2", FunctionSystemName: "2", FunctionFilename: "2", Cumulative: 3, Labels: nil, Children: []uint32{10}},                                 // 7
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationFolded: false, LocationLine: 2, FunctionStartLine: 2, FunctionName: "2", FunctionSystemName: "2", FunctionFilename: "2", Cumulative: 4, Labels: map[string]string{"goroutine": "2"}, Children: []uint32{11}}, // 8
+			// level 3
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationFolded: false, LocationLine: 3, FunctionStartLine: 3, FunctionName: "3", FunctionSystemName: "3", FunctionFilename: "3", Cumulative: 1, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{12}}, // 9
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationFolded: false, LocationLine: 3, FunctionStartLine: 3, FunctionName: "3", FunctionSystemName: "3", FunctionFilename: "3", Cumulative: 3, Labels: nil, Children: []uint32{13}},                                 // 10
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationFolded: false, LocationLine: 3, FunctionStartLine: 3, FunctionName: "3", FunctionSystemName: "3", FunctionFilename: "3", Cumulative: 4, Labels: map[string]string{"goroutine": "2"}, Children: []uint32{14}}, // 11
+			// level 4
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa5, LocationFolded: false, LocationLine: 5, FunctionStartLine: 5, FunctionName: "5", FunctionSystemName: "5", FunctionFilename: "5", Cumulative: 1, Labels: map[string]string{"goroutine": "1"}, Children: nil}, // 12
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa4, LocationFolded: false, LocationLine: 4, FunctionStartLine: 4, FunctionName: "4", FunctionSystemName: "4", FunctionFilename: "4", Cumulative: 3, Labels: nil, Children: nil},                                 // 13
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa5, LocationFolded: false, LocationLine: 5, FunctionStartLine: 5, FunctionName: "5", FunctionSystemName: "5", FunctionFilename: "5", Cumulative: 4, Labels: map[string]string{"goroutine": "2"}, Children: nil}, // 14
 		},
 	}, {
 		name:      "aggregate-function-name",
@@ -345,14 +349,14 @@ func TestGenerateFlamegraphArrow(t *testing.T) {
 		// expectations
 		cumulative: 10,
 		height:     5,
-		trimmed:    0, // TODO
+		trimmed:    0,
 		rows: []flamegraphRow{
-			{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: "(null)", MappingBuildID: "(null)", LocationAddress: 0, LocationFolded: false, LocationLine: 0, FunctionStartLine: 0, FunctionName: "(null)", FunctionSystemName: "(null)", FunctionFilename: "(null)", Cumulative: 10, Labels: nil, Children: []uint32{1}}, // 0
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationFolded: false, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 10, Labels: nil, Children: []uint32{2}},                // 1
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationFolded: false, LocationLine: 2, FunctionStartLine: 2, FunctionName: "2", FunctionSystemName: "2", FunctionFilename: "2", Cumulative: 10, Labels: nil, Children: []uint32{3}},                // 2
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationFolded: false, LocationLine: 3, FunctionStartLine: 3, FunctionName: "3", FunctionSystemName: "3", FunctionFilename: "3", Cumulative: 8, Labels: nil, Children: []uint32{4, 5}},              // 3
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa5, LocationFolded: false, LocationLine: 5, FunctionStartLine: 5, FunctionName: "5", FunctionSystemName: "5", FunctionFilename: "5", Cumulative: 5, Labels: nil, Children: nil},                         // 4
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa4, LocationFolded: false, LocationLine: 4, FunctionStartLine: 4, FunctionName: "4", FunctionSystemName: "4", FunctionFilename: "4", Cumulative: 3, Labels: nil, Children: nil},                         // 5
+			{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0, LocationFolded: false, LocationLine: 0, FunctionStartLine: 0, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 10, Labels: nil, Children: []uint32{1}}, // 0
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationFolded: false, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 10, Labels: nil, Children: []uint32{2}},                                                                  // 1
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationFolded: false, LocationLine: 2, FunctionStartLine: 2, FunctionName: "2", FunctionSystemName: "2", FunctionFilename: "2", Cumulative: 10, Labels: nil, Children: []uint32{3}},                                                                  // 2
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationFolded: false, LocationLine: 3, FunctionStartLine: 3, FunctionName: "3", FunctionSystemName: "3", FunctionFilename: "3", Cumulative: 8, Labels: nil, Children: []uint32{4, 5}},                                                                // 3
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa5, LocationFolded: false, LocationLine: 5, FunctionStartLine: 5, FunctionName: "5", FunctionSystemName: "5", FunctionFilename: "5", Cumulative: 5, Labels: nil, Children: nil},                                                                           // 4
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa4, LocationFolded: false, LocationLine: 4, FunctionStartLine: 4, FunctionName: "4", FunctionSystemName: "4", FunctionFilename: "4", Cumulative: 3, Labels: nil, Children: nil},                                                                           // 5
 		},
 	}, {
 		name:      "aggregate-pprof-labels",
@@ -360,26 +364,29 @@ func TestGenerateFlamegraphArrow(t *testing.T) {
 		// expectations
 		cumulative: 10,
 		height:     6,
-		trimmed:    0, // TODO
+		trimmed:    0,
 		rows: []flamegraphRow{
-			{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: "(null)", MappingBuildID: "(null)", LocationAddress: 0, LocationFolded: false, LocationLine: 0, FunctionStartLine: 0, FunctionName: `(null)`, FunctionSystemName: "(null)", FunctionFilename: "(null)", Cumulative: 10, Labels: nil, Children: []uint32{1, 6, 10}}, // 0
-			// all of these have the same labels, so they are aggregated
-			{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: "(null)", MappingBuildID: "(null)", LocationAddress: 0, LocationFolded: false, LocationLine: 0, FunctionStartLine: 0, FunctionName: `(null)`, FunctionSystemName: "(null)", FunctionFilename: "(null)", Cumulative: 3, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{2}, LabelsOnly: true}, // 1
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationFolded: false, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 3, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{3}},                                  // 2
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationFolded: false, LocationLine: 2, FunctionStartLine: 2, FunctionName: "2", FunctionSystemName: "2", FunctionFilename: "2", Cumulative: 3, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{4}},                                  // 3
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationFolded: false, LocationLine: 3, FunctionStartLine: 3, FunctionName: "3", FunctionSystemName: "3", FunctionFilename: "3", Cumulative: 1, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{5}},                                  // 4
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa5, LocationFolded: false, LocationLine: 5, FunctionStartLine: 5, FunctionName: "5", FunctionSystemName: "5", FunctionFilename: "5", Cumulative: 1, Labels: map[string]string{"goroutine": "1"}, Children: nil},                                          // 5
-			// all of these have no labels, so they are kept separate
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationFolded: false, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 3, Labels: nil, Children: []uint32{7}}, // 6
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationFolded: false, LocationLine: 2, FunctionStartLine: 2, FunctionName: "2", FunctionSystemName: "2", FunctionFilename: "2", Cumulative: 3, Labels: nil, Children: []uint32{8}}, // 7
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationFolded: false, LocationLine: 3, FunctionStartLine: 3, FunctionName: "3", FunctionSystemName: "3", FunctionFilename: "3", Cumulative: 3, Labels: nil, Children: []uint32{9}}, // 8
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa4, LocationFolded: false, LocationLine: 4, FunctionStartLine: 4, FunctionName: "4", FunctionSystemName: "4", FunctionFilename: "4", Cumulative: 3, Labels: nil, Children: nil},         // 9
-			// the same stack as the second stack, but a different pprof label
-			{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: "(null)", MappingBuildID: "(null)", LocationAddress: 0, LocationFolded: false, LocationLine: 0, FunctionStartLine: 0, FunctionName: `(null)`, FunctionSystemName: "(null)", FunctionFilename: "(null)", Cumulative: 4, Labels: map[string]string{"goroutine": "2"}, Children: []uint32{11}, LabelsOnly: true}, // 10
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationFolded: false, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 4, Labels: map[string]string{"goroutine": "2"}, Children: []uint32{12}},                                  // 11
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationFolded: false, LocationLine: 2, FunctionStartLine: 2, FunctionName: "2", FunctionSystemName: "2", FunctionFilename: "2", Cumulative: 4, Labels: map[string]string{"goroutine": "2"}, Children: []uint32{13}},                                  // 12
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationFolded: false, LocationLine: 3, FunctionStartLine: 3, FunctionName: "3", FunctionSystemName: "3", FunctionFilename: "3", Cumulative: 4, Labels: map[string]string{"goroutine": "2"}, Children: []uint32{14}},                                  // 13
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa5, LocationFolded: false, LocationLine: 5, FunctionStartLine: 5, FunctionName: "5", FunctionSystemName: "5", FunctionFilename: "5", Cumulative: 4, Labels: map[string]string{"goroutine": "2"}, Children: nil},                                           // 14
+			// level 0 - root
+			{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0, LocationFolded: false, LocationLine: 0, FunctionStartLine: 0, FunctionName: `(null)`, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 10, Labels: nil, Children: []uint32{1, 2, 3}}, // 0
+			// level 1
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationFolded: false, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 3, Labels: nil, Children: []uint32{4}},                                                                                                          // 1
+			{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0, LocationFolded: false, LocationLine: 0, FunctionStartLine: 0, FunctionName: `(null)`, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 4, Labels: map[string]string{"goroutine": "2"}, Children: []uint32{5}, LabelsOnly: true}, // 2
+			{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0, LocationFolded: false, LocationLine: 0, FunctionStartLine: 0, FunctionName: `(null)`, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 3, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{6}, LabelsOnly: true}, // 3
+			// level 2
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationFolded: false, LocationLine: 2, FunctionStartLine: 2, FunctionName: "2", FunctionSystemName: "2", FunctionFilename: "2", Cumulative: 3, Labels: nil, Children: []uint32{7}},                                 // 4
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationFolded: false, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 4, Labels: map[string]string{"goroutine": "2"}, Children: []uint32{8}}, // 6
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationFolded: false, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 3, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{9}}, // 5
+			// level 3
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationFolded: false, LocationLine: 3, FunctionStartLine: 3, FunctionName: "3", FunctionSystemName: "3", FunctionFilename: "3", Cumulative: 3, Labels: nil, Children: []uint32{10}},                                 // 7
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationFolded: false, LocationLine: 2, FunctionStartLine: 2, FunctionName: "2", FunctionSystemName: "2", FunctionFilename: "2", Cumulative: 4, Labels: map[string]string{"goroutine": "2"}, Children: []uint32{11}}, // 9
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationFolded: false, LocationLine: 2, FunctionStartLine: 2, FunctionName: "2", FunctionSystemName: "2", FunctionFilename: "2", Cumulative: 3, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{12}}, // 8
+			// level 4
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa4, LocationFolded: false, LocationLine: 4, FunctionStartLine: 4, FunctionName: "4", FunctionSystemName: "4", FunctionFilename: "4", Cumulative: 3, Labels: nil, Children: nil},                                          // 10
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationFolded: false, LocationLine: 3, FunctionStartLine: 3, FunctionName: "3", FunctionSystemName: "3", FunctionFilename: "3", Cumulative: 4, Labels: map[string]string{"goroutine": "2"}, Children: []uint32{13}}, // 12
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationFolded: false, LocationLine: 3, FunctionStartLine: 3, FunctionName: "3", FunctionSystemName: "3", FunctionFilename: "3", Cumulative: 1, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{14}}, // 11
+			// level 5
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa5, LocationFolded: false, LocationLine: 5, FunctionStartLine: 5, FunctionName: "5", FunctionSystemName: "5", FunctionFilename: "5", Cumulative: 4, Labels: map[string]string{"goroutine": "2"}, Children: nil}, // 13
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa5, LocationFolded: false, LocationLine: 5, FunctionStartLine: 5, FunctionName: "5", FunctionSystemName: "5", FunctionFilename: "5", Cumulative: 1, Labels: map[string]string{"goroutine": "1"}, Children: nil}, // 14
 		},
 	}, {
 		name:      "aggregate-mapping-file",
@@ -390,11 +397,11 @@ func TestGenerateFlamegraphArrow(t *testing.T) {
 		trimmed:    0, // TODO
 		rows: []flamegraphRow{
 			// This aggregates all the rows with the same mapping file, meaning that we only keep one flamegraphRow per stack depth in this example.
-			{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: "(null)", MappingBuildID: "(null)", LocationAddress: 0, LocationFolded: false, LocationLine: 0, FunctionStartLine: 0, FunctionName: "(null)", FunctionSystemName: "(null)", FunctionFilename: "(null)", Cumulative: 10, Labels: nil, Children: []uint32{1}}, // 0
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationFolded: false, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 10, Labels: nil, Children: []uint32{2}},                // 1
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationFolded: false, LocationLine: 2, FunctionStartLine: 2, FunctionName: "2", FunctionSystemName: "2", FunctionFilename: "2", Cumulative: 10, Labels: nil, Children: []uint32{3}},                // 2
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationFolded: false, LocationLine: 3, FunctionStartLine: 3, FunctionName: "3", FunctionSystemName: "3", FunctionFilename: "3", Cumulative: 8, Labels: nil, Children: []uint32{4}},                 // 3
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa5, LocationFolded: false, LocationLine: 5, FunctionStartLine: 5, FunctionName: "5", FunctionSystemName: "5", FunctionFilename: "5", Cumulative: 8, Labels: nil, Children: nil},                         // 4
+			{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0, LocationFolded: false, LocationLine: 0, FunctionStartLine: 0, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 10, Labels: nil, Children: []uint32{1}}, // 0
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationFolded: false, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 10, Labels: nil, Children: []uint32{2}},                                                                  // 1
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationFolded: false, LocationLine: 2, FunctionStartLine: 2, FunctionName: "2", FunctionSystemName: "2", FunctionFilename: "2", Cumulative: 10, Labels: nil, Children: []uint32{3}},                                                                  // 2
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationFolded: false, LocationLine: 3, FunctionStartLine: 3, FunctionName: "3", FunctionSystemName: "3", FunctionFilename: "3", Cumulative: 8, Labels: nil, Children: []uint32{4}},                                                                   // 3
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa5, LocationFolded: false, LocationLine: 5, FunctionStartLine: 5, FunctionName: "5", FunctionSystemName: "5", FunctionFilename: "5", Cumulative: 8, Labels: nil, Children: nil},                                                                           // 4
 		},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -462,7 +469,7 @@ func TestGenerateFlamegraphArrowWithInlined(t *testing.T) {
 
 	ctx := context.Background()
 	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
-	defer mem.AssertSize(t, 0)
+	// defer mem.AssertSize(t, 0)
 	logger := log.NewNopLogger()
 	reg := prometheus.NewRegistry()
 	counter := promauto.With(reg).NewCounter(prometheus.CounterOpts{
@@ -553,7 +560,7 @@ func TestGenerateFlamegraphArrowWithInlined(t *testing.T) {
 func TestGenerateFlamegraphArrowUnsymbolized(t *testing.T) {
 	ctx := context.Background()
 	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
-	defer mem.AssertSize(t, 0)
+	// defer mem.AssertSize(t, 0)
 	var err error
 
 	l := metastoretest.NewTestMetastore(
@@ -689,6 +696,135 @@ func TestGenerateFlamegraphArrowUnsymbolized(t *testing.T) {
 	}
 }
 
+func TestGenerateFlamegraphArrowTrimming(t *testing.T) {
+	ctx := context.Background()
+	mem := memory.NewGoAllocator()
+	var err error
+
+	l := metastoretest.NewTestMetastore(
+		t,
+		log.NewNopLogger(),
+		prometheus.NewRegistry(),
+		trace.NewNoopTracerProvider().Tracer(""),
+	)
+
+	metastore := metastore.NewInProcessClient(l)
+
+	mres, err := metastore.GetOrCreateMappings(ctx, &metastorepb.GetOrCreateMappingsRequest{
+		Mappings: []*metastorepb.Mapping{{
+			File: "a",
+		}},
+	})
+	require.NoError(t, err)
+	m := mres.Mappings[0]
+
+	fres, err := metastore.GetOrCreateFunctions(ctx, &metastorepb.GetOrCreateFunctionsRequest{
+		Functions: []*metastorepb.Function{
+			{Name: "1"},
+			{Name: "2"},
+			{Name: "3"},
+			{Name: "4"},
+			{Name: "5"},
+		},
+	})
+	require.NoError(t, err)
+	f1 := fres.Functions[0]
+	f2 := fres.Functions[1]
+	f3 := fres.Functions[2]
+	f4 := fres.Functions[3]
+	f5 := fres.Functions[4]
+
+	lres, err := metastore.GetOrCreateLocations(ctx, &metastorepb.GetOrCreateLocationsRequest{
+		Locations: []*metastorepb.Location{{
+			MappingId: m.Id,
+			Lines: []*metastorepb.Line{{
+				FunctionId: f1.Id,
+			}},
+		}, {
+			MappingId: m.Id,
+			Lines: []*metastorepb.Line{{
+				FunctionId: f2.Id,
+			}},
+		}, {
+			MappingId: m.Id,
+			Lines: []*metastorepb.Line{{
+				FunctionId: f3.Id,
+			}},
+		}, {
+			MappingId: m.Id,
+			Lines: []*metastorepb.Line{{
+				FunctionId: f4.Id,
+			}},
+		}, {
+			MappingId: m.Id,
+			Lines: []*metastorepb.Line{{
+				FunctionId: f5.Id,
+			}},
+		}},
+	})
+	require.NoError(t, err)
+	l1 := lres.Locations[0]
+	l2 := lres.Locations[1]
+	l3 := lres.Locations[2]
+	l4 := lres.Locations[3]
+	l5 := lres.Locations[4]
+
+	sres, err := metastore.GetOrCreateStacktraces(ctx, &metastorepb.GetOrCreateStacktracesRequest{
+		Stacktraces: []*metastorepb.Stacktrace{{
+			LocationIds: []string{l2.Id, l1.Id},
+		}, {
+			LocationIds: []string{l5.Id, l3.Id, l2.Id, l1.Id},
+		}, {
+			LocationIds: []string{l4.Id, l3.Id, l2.Id, l1.Id},
+		}},
+	})
+	require.NoError(t, err)
+	s1 := sres.Stacktraces[0]
+	s2 := sres.Stacktraces[1]
+	s3 := sres.Stacktraces[2]
+
+	tracer := trace.NewNoopTracerProvider().Tracer("")
+
+	p, err := parcacol.NewProfileSymbolizer(tracer, metastore).SymbolizeNormalizedProfile(ctx, &parcaprofile.NormalizedProfile{
+		Samples: []*parcaprofile.NormalizedSample{{
+			StacktraceID: s1.Id,
+			Value:        10,
+		}, {
+			// The following two samples are trimmed from the flamegraph.
+			StacktraceID: s2.Id,
+			Value:        1,
+		}, {
+			StacktraceID: s3.Id,
+			Value:        3,
+		}},
+	})
+	require.NoError(t, err)
+
+	np, err := OldProfileToArrowProfile(p)
+	require.NoError(t, err)
+
+	fa, cumulative, height, trimmed, err := generateFlamegraphArrowRecord(ctx, mem, tracer, np, []string{FlamegraphFieldFunctionName}, float32(0.5))
+	require.NoError(t, err)
+
+	require.Equal(t, int64(14), cumulative)
+	require.Equal(t, int32(5), height)
+	require.Equal(t, int64(4), trimmed)
+	require.Equal(t, int64(3), fa.NumRows())
+	require.Equal(t, int64(16), fa.NumCols())
+
+	rows := []flamegraphRow{
+		{FunctionName: "(null)", Cumulative: 14, Children: []uint32{1}}, // 0
+		{FunctionName: "1", Cumulative: 14, Children: []uint32{2}},      // 1
+		{FunctionName: "2", Cumulative: 14, Children: nil},              // 2
+	}
+	columns := rowsToColumn(rows)
+
+	requireColumnBinaryDict(t, fa, FlamegraphFieldFunctionName, columns.functionNames)
+	requireColumn(t, fa, FlamegraphFieldCumulative, columns.cumulative)
+	requireColumn(t, fa, FlamegraphFieldDiff, columns.diff)
+	requireColumnChildren(t, fa, columns.children)
+}
+
 func TestParents(t *testing.T) {
 	p := parent(-1)
 	require.Equal(t, -1, p.Get())
@@ -774,4 +910,69 @@ func BenchmarkArrowFlamegraph(b *testing.B) {
 		)
 		require.NoError(b, err)
 	}
+}
+
+func TestCompactDictionary(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	// defer mem.AssertSize(t, 0)
+
+	builder := array.NewStringBuilder(mem)
+	builder.AppendValues([]string{"a", "b", "c"}, nil)
+	values := builder.NewArray()
+	defer values.Release()
+	defer builder.Release()
+
+	// Test two values and a single null.
+	index1Builder := array.NewInt32Builder(mem)
+	index1Builder.AppendValues([]int32{0, 0}, nil)
+	index1Builder.AppendNull()
+	index1Builder.AppendValues([]int32{0, 1}, nil)
+	index1 := index1Builder.NewArray()
+	compArr, err := compactDictionary(mem, array.NewDictionaryArray(
+		&arrow.DictionaryType{IndexType: index1.DataType(), ValueType: values.DataType()},
+		index1,
+		values,
+	))
+	require.NoError(t, err)
+	require.Equal(t, 2, compArr.Dictionary().Len()) // make sure we actually compact values.
+	require.Equal(t, "a", compArr.Dictionary().ValueStr(compArr.GetValueIndex(0)))
+	require.Equal(t, "a", compArr.Dictionary().ValueStr(compArr.GetValueIndex(1)))
+	require.True(t, compArr.IsNull(2))
+	require.Equal(t, "a", compArr.Dictionary().ValueStr(compArr.GetValueIndex(3)))
+	require.Equal(t, "b", compArr.Dictionary().ValueStr(compArr.GetValueIndex(4)))
+	index1Builder.Release()
+	index1.Release()
+	compArr.Release()
+
+	// Just one single underlying value.
+	index2Builder := array.NewInt32Builder(mem)
+	index2Builder.Append(2)
+	index2 := index2Builder.NewArray()
+	compArr, err = compactDictionary(mem, array.NewDictionaryArray(
+		&arrow.DictionaryType{IndexType: index2.DataType(), ValueType: values.DataType()},
+		index2,
+		values,
+	))
+	require.NoError(t, err)
+	require.Equal(t, 1, compArr.Dictionary().Len()) // make sure we actually compact values.
+	require.Equal(t, "c", compArr.Dictionary().ValueStr(compArr.GetValueIndex(0)))
+	index2Builder.Release()
+	index2.Release()
+	compArr.Release()
+
+	// Just one single null, no actual values.
+	index3Builder := array.NewInt32Builder(mem)
+	index3Builder.AppendNull()
+	index3 := index3Builder.NewArray()
+	compArr, err = compactDictionary(mem, array.NewDictionaryArray(
+		&arrow.DictionaryType{IndexType: index3.DataType(), ValueType: values.DataType()},
+		index3,
+		values,
+	))
+	require.NoError(t, err)
+	require.Equal(t, 0, compArr.Dictionary().Len()) // make sure we actually compact values.
+	require.True(t, compArr.IsNull(0))
+	index3Builder.Release()
+	index3.Release()
+	compArr.Release()
 }

--- a/pkg/query/flamegraph_arrow_test.go
+++ b/pkg/query/flamegraph_arrow_test.go
@@ -187,7 +187,7 @@ func requireColumnChildren(t *testing.T, record arrow.Record, expected [][]uint3
 func TestGenerateFlamegraphArrow(t *testing.T) {
 	ctx := context.Background()
 	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
-	// defer mem.AssertSize(t, 0)
+	defer mem.AssertSize(t, 0)
 
 	l := metastoretest.NewTestMetastore(
 		t,
@@ -469,7 +469,7 @@ func TestGenerateFlamegraphArrowWithInlined(t *testing.T) {
 
 	ctx := context.Background()
 	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
-	// defer mem.AssertSize(t, 0)
+	defer mem.AssertSize(t, 0)
 	logger := log.NewNopLogger()
 	reg := prometheus.NewRegistry()
 	counter := promauto.With(reg).NewCounter(prometheus.CounterOpts{
@@ -560,7 +560,7 @@ func TestGenerateFlamegraphArrowWithInlined(t *testing.T) {
 func TestGenerateFlamegraphArrowUnsymbolized(t *testing.T) {
 	ctx := context.Background()
 	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
-	// defer mem.AssertSize(t, 0)
+	defer mem.AssertSize(t, 0)
 	var err error
 
 	l := metastoretest.NewTestMetastore(
@@ -698,7 +698,9 @@ func TestGenerateFlamegraphArrowUnsymbolized(t *testing.T) {
 
 func TestGenerateFlamegraphArrowTrimming(t *testing.T) {
 	ctx := context.Background()
-	mem := memory.NewGoAllocator()
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+
 	var err error
 
 	l := metastoretest.NewTestMetastore(
@@ -914,7 +916,7 @@ func BenchmarkArrowFlamegraph(b *testing.B) {
 
 func TestCompactDictionary(t *testing.T) {
 	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
-	// defer mem.AssertSize(t, 0)
+	defer mem.AssertSize(t, 0)
 
 	builder := array.NewStringBuilder(mem)
 	builder.AppendValues([]string{"a", "b", "c"}, nil)


### PR DESCRIPTION
This adds trimming based on breadth-first-search using dictionary compaction. 

It passes the tests locally now. :relieved: :tada: 

Some TODOs are left either to fix within this PR or as follow-ups. 
- [ ] Remove the sorting of label rows from production code (required)
- [ ] Either update Arrow or use a fork for https://github.com/apache/arrow/pull/37459 (required)
- [x] Fix all the memory leaks with the CheckedAllocator (seems like there might have been leaks before)
- [ ] Potentially upstream the compactDictionary at some point later. 
