### PR TITLE
Fix Clear Selection button in table

### DIFF
--- a/ui/packages/shared/profile/src/ProfileIcicleGraph/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph/index.tsx
@@ -188,7 +188,7 @@ const ProfileIcicleGraph = function ProfileIcicleGraphNonMemo({
   }
 
   if (graph === undefined && table === undefined)
-    return <div className="mx-auto text-center">no data...</div>;
+    return <div className="mx-auto text-center">No data...</div>;
 
   if (total === 0n && !loading)
     return <div className="mx-auto text-center">Profile has no samples</div>;

--- a/ui/packages/shared/profile/src/Table/index.tsx
+++ b/ui/packages/shared/profile/src/Table/index.tsx
@@ -57,6 +57,7 @@ export const Table = React.memo(function Table({
   const router = parseParams(window?.location.search);
   const [rawDashboardItems] = useURLState({param: 'dashboard_items'});
   const [rawcompareMode] = useURLState({param: 'compare_a'});
+  const [filterByFunctionInput] = useURLState({param: 'filter_by_function'});
 
   const compareMode: boolean = rawcompareMode === undefined ? false : rawcompareMode === 'true';
 
@@ -158,7 +159,7 @@ export const Table = React.memo(function Table({
         '/',
         {
           ...router,
-          ...{search_string: ''},
+          ...{search_string: filterByFunctionInput ?? ''},
         },
         {replace: true}
       );

--- a/ui/packages/shared/profile/src/Table/index.tsx
+++ b/ui/packages/shared/profile/src/Table/index.tsx
@@ -164,7 +164,7 @@ export const Table = React.memo(function Table({
         {replace: true}
       );
     }
-  }, [navigateTo, router]);
+  }, [navigateTo, router, filterByFunctionInput]);
 
   useEffect(() => {
     if (setActionButtons === undefined) {


### PR DESCRIPTION
With this fix, if the user hits "Clear selection" in the table and something has been previously entered in the "filter by function" input, the highlighting will revert to the filtered result instead of improperly clearing all highlighting (as had been the case before the fix). 