### PR TITLE
Disable Parca scraping by default

### DIFF
--- a/parca.yaml
+++ b/parca.yaml
@@ -9,11 +9,11 @@ object_storage:
 # Scraping tends to produce a lot more data than Parca Agent CPU which
 # results in memory usage by the server.
 #
-scrape_configs:
-  - job_name: "default"
-    scrape_interval: "1s"
-    static_configs:
-      - targets: [ '127.0.0.1:6060' ]
+# scrape_configs:
+#   - job_name: "parca"
+#     scrape_interval: "10s"
+#     static_configs:
+#       - targets: [ '127.0.0.1:7070' ]
 
 # Nested under the job config:
 #


### PR DESCRIPTION
Scraping every 10s should be totally fine for most use cases.
Also, naming the job parca seems much more descriptive than default.
