### PR TITLE
chore(renovate): allow scheduling on weekends

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>parca-dev/.github"],
-  "schedule": ["after 12am", "before 4am"],
+  "schedule": [
+    "after 8pm every weekday",
+    "before 4am every weekday",
+    "every weekend"
+  ],
   "packageRules": [
     {
       "description": "One week stability period for Buf packages",


### PR DESCRIPTION
Widen start of the scheduling window as well: lots of dependencies, so the backlog grows quickly if little time is given to process it