### PR TITLE
ui: Flamegraph - passing width from the parent instead of detecting from within

### DIFF
--- a/ui/packages/shared/profile/src/ProfileIcicleGraph/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph/index.tsx
@@ -19,7 +19,6 @@ import {Table} from 'apache-arrow';
 
 import {Flamegraph} from '@parca/client';
 import {Button, Select, useParcaContext, useURLState} from '@parca/components';
-import {useContainerDimensions} from '@parca/hooks';
 import {divide, selectQueryParam, type NavigateFunction} from '@parca/utilities';
 
 import DiffLegend from '../components/DiffLegend';
@@ -36,7 +35,7 @@ const numberFormatter = new Intl.NumberFormat('en-US');
 export type ResizeHandler = (width: number, height: number) => void;
 
 interface ProfileIcicleGraphProps {
-  width?: number;
+  width: number;
   graph?: Flamegraph;
   table?: Table<any>;
   total: bigint;
@@ -113,11 +112,11 @@ const ProfileIcicleGraph = function ProfileIcicleGraphNonMemo({
   loading,
   setActionButtons,
   error,
+  width,
 }: ProfileIcicleGraphProps): JSX.Element {
   const {loader} = useParcaContext();
   const compareMode: boolean =
     selectQueryParam('compare_a') === 'true' && selectQueryParam('compare_b') === 'true';
-  const {ref, dimensions} = useContainerDimensions();
 
   const [storeSortBy = FIELD_FUNCTION_NAME] = useURLState({
     param: 'sort_by',
@@ -200,10 +199,10 @@ const ProfileIcicleGraph = function ProfileIcicleGraphNonMemo({
   return (
     <div className="relative">
       {compareMode && <DiffLegend />}
-      <div ref={ref} className="min-h-48">
+      <div className="min-h-48">
         {graph !== undefined && (
           <IcicleGraph
-            width={dimensions?.width}
+            width={width}
             graph={graph}
             total={total}
             filtered={filtered}
@@ -215,7 +214,7 @@ const ProfileIcicleGraph = function ProfileIcicleGraphNonMemo({
         )}
         {table !== undefined && (
           <IcicleGraphArrow
-            width={dimensions?.width}
+            width={width}
             table={table}
             total={total}
             filtered={filtered}

--- a/ui/packages/shared/profile/src/ProfileView/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileView/index.tsx
@@ -267,6 +267,13 @@ export const ProfileView = ({
               loading={flamegraphData.loading}
               setActionButtons={setActionButtons}
               error={flamegraphData.error}
+              width={
+                dimensions?.width !== undefined
+                  ? isHalfScreen
+                    ? (dimensions.width - 40) / 2
+                    : dimensions.width - 16
+                  : 0
+              }
             />
           </ConditionalWrapper>
         );


### PR DESCRIPTION
Detecting the width form within the component is creating a flaky situation where the `ref.current` might not be populated based on whether the child component has rendered or not, that was making the width to `undefined` sometimes causing the flame graph not visible. 

So, this fix passed the width from the parent component so that we can be well sure that the ref is already populated. 