### PR TITLE
pkg/query/flamegraph_arrow: Return empty record if no samples

### DIFF
--- a/pkg/query/flamegraph_arrow_test.go
+++ b/pkg/query/flamegraph_arrow_test.go
@@ -538,6 +538,28 @@ func TestGenerateFlamegraphArrow(t *testing.T) {
 	}
 }
 
+func TestGenerateFlamegraphArrowEmpty(t *testing.T) {
+	ctx := context.Background()
+	tracer := trace.NewNoopTracerProvider().Tracer("")
+
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+
+	// empty profile
+	// basically the same as querying a time range with no data.
+	p := profile.Profile{}
+
+	record, total, height, trimmed, err := generateFlamegraphArrowRecord(ctx, mem, tracer, p, []string{FlamegraphFieldFunctionName}, 0)
+	require.NoError(t, err)
+	defer record.Release()
+
+	require.Equal(t, int64(0), total)
+	require.Equal(t, int32(1), height)
+	require.Equal(t, int64(0), trimmed)
+	require.Equal(t, int64(16), record.NumCols())
+	require.Equal(t, int64(1), record.NumRows())
+}
+
 func TestGenerateFlamegraphArrowWithInlined(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This is going to return an empty (except for the root row) arrow record with all columns and one root row.
The frontend can then handle the case the record has 0 or 1 row.

This was approach was in favor over returning an no-data-error as it signals that the request overall was correctly processed.
