### PR TITLE
Fix double free

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ check-license:
 
 .PHONY: go/test
 go/test:
-	go test $(SANITIZERS) -v `go list ./...`
+	go test $(SANITIZERS) -tags assert -v `go list ./...`
 
 .PHONY: go/bench
 go/bench:

--- a/pkg/parcacol/querier.go
+++ b/pkg/parcacol/querier.go
@@ -521,6 +521,11 @@ func (q *Querier) queryRangeDelta(ctx context.Context, filterExpr logicalplan.Ex
 
 func (q *Querier) queryRangeNonDelta(ctx context.Context, filterExpr logicalplan.Expr, step time.Duration) ([]*pb.MetricsSeries, error) {
 	records := []arrow.Record{}
+	defer func() {
+		for _, r := range records {
+			r.Release()
+		}
+	}()
 	rows := 0
 	err := q.engine.ScanTable(q.tableName).
 		Filter(filterExpr).

--- a/pkg/parcacol/querier.go
+++ b/pkg/parcacol/querier.go
@@ -348,6 +348,11 @@ const (
 
 func (q *Querier) queryRangeDelta(ctx context.Context, filterExpr logicalplan.Expr, step time.Duration, sampleTypeUnit string) ([]*pb.MetricsSeries, error) {
 	records := []arrow.Record{}
+	defer func() {
+		for _, r := range records {
+			r.Release()
+		}
+	}()
 	rows := 0
 	err := q.engine.ScanTable(q.tableName).
 		Filter(filterExpr).

--- a/pkg/query/columnquery.go
+++ b/pkg/query/columnquery.go
@@ -699,30 +699,36 @@ func (q *ColumnQueryAPI) selectDiff(ctx context.Context, d *pb.DiffProfile) (pro
 
 	for _, r := range compare.Samples {
 		columns := r.Columns()
+		cols := make([]arrow.Array, len(columns))
+		copy(cols, columns)
 		// This is intentional, the diff value of the `compare` profile is the same
 		// as the value of the `compare` profile, because what we're actually doing
 		// is subtracting the `base` profile, but the actual calculation happens
 		// when building the visualizations. We should eventually have this be done
 		// directly by the query engine.
-		columns[len(columns)-1] = columns[len(columns)-2]
+		cols[len(cols)-1] = cols[len(cols)-2]
 		records = append(records, array.NewRecord(
 			r.Schema(),
-			columns,
+			cols,
 			r.NumRows(),
 		))
 	}
 
 	for _, r := range base.Samples {
-		columns := r.Columns()
-		// This has to be this order as we're overriding the value column (-2)
-		// in the next line.
-		columns[len(columns)-1] = multiplyInt64By(q.mem, columns[len(columns)-2].(*array.Int64), -1)
-		columns[len(columns)-2] = zeroArray(q.mem, int(r.NumRows()))
-		records = append(records, array.NewRecord(
-			r.Schema(),
-			columns,
-			r.NumRows(),
-		))
+		func() {
+			columns := r.Columns()
+			cols := make([]arrow.Array, len(columns))
+			copy(cols, columns)
+			mult := multiplyInt64By(q.mem, columns[len(columns)-2].(*array.Int64), -1)
+			defer mult.Release()
+			zero := zeroArray(q.mem, int(r.NumRows()))
+			defer zero.Release()
+			records = append(records, array.NewRecord(
+				r.Schema(),
+				append(cols[:len(cols)-2], zero, mult),
+				r.NumRows(),
+			))
+		}()
 	}
 
 	return profile.Profile{

--- a/pkg/query/columnquery_test.go
+++ b/pkg/query/columnquery_test.go
@@ -769,8 +769,8 @@ func TestColumnQueryAPIQueryDiff(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// TODO: this should used a checked allocator but there is a bug in Frostdb(https://github.com/polarsignals/frostdb/issues/499) that causes it to leak allocations.
-	mem := memory.DefaultAllocator
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
 	api := NewColumnQueryAPI(
 		logger,
 		tracer,

--- a/pkg/query/columnquery_test.go
+++ b/pkg/query/columnquery_test.go
@@ -210,8 +210,8 @@ func TestColumnQueryAPIQueryRange(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	// TODO: this should used a checked allocator but there is a bug in Frostdb(https://github.com/polarsignals/frostdb/issues/499) that causes it to leak allocations.
-	mem := memory.DefaultAllocator
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
 	api := NewColumnQueryAPI(
 		logger,
 		tracer,

--- a/pkg/query/columnquery_test.go
+++ b/pkg/query/columnquery_test.go
@@ -446,8 +446,8 @@ func TestColumnQueryAPIQueryFgprof(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// TODO: this should used a checked allocator but there is a bug in Frostdb(https://github.com/polarsignals/frostdb/issues/499) that causes it to leak allocations.
-	mem := memory.DefaultAllocator
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
 	api := NewColumnQueryAPI(
 		logger,
 		tracer,

--- a/pkg/query/flamegraph_arrow.go
+++ b/pkg/query/flamegraph_arrow.go
@@ -466,7 +466,6 @@ func transpositionFromDict(unifier array.DictionaryUnifier, dict *array.Binary) 
 		0,
 		0,
 	)
-	defer data.Release()
 	indices := array.NewInt32Data(data)
 
 	return data, indices, nil
@@ -1036,7 +1035,6 @@ func (fb *flamegraphBuilder) Release() {
 	fb.builderFunctionFilenameDictUnifier.Release()
 
 	fb.builderChildren.Release()
-	fb.builderChildrenValues.Release()
 	fb.builderCumulative.Release()
 	fb.builderDiff.Release()
 

--- a/pkg/query/flamegraph_arrow.go
+++ b/pkg/query/flamegraph_arrow.go
@@ -879,7 +879,7 @@ func (fb *flamegraphBuilder) NewRecord() (arrow.Record, error) {
 		return nil, err
 	}
 	cleanupArrs = append(cleanupArrs, mappingBuildIDDict)
-	mappingBuildIDType := &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Int32, ValueType: arrow.BinaryTypes.String}
+	mappingBuildIDType := &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Int32, ValueType: arrow.BinaryTypes.Binary}
 	mappingBuildID := array.NewDictionaryArray(mappingBuildIDType, mappingBuildIDIndices, mappingBuildIDDict)
 	cleanupArrs = append(cleanupArrs, mappingBuildID)
 
@@ -890,7 +890,7 @@ func (fb *flamegraphBuilder) NewRecord() (arrow.Record, error) {
 		return nil, err
 	}
 	cleanupArrs = append(cleanupArrs, mappingFileDict)
-	mappingFileType := &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Int32, ValueType: arrow.BinaryTypes.String}
+	mappingFileType := &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Int32, ValueType: arrow.BinaryTypes.Binary}
 	mappingFile := array.NewDictionaryArray(mappingFileType, mappingFileIndices, mappingFileDict)
 	cleanupArrs = append(cleanupArrs, mappingFile)
 
@@ -901,7 +901,7 @@ func (fb *flamegraphBuilder) NewRecord() (arrow.Record, error) {
 		return nil, err
 	}
 	cleanupArrs = append(cleanupArrs, functionNameDict)
-	functionNameType := &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Int32, ValueType: arrow.BinaryTypes.String}
+	functionNameType := &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Int32, ValueType: arrow.BinaryTypes.Binary}
 	functionName := array.NewDictionaryArray(functionNameType, functionNameIndices, functionNameDict)
 	cleanupArrs = append(cleanupArrs, functionName)
 
@@ -912,7 +912,7 @@ func (fb *flamegraphBuilder) NewRecord() (arrow.Record, error) {
 		return nil, err
 	}
 	cleanupArrs = append(cleanupArrs, functionSystemNameDict)
-	functionSystemNameType := &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Int32, ValueType: arrow.BinaryTypes.String}
+	functionSystemNameType := &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Int32, ValueType: arrow.BinaryTypes.Binary}
 	functionSystemName := array.NewDictionaryArray(functionSystemNameType, functionSystemNameIndices, functionSystemNameDict)
 	cleanupArrs = append(cleanupArrs, functionSystemName)
 
@@ -923,7 +923,7 @@ func (fb *flamegraphBuilder) NewRecord() (arrow.Record, error) {
 		return nil, err
 	}
 	cleanupArrs = append(cleanupArrs, functionFilenameDict)
-	functionFilenameType := &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Int32, ValueType: arrow.BinaryTypes.String}
+	functionFilenameType := &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Int32, ValueType: arrow.BinaryTypes.Binary}
 	functionFilename := array.NewDictionaryArray(functionFilenameType, functionFilenameIndices, functionFilenameDict)
 	cleanupArrs = append(cleanupArrs, functionFilename)
 
@@ -984,7 +984,7 @@ func (fb *flamegraphBuilder) NewRecord() (arrow.Record, error) {
 
 	for i := range fb.builderLabelFields {
 		if err := func() error {
-			typ := &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Int32, ValueType: arrow.BinaryTypes.String}
+			typ := &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Int32, ValueType: arrow.BinaryTypes.Binary}
 			fields = append(fields, arrow.Field{
 				Name: fb.builderLabelFields[i].Name,
 				Type: typ,


### PR DESCRIPTION
Fixes the double free in the `TestColumnQueryAPIQueryDiff`

Fixes all the double frees in the query tests. Turns on the `assert` tag for all go tests