### PR TITLE
pkg/query: Use maps instead of slices for children for O(1) access

### DIFF
--- a/pkg/query/flamegraph_arrow_test.go
+++ b/pkg/query/flamegraph_arrow_test.go
@@ -315,35 +315,6 @@ func TestGenerateFlamegraphArrow(t *testing.T) {
 		height     int32
 		trimmed    int64
 	}{{
-		name:      "aggregate-nothing", // raw
-		aggregate: nil,
-		// expectations
-		cumulative: 10,
-		height:     5,
-		trimmed:    0,
-		rows: []flamegraphRow{
-			// level 0 - root
-			{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0, LocationFolded: false, LocationLine: 0, FunctionStartLine: 0, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 10, Labels: nil, Children: []uint32{1, 2, 3, 4}}, // 0
-			// level 1
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationFolded: false, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 2, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{5}}, // 1
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationFolded: false, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 1, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{6}}, // 2
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationFolded: false, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 3, Labels: nil, Children: []uint32{7}},                                 // 3
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationFolded: false, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 4, Labels: map[string]string{"goroutine": "2"}, Children: []uint32{8}}, // 4
-			// level 2
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationFolded: false, LocationLine: 2, FunctionStartLine: 2, FunctionName: "2", FunctionSystemName: "2", FunctionFilename: "2", Cumulative: 2, Labels: map[string]string{"goroutine": "1"}, Children: nil},          // 5
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationFolded: false, LocationLine: 2, FunctionStartLine: 2, FunctionName: "2", FunctionSystemName: "2", FunctionFilename: "2", Cumulative: 1, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{9}},  // 6
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationFolded: false, LocationLine: 2, FunctionStartLine: 2, FunctionName: "2", FunctionSystemName: "2", FunctionFilename: "2", Cumulative: 3, Labels: nil, Children: []uint32{10}},                                 // 7
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationFolded: false, LocationLine: 2, FunctionStartLine: 2, FunctionName: "2", FunctionSystemName: "2", FunctionFilename: "2", Cumulative: 4, Labels: map[string]string{"goroutine": "2"}, Children: []uint32{11}}, // 8
-			// level 3
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationFolded: false, LocationLine: 3, FunctionStartLine: 3, FunctionName: "3", FunctionSystemName: "3", FunctionFilename: "3", Cumulative: 1, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{12}}, // 9
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationFolded: false, LocationLine: 3, FunctionStartLine: 3, FunctionName: "3", FunctionSystemName: "3", FunctionFilename: "3", Cumulative: 3, Labels: nil, Children: []uint32{13}},                                 // 10
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationFolded: false, LocationLine: 3, FunctionStartLine: 3, FunctionName: "3", FunctionSystemName: "3", FunctionFilename: "3", Cumulative: 4, Labels: map[string]string{"goroutine": "2"}, Children: []uint32{14}}, // 11
-			// level 4
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa5, LocationFolded: false, LocationLine: 5, FunctionStartLine: 5, FunctionName: "5", FunctionSystemName: "5", FunctionFilename: "5", Cumulative: 1, Labels: map[string]string{"goroutine": "1"}, Children: nil}, // 12
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa4, LocationFolded: false, LocationLine: 4, FunctionStartLine: 4, FunctionName: "4", FunctionSystemName: "4", FunctionFilename: "4", Cumulative: 3, Labels: nil, Children: nil},                                 // 13
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa5, LocationFolded: false, LocationLine: 5, FunctionStartLine: 5, FunctionName: "5", FunctionSystemName: "5", FunctionFilename: "5", Cumulative: 4, Labels: map[string]string{"goroutine": "2"}, Children: nil}, // 14
-		},
-	}, {
 		name:      "aggregate-function-name",
 		aggregate: []string{FlamegraphFieldFunctionName},
 		// expectations
@@ -400,8 +371,9 @@ func TestGenerateFlamegraphArrow(t *testing.T) {
 			{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0, LocationFolded: false, LocationLine: 0, FunctionStartLine: 0, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 10, Labels: nil, Children: []uint32{1}}, // 0
 			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationFolded: false, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 10, Labels: nil, Children: []uint32{2}},                                                                  // 1
 			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationFolded: false, LocationLine: 2, FunctionStartLine: 2, FunctionName: "2", FunctionSystemName: "2", FunctionFilename: "2", Cumulative: 10, Labels: nil, Children: []uint32{3}},                                                                  // 2
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationFolded: false, LocationLine: 3, FunctionStartLine: 3, FunctionName: "3", FunctionSystemName: "3", FunctionFilename: "3", Cumulative: 8, Labels: nil, Children: []uint32{4}},                                                                   // 3
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa5, LocationFolded: false, LocationLine: 5, FunctionStartLine: 5, FunctionName: "5", FunctionSystemName: "5", FunctionFilename: "5", Cumulative: 8, Labels: nil, Children: nil},                                                                           // 4
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationFolded: false, LocationLine: 3, FunctionStartLine: 3, FunctionName: "3", FunctionSystemName: "3", FunctionFilename: "3", Cumulative: 8, Labels: nil, Children: []uint32{4, 5}},                                                                // 3
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa5, LocationFolded: false, LocationLine: 5, FunctionStartLine: 5, FunctionName: "5", FunctionSystemName: "5", FunctionFilename: "5", Cumulative: 5, Labels: nil, Children: nil},                                                                           // 4
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa4, LocationFolded: false, LocationLine: 4, FunctionStartLine: 4, FunctionName: "4", FunctionSystemName: "4", FunctionFilename: "4", Cumulative: 3, Labels: nil, Children: nil},                                                                           // 4
 		},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -636,23 +608,6 @@ func TestGenerateFlamegraphArrowUnsymbolized(t *testing.T) {
 		height     int32
 		trimmed    int64
 	}{
-		// Aggregating by nothing or by function name yields the same result without function names.
-		{
-			name:      "aggregate-nothing", // raw
-			aggregate: nil,
-			// expectations
-			cumulative: 6,
-			height:     5,
-			trimmed:    0, // TODO
-			rows: []flamegraphRow{
-				{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: "(null)", MappingBuildID: "(null)", LocationAddress: 0, LocationFolded: false, LocationLine: 0, Cumulative: 6, Children: []uint32{1}},    // 0
-				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationFolded: false, LocationLine: 1, Cumulative: 6, Children: []uint32{2}},    // 1
-				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationFolded: false, LocationLine: 2, Cumulative: 6, Children: []uint32{3}},    // 2
-				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationFolded: false, LocationLine: 3, Cumulative: 4, Children: []uint32{4, 5}}, // 3
-				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa5, LocationFolded: false, LocationLine: 5, Cumulative: 1, Children: nil},            // 4
-				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa4, LocationFolded: false, LocationLine: 4, Cumulative: 3, Children: nil},            // 5
-			},
-		},
 		{
 			name:      "aggregate-function-name",
 			aggregate: []string{FlamegraphFieldFunctionName},

--- a/pkg/query/flamegraph_arrow_test.go
+++ b/pkg/query/flamegraph_arrow_test.go
@@ -82,6 +82,65 @@ type flamegraphColumns struct {
 	diff                []int64
 }
 
+func (c flamegraphColumns) slice(start, end int) flamegraphColumns {
+	return flamegraphColumns{
+		labelsOnly:          c.labelsOnly[start:end],
+		mappingStart:        c.mappingStart[start:end],
+		mappingLimit:        c.mappingLimit[start:end],
+		mappingOffset:       c.mappingOffset[start:end],
+		mappingFiles:        c.mappingFiles[start:end],
+		mappingBuildIDs:     c.mappingBuildIDs[start:end],
+		locationAddresses:   c.locationAddresses[start:end],
+		locationFolded:      c.locationFolded[start:end],
+		locationLines:       c.locationLines[start:end],
+		functionStartLines:  c.functionStartLines[start:end],
+		functionNames:       c.functionNames[start:end],
+		functionSystemNames: c.functionSystemNames[start:end],
+		functionFileNames:   c.functionFileNames[start:end],
+		labels:              c.labels[start:end],
+		children:            c.children[start:end],
+		cumulative:          c.cumulative[start:end],
+		diff:                c.diff[start:end],
+	}
+}
+
+func (c flamegraphColumns) swap(i, j int) {
+	c.labelsOnly[i], c.labelsOnly[j] = c.labelsOnly[j], c.labelsOnly[i]
+	c.mappingStart[i], c.mappingStart[j] = c.mappingStart[j], c.mappingStart[i]
+	c.mappingLimit[i], c.mappingLimit[j] = c.mappingLimit[j], c.mappingLimit[i]
+	c.mappingOffset[i], c.mappingOffset[j] = c.mappingOffset[j], c.mappingOffset[i]
+	c.mappingFiles[i], c.mappingFiles[j] = c.mappingFiles[j], c.mappingFiles[i]
+	c.mappingBuildIDs[i], c.mappingBuildIDs[j] = c.mappingBuildIDs[j], c.mappingBuildIDs[i]
+	c.locationAddresses[i], c.locationAddresses[j] = c.locationAddresses[j], c.locationAddresses[i]
+	c.locationFolded[i], c.locationFolded[j] = c.locationFolded[j], c.locationFolded[i]
+	c.locationLines[i], c.locationLines[j] = c.locationLines[j], c.locationLines[i]
+	c.functionStartLines[i], c.functionStartLines[j] = c.functionStartLines[j], c.functionStartLines[i]
+	c.functionNames[i], c.functionNames[j] = c.functionNames[j], c.functionNames[i]
+	c.functionSystemNames[i], c.functionSystemNames[j] = c.functionSystemNames[j], c.functionSystemNames[i]
+	c.functionFileNames[i], c.functionFileNames[j] = c.functionFileNames[j], c.functionFileNames[i]
+	c.labels[i], c.labels[j] = c.labels[j], c.labels[i]
+	c.children[i], c.children[j] = c.children[j], c.children[i]
+	c.cumulative[i], c.cumulative[j] = c.cumulative[j], c.cumulative[i]
+	c.diff[i], c.diff[j] = c.diff[j], c.diff[i]
+}
+
+type flamegraphColumnSorter struct {
+	columns flamegraphColumns
+	less    func(c flamegraphColumns, a, b int) bool
+	slices  [][2]int
+}
+
+func (s *flamegraphColumnSorter) Len() int           { return len(s.columns.labelsOnly) }
+func (s *flamegraphColumnSorter) Swap(i, j int)      { s.columns.swap(i, j) }
+func (s *flamegraphColumnSorter) Less(i, j int) bool { return s.less(s.columns, i, j) }
+
+func (s *flamegraphColumnSorter) sort(columns flamegraphColumns) {
+	for _, slice := range s.slices {
+		s.columns = columns.slice(slice[0], slice[1])
+		sort.Sort(s)
+	}
+}
+
 func rowsToColumn(rows []flamegraphRow) flamegraphColumns {
 	columns := flamegraphColumns{}
 	for _, row := range rows {
@@ -106,68 +165,55 @@ func rowsToColumn(rows []flamegraphRow) flamegraphColumns {
 	return columns
 }
 
-func requireColumn(t *testing.T, r arrow.Record, field string, expected any) {
-	switch expected.(type) {
-	case []int64:
-		require.Equal(t,
-			expected,
-			r.Column(r.Schema().FieldIndices(field)[0]).(*array.Int64).Int64Values(),
-		)
-	case []uint64:
-		require.Equal(t,
-			expected,
-			r.Column(r.Schema().FieldIndices(field)[0]).(*array.Uint64).Uint64Values(),
-		)
-	case []bool:
-		actual := make([]bool, r.NumRows())
-		col := r.Column(r.Schema().FieldIndices(field)[0]).(*array.Boolean)
-		for i := 0; i < int(r.NumRows()); i++ {
-			actual[i] = col.Value(i)
-		}
-		require.Equal(t, expected, actual)
-
-	default:
-		require.Fail(t, "unsupported type")
+func fgRecordToColumns(t *testing.T, r arrow.Record) flamegraphColumns {
+	return flamegraphColumns{
+		labelsOnly:          extractColumn(t, r, FlamegraphFieldLabelsOnly).([]bool),
+		mappingStart:        extractColumn(t, r, FlamegraphFieldMappingStart).([]uint64),
+		mappingLimit:        extractColumn(t, r, FlamegraphFieldMappingLimit).([]uint64),
+		mappingOffset:       extractColumn(t, r, FlamegraphFieldMappingOffset).([]uint64),
+		mappingFiles:        extractColumn(t, r, FlamegraphFieldMappingFile).([]string),
+		mappingBuildIDs:     extractColumn(t, r, FlamegraphFieldMappingBuildID).([]string),
+		locationAddresses:   extractColumn(t, r, FlamegraphFieldLocationAddress).([]uint64),
+		locationFolded:      extractColumn(t, r, FlamegraphFieldLocationFolded).([]bool),
+		locationLines:       extractColumn(t, r, FlamegraphFieldLocationLine).([]int64),
+		functionStartLines:  extractColumn(t, r, FlamegraphFieldFunctionStartLine).([]int64),
+		functionNames:       extractColumn(t, r, FlamegraphFieldFunctionName).([]string),
+		functionSystemNames: extractColumn(t, r, FlamegraphFieldFunctionSystemName).([]string),
+		functionFileNames:   extractColumn(t, r, FlamegraphFieldFunctionFileName).([]string),
+		labels:              extractLabelColumns(t, r),
+		children:            extractChildrenColumn(t, r),
+		cumulative:          extractColumn(t, r, FlamegraphFieldCumulative).([]int64),
+		diff:                extractColumn(t, r, FlamegraphFieldDiff).([]int64),
 	}
 }
 
-func requireColumnBinaryDict(t *testing.T, r arrow.Record, field string, expected any) {
-	dict := r.Column(r.Schema().FieldIndices(field)[0]).(*array.Dictionary)
+func extractLabelColumns(t *testing.T, r arrow.Record) []map[string]string {
+	pprofLabels := make([]map[string]string, r.NumRows())
+	for i := 0; i < int(r.NumRows()); i++ {
+		sampleLabels := map[string]string{}
+		for j, f := range r.Schema().Fields() {
+			if strings.HasPrefix(f.Name, profile.ColumnPprofLabelsPrefix) && r.Column(j).IsValid(i) {
+				col := r.Column(r.Schema().FieldIndices(f.Name)[0]).(*array.Dictionary)
+				dict := col.Dictionary().(*array.Binary)
 
-	switch expected.(type) {
-	case []string:
-		if dictStringsBytes, ok := dict.Dictionary().(*array.Binary); ok {
-			actual := make([]string, r.NumRows())
-			for i := 0; i < int(r.NumRows()); i++ {
-				if dict.IsValid(i) {
-					actual[i] = string(dictStringsBytes.Value(dict.GetValueIndex(i)))
-				} else {
-					actual[i] = "(null)"
-				}
+				labelName := strings.TrimPrefix(f.Name, profile.ColumnPprofLabelsPrefix)
+				sampleLabels[labelName] = string(dict.Value(col.GetValueIndex(i)))
 			}
-			require.Equal(t, expected, actual)
 		}
-		if dictStrings, ok := dict.Dictionary().(*array.String); ok {
-			actual := make([]string, r.NumRows())
-			for i := 0; i < int(r.NumRows()); i++ {
-				if dict.IsValid(i) {
-					actual[i] = dictStrings.Value(dict.GetValueIndex(i))
-				} else {
-					actual[i] = "(null)"
-				}
-			}
-			require.Equal(t, expected, actual)
+
+		if len(sampleLabels) > 0 {
+			pprofLabels[i] = sampleLabels
 		}
-	default:
-		require.Fail(t, "unsupported type")
 	}
+
+	return pprofLabels
 }
 
-func requireColumnChildren(t *testing.T, record arrow.Record, expected [][]uint32) {
-	children := make([][]uint32, record.NumRows())
-	list := record.Column(record.Schema().FieldIndices(FlamegraphFieldChildren)[0]).(*array.List)
+func extractChildrenColumn(t *testing.T, r arrow.Record) [][]uint32 {
+	children := make([][]uint32, r.NumRows())
+	list := r.Column(r.Schema().FieldIndices(FlamegraphFieldChildren)[0]).(*array.List)
 	listValues := list.ListValues().(*array.Uint32).Uint32Values()
-	for i := 0; i < int(record.NumRows()); i++ {
+	for i := 0; i < int(r.NumRows()); i++ {
 		if !list.IsValid(i) {
 			children[i] = nil
 		} else {
@@ -181,7 +227,60 @@ func requireColumnChildren(t *testing.T, record arrow.Record, expected [][]uint3
 			}
 		}
 	}
-	require.Equal(t, expected, children)
+
+	return children
+}
+
+func extractColumn(t *testing.T, r arrow.Record, field string) any {
+	fi := r.Schema().FieldIndices(field)
+	require.Equal(t, 1, len(fi))
+
+	arr := r.Column(fi[0])
+	switch arr := arr.(type) {
+	case *array.Int64:
+		return arr.Int64Values()
+	case *array.Uint64:
+		return arr.Uint64Values()
+	case *array.Boolean:
+		vals := make([]bool, r.NumRows())
+		for i := 0; i < int(r.NumRows()); i++ {
+			vals[i] = arr.Value(i)
+		}
+
+		return vals
+	case *array.Dictionary:
+		dict := arr.Dictionary()
+		switch dict := dict.(type) {
+		case *array.Binary:
+			vals := make([]string, r.NumRows())
+			for i := 0; i < int(r.NumRows()); i++ {
+				if arr.IsValid(i) {
+					vals[i] = string(dict.Value(arr.GetValueIndex(i)))
+				} else {
+					vals[i] = "(null)"
+				}
+			}
+
+			return vals
+		case *array.String:
+			vals := make([]string, r.NumRows())
+			for i := 0; i < int(r.NumRows()); i++ {
+				if arr.IsValid(i) {
+					vals[i] = dict.Value(arr.GetValueIndex(i))
+				} else {
+					vals[i] = "(null)"
+				}
+			}
+
+			return vals
+		default:
+			t.Fatalf("unsupported type %T", arr)
+			return nil
+		}
+	default:
+		t.Fatalf("unsupported type %T", arr)
+		return nil
+	}
 }
 
 func TestGenerateFlamegraphArrow(t *testing.T) {
@@ -311,6 +410,7 @@ func TestGenerateFlamegraphArrow(t *testing.T) {
 		aggregate []string
 		// expectations
 		rows       []flamegraphRow
+		sorter     *flamegraphColumnSorter
 		cumulative int64
 		height     int32
 		trimmed    int64
@@ -321,6 +421,12 @@ func TestGenerateFlamegraphArrow(t *testing.T) {
 		cumulative: 10,
 		height:     5,
 		trimmed:    0,
+		sorter: &flamegraphColumnSorter{
+			slices: [][2]int{{4, 6}}, // lines 4 and 5 are not in stable order in the result so we need to sort them for the test to be deterministic, so the range we want to sort is [4, 6)
+			less: func(columns flamegraphColumns, i, j int) bool {
+				return columns.functionNames[i] > columns.functionNames[j]
+			},
+		},
 		rows: []flamegraphRow{
 			{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0, LocationFolded: false, LocationLine: 0, FunctionStartLine: 0, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 10, Labels: nil, Children: []uint32{1}}, // 0
 			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationFolded: false, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 10, Labels: nil, Children: []uint32{2}},                                                                  // 1
@@ -366,6 +472,12 @@ func TestGenerateFlamegraphArrow(t *testing.T) {
 		cumulative: 10,
 		height:     5,
 		trimmed:    0, // TODO
+		sorter: &flamegraphColumnSorter{
+			slices: [][2]int{{4, 6}}, // lines 4 and 5 are not in stable order in the result so we need to sort them for the test to be deterministic, so the range we want to sort is [4, 6)
+			less: func(columns flamegraphColumns, i, j int) bool {
+				return columns.functionNames[i] > columns.functionNames[j]
+			},
+		},
 		rows: []flamegraphRow{
 			// This aggregates all the rows with the same mapping file, meaning that we only keep one flamegraphRow per stack depth in this example.
 			{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0, LocationFolded: false, LocationLine: 0, FunctionStartLine: 0, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 10, Labels: nil, Children: []uint32{1}}, // 0
@@ -398,43 +510,30 @@ func TestGenerateFlamegraphArrow(t *testing.T) {
 			require.Equal(t, int64(17), fa.NumCols())
 
 			// Convert the numRows to columns for easier access when testing below.
-			columns := rowsToColumn(tc.rows)
+			expectedColumns := rowsToColumn(tc.rows)
+			actualColumns := fgRecordToColumns(t, fa)
 
-			requireColumn(t, fa, FlamegraphFieldLabelsOnly, columns.labelsOnly)
-			requireColumn(t, fa, FlamegraphFieldMappingStart, columns.mappingStart)
-			requireColumn(t, fa, FlamegraphFieldMappingLimit, columns.mappingLimit)
-			requireColumn(t, fa, FlamegraphFieldMappingOffset, columns.mappingOffset)
-			requireColumnBinaryDict(t, fa, FlamegraphFieldMappingFile, columns.mappingFiles)
-			requireColumnBinaryDict(t, fa, FlamegraphFieldMappingBuildID, columns.mappingBuildIDs)
-			requireColumn(t, fa, FlamegraphFieldLocationAddress, columns.locationAddresses)
-			requireColumn(t, fa, FlamegraphFieldLocationFolded, columns.locationFolded)
-			requireColumn(t, fa, FlamegraphFieldLocationLine, columns.locationLines)
-			requireColumn(t, fa, FlamegraphFieldFunctionStartLine, columns.functionStartLines)
-			requireColumnBinaryDict(t, fa, FlamegraphFieldFunctionName, columns.functionNames)
-			requireColumnBinaryDict(t, fa, FlamegraphFieldFunctionSystemName, columns.functionSystemNames)
-			requireColumnBinaryDict(t, fa, FlamegraphFieldFunctionFileName, columns.functionFileNames)
-			requireColumn(t, fa, FlamegraphFieldCumulative, columns.cumulative)
-			requireColumn(t, fa, FlamegraphFieldDiff, columns.diff)
-			requireColumnChildren(t, fa, columns.children)
-
-			pprofLabels := make([]map[string]string, fa.NumRows())
-			for i := 0; i < int(fa.NumRows()); i++ {
-				sampleLabels := map[string]string{}
-				for j, f := range fa.Schema().Fields() {
-					if strings.HasPrefix(f.Name, profile.ColumnPprofLabelsPrefix) && fa.Column(j).IsValid(i) {
-						col := fa.Column(fa.Schema().FieldIndices(f.Name)[0]).(*array.Dictionary)
-						dict := col.Dictionary().(*array.Binary)
-
-						labelName := strings.TrimPrefix(f.Name, profile.ColumnPprofLabelsPrefix)
-						sampleLabels[labelName] = string(dict.Value(col.GetValueIndex(i)))
-					}
-				}
-
-				if len(sampleLabels) > 0 {
-					pprofLabels[i] = sampleLabels
-				}
+			if tc.sorter != nil {
+				tc.sorter.sort(actualColumns)
 			}
-			require.Equal(t, columns.labels, pprofLabels)
+
+			require.Equal(t, expectedColumns.labelsOnly, actualColumns.labelsOnly)
+			require.Equal(t, expectedColumns.mappingStart, actualColumns.mappingStart)
+			require.Equal(t, expectedColumns.mappingLimit, actualColumns.mappingLimit)
+			require.Equal(t, expectedColumns.mappingOffset, actualColumns.mappingOffset)
+			require.Equal(t, expectedColumns.mappingFiles, actualColumns.mappingFiles)
+			require.Equal(t, expectedColumns.mappingBuildIDs, actualColumns.mappingBuildIDs)
+			require.Equal(t, expectedColumns.locationAddresses, actualColumns.locationAddresses)
+			require.Equal(t, expectedColumns.locationFolded, actualColumns.locationFolded)
+			require.Equal(t, expectedColumns.locationLines, actualColumns.locationLines)
+			require.Equal(t, expectedColumns.functionStartLines, actualColumns.functionStartLines)
+			require.Equal(t, expectedColumns.functionNames, actualColumns.functionNames)
+			require.Equal(t, expectedColumns.functionSystemNames, actualColumns.functionSystemNames)
+			require.Equal(t, expectedColumns.functionFileNames, actualColumns.functionFileNames)
+			require.Equal(t, expectedColumns.labels, actualColumns.labels)
+			require.Equal(t, expectedColumns.children, actualColumns.children)
+			require.Equal(t, expectedColumns.cumulative, actualColumns.cumulative)
+			require.Equal(t, expectedColumns.diff, actualColumns.diff)
 		})
 	}
 }
@@ -518,18 +617,19 @@ func TestGenerateFlamegraphArrowWithInlined(t *testing.T) {
 		{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationFolded: false, LocationLine: 89, FunctionStartLine: 0, FunctionName: "internal/poll.(*FD).Accept", FunctionSystemName: "internal/poll.(*FD).Accept", FunctionFilename: "internal/poll/fd_unix.go", Cumulative: 1, Labels: nil, Children: []uint32{4}},                          // 3
 		{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationFolded: false, LocationLine: 84, FunctionStartLine: 0, FunctionName: "internal/poll.(*pollDesc).wait", FunctionSystemName: "internal/poll.(*pollDesc).wait", FunctionFilename: "internal/poll/fd_poll_runtime.go", Cumulative: 1, Labels: nil, Children: nil},                  // 4
 	}
-	columns := rowsToColumn(rows)
+	expectedColumns := rowsToColumn(rows)
+	actualColumns := fgRecordToColumns(t, record)
 
 	// mapping fields are all null here
-	requireColumn(t, record, FlamegraphFieldLocationAddress, columns.locationAddresses)
-	requireColumn(t, record, FlamegraphFieldLocationFolded, columns.locationFolded)
-	requireColumn(t, record, FlamegraphFieldLocationLine, columns.locationLines)
-	requireColumn(t, record, FlamegraphFieldFunctionStartLine, columns.functionStartLines)
-	requireColumnBinaryDict(t, record, FlamegraphFieldFunctionName, columns.functionNames)
-	requireColumnBinaryDict(t, record, FlamegraphFieldFunctionSystemName, columns.functionSystemNames)
-	requireColumnBinaryDict(t, record, FlamegraphFieldFunctionFileName, columns.functionFileNames)
-	requireColumn(t, record, FlamegraphFieldCumulative, columns.cumulative)
-	requireColumnChildren(t, record, columns.children)
+	require.Equal(t, expectedColumns.locationAddresses, actualColumns.locationAddresses)
+	require.Equal(t, expectedColumns.locationFolded, actualColumns.locationFolded)
+	require.Equal(t, expectedColumns.locationLines, actualColumns.locationLines)
+	require.Equal(t, expectedColumns.functionStartLines, actualColumns.functionStartLines)
+	require.Equal(t, expectedColumns.functionNames, actualColumns.functionNames)
+	require.Equal(t, expectedColumns.functionSystemNames, actualColumns.functionSystemNames)
+	require.Equal(t, expectedColumns.functionFileNames, actualColumns.functionFileNames)
+	require.Equal(t, expectedColumns.cumulative, actualColumns.cumulative)
+	require.Equal(t, expectedColumns.children, actualColumns.children)
 }
 
 func TestGenerateFlamegraphArrowUnsymbolized(t *testing.T) {
@@ -604,6 +704,7 @@ func TestGenerateFlamegraphArrowUnsymbolized(t *testing.T) {
 		aggregate []string
 		// expectations
 		rows       []flamegraphRow
+		sorter     *flamegraphColumnSorter
 		cumulative int64
 		height     int32
 		trimmed    int64
@@ -615,6 +716,12 @@ func TestGenerateFlamegraphArrowUnsymbolized(t *testing.T) {
 			cumulative: 6,
 			height:     5,
 			trimmed:    0, // TODO
+			sorter: &flamegraphColumnSorter{
+				slices: [][2]int{{4, 6}}, // lines 4 and 5 are not in stable order in the result so we need to sort them for the test to be deterministic, so the range we want to sort is [4, 6)
+				less: func(columns flamegraphColumns, i, j int) bool {
+					return columns.locationAddresses[i] > columns.locationAddresses[j]
+				},
+			},
 			rows: []flamegraphRow{
 				{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: "(null)", MappingBuildID: "(null)", LocationAddress: 0, LocationFolded: false, LocationLine: 0, Cumulative: 6, Children: []uint32{1}},    // 0
 				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationFolded: false, LocationLine: 1, Cumulative: 6, Children: []uint32{2}},    // 1
@@ -639,17 +746,22 @@ func TestGenerateFlamegraphArrowUnsymbolized(t *testing.T) {
 			require.Equal(t, int64(16), fa.NumCols())
 
 			// Convert the numRows to columns for easier access when testing below.
-			columns := rowsToColumn(tc.rows)
+			expectedColumns := rowsToColumn(tc.rows)
+			actualColumns := fgRecordToColumns(t, fa)
 
-			requireColumn(t, fa, FlamegraphFieldMappingStart, columns.mappingStart)
-			requireColumn(t, fa, FlamegraphFieldMappingLimit, columns.mappingLimit)
-			requireColumn(t, fa, FlamegraphFieldMappingOffset, columns.mappingOffset)
-			requireColumnBinaryDict(t, fa, FlamegraphFieldMappingFile, columns.mappingFiles)
-			requireColumnBinaryDict(t, fa, FlamegraphFieldMappingBuildID, columns.mappingBuildIDs)
-			requireColumn(t, fa, FlamegraphFieldLocationAddress, columns.locationAddresses)
-			requireColumn(t, fa, FlamegraphFieldLocationFolded, columns.locationFolded)
-			requireColumn(t, fa, FlamegraphFieldCumulative, columns.cumulative)
-			requireColumnChildren(t, fa, columns.children)
+			if tc.sorter != nil {
+				tc.sorter.sort(actualColumns)
+			}
+
+			require.Equal(t, expectedColumns.mappingStart, actualColumns.mappingStart)
+			require.Equal(t, expectedColumns.mappingLimit, actualColumns.mappingLimit)
+			require.Equal(t, expectedColumns.mappingOffset, actualColumns.mappingOffset)
+			require.Equal(t, expectedColumns.mappingFiles, actualColumns.mappingFiles)
+			require.Equal(t, expectedColumns.mappingBuildIDs, actualColumns.mappingBuildIDs)
+			require.Equal(t, expectedColumns.locationAddresses, actualColumns.locationAddresses)
+			require.Equal(t, expectedColumns.locationFolded, actualColumns.locationFolded)
+			require.Equal(t, expectedColumns.cumulative, actualColumns.cumulative)
+			require.Equal(t, expectedColumns.children, actualColumns.children)
 		})
 	}
 }
@@ -775,12 +887,13 @@ func TestGenerateFlamegraphArrowTrimming(t *testing.T) {
 		{FunctionName: "1", Cumulative: 14, Children: []uint32{2}},      // 1
 		{FunctionName: "2", Cumulative: 14, Children: nil},              // 2
 	}
-	columns := rowsToColumn(rows)
+	expectedColumns := rowsToColumn(rows)
+	actualColumns := fgRecordToColumns(t, fa)
 
-	requireColumnBinaryDict(t, fa, FlamegraphFieldFunctionName, columns.functionNames)
-	requireColumn(t, fa, FlamegraphFieldCumulative, columns.cumulative)
-	requireColumn(t, fa, FlamegraphFieldDiff, columns.diff)
-	requireColumnChildren(t, fa, columns.children)
+	require.Equal(t, expectedColumns.functionNames, actualColumns.functionNames)
+	require.Equal(t, expectedColumns.cumulative, actualColumns.cumulative)
+	require.Equal(t, expectedColumns.diff, actualColumns.diff)
+	require.Equal(t, expectedColumns.children, actualColumns.children)
 }
 
 func TestParents(t *testing.T) {

--- a/pkg/query/table_test.go
+++ b/pkg/query/table_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/apache/arrow/go/v14/arrow"
 	"github.com/apache/arrow/go/v14/arrow/array"
 	"github.com/apache/arrow/go/v14/arrow/memory"
 	"github.com/go-kit/log"
@@ -228,23 +229,65 @@ func TestGenerateTableAggregateFlat(t *testing.T) {
 	require.Equal(t, int64(4), rec.NumRows())
 	require.Equal(t, int64(10), cumulative)
 
-	requireColumn(t, rec, TableFieldMappingStart, []uint64{1, 1, 1, 1})
-	requireColumn(t, rec, TableFieldMappingLimit, []uint64{1, 1, 1, 1})
-	requireColumn(t, rec, TableFieldMappingOffset, []uint64{1, 1, 1, 1})
-	requireColumnBinaryDict(t, rec, TableFieldMappingFile, []string{"1", "1", "1", "1"})
-	requireColumnBinaryDict(t, rec, TableFieldMappingBuildID, []string{"1", "1", "1", "1"})
+	expectedColumns := tableColumns{
+		mappingStart:       []uint64{1, 1, 1, 1},
+		mappingLimit:       []uint64{1, 1, 1, 1},
+		mappingOffset:      []uint64{1, 1, 1, 1},
+		mappingFile:        []string{"1", "1", "1", "1"},
+		mappingBuildID:     []string{"1", "1", "1", "1"},
+		locationAddress:    []uint64{2, 1, 3, 4},
+		locationFolded:     []bool{false, false, false, false},
+		locationLine:       []int64{0, 0, 0, 0},
+		functionStartLine:  []int64{0, 0, 0, 0},
+		functionName:       []string{"(null)", "(null)", "(null)", "(null)"},
+		functionSystemName: []string{"(null)", "(null)", "(null)", "(null)"},
+		functionFileName:   []string{"(null)", "(null)", "(null)", "(null)"},
+		cumulative:         []int64{1, 10, 2, 3},
+		cumulativeDiff:     []int64{0, 0, 0, 0},
+		flat:               []int64{1, 4, 2, 3},
+		flatDiff:           []int64{0, 0, 0, 0},
+	}
+	actualColumns := tableRecordToColumns(t, rec)
 
-	requireColumn(t, rec, TableFieldLocationAddress, []uint64{2, 1, 3, 4})
-	requireColumn(t, rec, TableFieldLocationFolded, []bool{false, false, false, false})
-	requireColumn(t, rec, TableFieldLocationLine, []int64{0, 0, 0, 0})
+	require.Equal(t, expectedColumns, actualColumns)
+}
 
-	requireColumn(t, rec, TableFieldFunctionStartLine, []int64{0, 0, 0, 0})
-	requireColumnBinaryDict(t, rec, TableFieldFunctionName, []string{"(null)", "(null)", "(null)", "(null)"})
-	requireColumnBinaryDict(t, rec, TableFieldFunctionSystemName, []string{"(null)", "(null)", "(null)", "(null)"})
-	requireColumnBinaryDict(t, rec, TableFieldFunctionFileName, []string{"(null)", "(null)", "(null)", "(null)"})
+type tableColumns struct {
+	mappingStart       []uint64
+	mappingLimit       []uint64
+	mappingOffset      []uint64
+	mappingFile        []string
+	mappingBuildID     []string
+	locationAddress    []uint64
+	locationFolded     []bool
+	locationLine       []int64
+	functionStartLine  []int64
+	functionName       []string
+	functionSystemName []string
+	functionFileName   []string
+	cumulative         []int64
+	cumulativeDiff     []int64
+	flat               []int64
+	flatDiff           []int64
+}
 
-	requireColumn(t, rec, TableFieldCumulative, []int64{1, 10, 2, 3})
-	requireColumn(t, rec, TableFieldCumulativeDiff, []int64{0, 0, 0, 0})
-	requireColumn(t, rec, TableFieldFlat, []int64{1, 4, 2, 3})
-	requireColumn(t, rec, TableFieldFlatDiff, []int64{0, 0, 0, 0})
+func tableRecordToColumns(t *testing.T, r arrow.Record) tableColumns {
+	return tableColumns{
+		mappingStart:       extractColumn(t, r, TableFieldMappingStart).([]uint64),
+		mappingLimit:       extractColumn(t, r, TableFieldMappingLimit).([]uint64),
+		mappingOffset:      extractColumn(t, r, TableFieldMappingOffset).([]uint64),
+		mappingFile:        extractColumn(t, r, TableFieldMappingFile).([]string),
+		mappingBuildID:     extractColumn(t, r, TableFieldMappingBuildID).([]string),
+		locationAddress:    extractColumn(t, r, TableFieldLocationAddress).([]uint64),
+		locationFolded:     extractColumn(t, r, TableFieldLocationFolded).([]bool),
+		locationLine:       extractColumn(t, r, TableFieldLocationLine).([]int64),
+		functionStartLine:  extractColumn(t, r, TableFieldFunctionStartLine).([]int64),
+		functionName:       extractColumn(t, r, TableFieldFunctionName).([]string),
+		functionSystemName: extractColumn(t, r, TableFieldFunctionSystemName).([]string),
+		functionFileName:   extractColumn(t, r, TableFieldFunctionFileName).([]string),
+		cumulative:         extractColumn(t, r, TableFieldCumulative).([]int64),
+		cumulativeDiff:     extractColumn(t, r, TableFieldCumulativeDiff).([]int64),
+		flat:               extractColumn(t, r, TableFieldFlat).([]int64),
+		flatDiff:           extractColumn(t, r, TableFieldFlatDiff).([]int64),
+	}
 }


### PR DESCRIPTION
This improves the performance of building flamegraph API responses
dramatically. The major change is that instead of keeping children as
slices and iterating over them to find which child to step into when
building the graph, we build a key based on the fields we're aggregating
by and use that to check if the children map already contains it.

```
$ benchstat old.txt new.txt
name                old time/op  new time/op  delta
ArrowFlamegraph-10  5.04ms ± 2%  1.58ms ± 2%  -68.66%  (p=0.008 n=5+5)
```

The second commit adds some helpers to ensure we sort the result, so we get a deterministic result.