### PR TITLE
*: Remove unnecessary arrow structs

### DIFF
--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -33,43 +33,37 @@ var LocationsField = arrow.Field{
 		Name: "address",
 		Type: arrow.PrimitiveTypes.Uint64,
 	}, {
-		Name: "mapping",
-		Type: arrow.StructOf([]arrow.Field{{
-			Name: "start",
-			Type: arrow.PrimitiveTypes.Uint64,
-		}, {
-			Name: "limit",
-			Type: arrow.PrimitiveTypes.Uint64,
-		}, {
-			Name: "offset",
-			Type: arrow.PrimitiveTypes.Uint64,
-		}, {
-			Name: "file",
-			Type: &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Uint32, ValueType: arrow.BinaryTypes.Binary},
-		}, {
-			Name: "build_id",
-			Type: &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Uint32, ValueType: arrow.BinaryTypes.Binary},
-		}}...),
+		Name: "mapping_start",
+		Type: arrow.PrimitiveTypes.Uint64,
+	}, {
+		Name: "mapping_limit",
+		Type: arrow.PrimitiveTypes.Uint64,
+	}, {
+		Name: "mapping_offset",
+		Type: arrow.PrimitiveTypes.Uint64,
+	}, {
+		Name: "mapping_file",
+		Type: &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Uint32, ValueType: arrow.BinaryTypes.Binary},
+	}, {
+		Name: "mapping_build_id",
+		Type: &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Uint32, ValueType: arrow.BinaryTypes.Binary},
 	}, {
 		Name: "lines",
 		Type: arrow.ListOf(arrow.StructOf([]arrow.Field{{
 			Name: "line",
 			Type: arrow.PrimitiveTypes.Int64,
 		}, {
-			Name: "function",
-			Type: arrow.StructOf([]arrow.Field{{
-				Name: "name",
-				Type: &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Uint32, ValueType: arrow.BinaryTypes.Binary},
-			}, {
-				Name: "system_name",
-				Type: &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Uint32, ValueType: arrow.BinaryTypes.Binary},
-			}, {
-				Name: "filename",
-				Type: &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Uint32, ValueType: arrow.BinaryTypes.Binary},
-			}, {
-				Name: "start_line",
-				Type: arrow.PrimitiveTypes.Int64,
-			}}...),
+			Name: "function_name",
+			Type: &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Uint32, ValueType: arrow.BinaryTypes.Binary},
+		}, {
+			Name: "function_system_name",
+			Type: &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Uint32, ValueType: arrow.BinaryTypes.Binary},
+		}, {
+			Name: "function_filename",
+			Type: &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Uint32, ValueType: arrow.BinaryTypes.Binary},
+		}, {
+			Name: "function_start_line",
+			Type: arrow.PrimitiveTypes.Int64,
 		}}...)),
 	}}...)),
 }

--- a/pkg/profile/reader.go
+++ b/pkg/profile/reader.go
@@ -39,7 +39,6 @@ type RecordReader struct {
 	Locations                  *array.List
 	Location                   *array.Struct
 	Address                    *array.Uint64
-	Mapping                    *array.Struct
 	MappingStart               *array.Uint64
 	MappingLimit               *array.Uint64
 	MappingOffset              *array.Uint64
@@ -50,7 +49,6 @@ type RecordReader struct {
 	Lines                      *array.List
 	Line                       *array.Struct
 	LineNumber                 *array.Int64
-	LineFunction               *array.Struct
 	LineFunctionName           *array.Dictionary
 	LineFunctionNameDict       *array.Binary
 	LineFunctionSystemName     *array.Dictionary
@@ -98,25 +96,23 @@ func NewRecordReader(ar arrow.Record) *RecordReader {
 	locations := ar.Column(labelNum).(*array.List)
 	location := locations.ListValues().(*array.Struct)
 	address := location.Field(0).(*array.Uint64)
-	mapping := location.Field(1).(*array.Struct)
-	mappingStart := mapping.Field(0).(*array.Uint64)
-	mappingLimit := mapping.Field(1).(*array.Uint64)
-	mappingOffset := mapping.Field(2).(*array.Uint64)
-	mappingFile := mapping.Field(3).(*array.Dictionary)
+	mappingStart := location.Field(1).(*array.Uint64)
+	mappingLimit := location.Field(2).(*array.Uint64)
+	mappingOffset := location.Field(3).(*array.Uint64)
+	mappingFile := location.Field(4).(*array.Dictionary)
 	mappingFileDict := mappingFile.Dictionary().(*array.Binary)
-	mappingBuildID := mapping.Field(4).(*array.Dictionary)
+	mappingBuildID := location.Field(5).(*array.Dictionary)
 	mappingBuildIDDict := mappingBuildID.Dictionary().(*array.Binary)
-	lines := location.Field(2).(*array.List)
+	lines := location.Field(6).(*array.List)
 	line := lines.ListValues().(*array.Struct)
 	lineNumber := line.Field(0).(*array.Int64)
-	lineFunction := line.Field(1).(*array.Struct)
-	lineFunctionName := lineFunction.Field(0).(*array.Dictionary)
+	lineFunctionName := line.Field(1).(*array.Dictionary)
 	lineFunctionNameDict := lineFunctionName.Dictionary().(*array.Binary)
-	lineFunctionSystemName := lineFunction.Field(1).(*array.Dictionary)
+	lineFunctionSystemName := line.Field(2).(*array.Dictionary)
 	lineFunctionSystemNameDict := lineFunctionSystemName.Dictionary().(*array.Binary)
-	lineFunctionFilename := lineFunction.Field(2).(*array.Dictionary)
+	lineFunctionFilename := line.Field(3).(*array.Dictionary)
 	lineFunctionFilenameDict := lineFunctionFilename.Dictionary().(*array.Binary)
-	lineFunctionStartLine := lineFunction.Field(3).(*array.Int64)
+	lineFunctionStartLine := line.Field(4).(*array.Int64)
 	valueColumn := ar.Column(labelNum + 1).(*array.Int64)
 	diffColumn := ar.Column(labelNum + 2).(*array.Int64)
 
@@ -127,7 +123,6 @@ func NewRecordReader(ar arrow.Record) *RecordReader {
 		Locations:                  locations,
 		Location:                   location,
 		Address:                    address,
-		Mapping:                    mapping,
 		MappingStart:               mappingStart,
 		MappingLimit:               mappingLimit,
 		MappingOffset:              mappingOffset,
@@ -138,7 +133,6 @@ func NewRecordReader(ar arrow.Record) *RecordReader {
 		Lines:                      lines,
 		Line:                       line,
 		LineNumber:                 lineNumber,
-		LineFunction:               lineFunction,
 		LineFunctionName:           lineFunctionName,
 		LineFunctionNameDict:       lineFunctionNameDict,
 		LineFunctionSystemName:     lineFunctionSystemName,

--- a/pkg/profile/writer.go
+++ b/pkg/profile/writer.go
@@ -26,7 +26,6 @@ type Writer struct {
 	LocationsList      *array.ListBuilder
 	Locations          *array.StructBuilder
 	Addresses          *array.Uint64Builder
-	Mapping            *array.StructBuilder
 	MappingStart       *array.Uint64Builder
 	MappingLimit       *array.Uint64Builder
 	MappingOffset      *array.Uint64Builder
@@ -35,7 +34,6 @@ type Writer struct {
 	Lines              *array.ListBuilder
 	Line               *array.StructBuilder
 	LineNumber         *array.Int64Builder
-	Function           *array.StructBuilder
 	FunctionName       *array.BinaryDictionaryBuilder
 	FunctionSystemName *array.BinaryDictionaryBuilder
 	FunctionFilename   *array.BinaryDictionaryBuilder
@@ -69,21 +67,19 @@ func NewWriter(pool memory.Allocator, labelNames []string) Writer {
 
 	addresses := locations.FieldBuilder(0).(*array.Uint64Builder)
 
-	mapping := locations.FieldBuilder(1).(*array.StructBuilder)
-	mappingStart := mapping.FieldBuilder(0).(*array.Uint64Builder)
-	mappingLimit := mapping.FieldBuilder(1).(*array.Uint64Builder)
-	mappingOffset := mapping.FieldBuilder(2).(*array.Uint64Builder)
-	mappingFile := mapping.FieldBuilder(3).(*array.BinaryDictionaryBuilder)
-	mappingBuildID := mapping.FieldBuilder(4).(*array.BinaryDictionaryBuilder)
+	mappingStart := locations.FieldBuilder(1).(*array.Uint64Builder)
+	mappingLimit := locations.FieldBuilder(2).(*array.Uint64Builder)
+	mappingOffset := locations.FieldBuilder(3).(*array.Uint64Builder)
+	mappingFile := locations.FieldBuilder(4).(*array.BinaryDictionaryBuilder)
+	mappingBuildID := locations.FieldBuilder(5).(*array.BinaryDictionaryBuilder)
 
-	lines := locations.FieldBuilder(2).(*array.ListBuilder)
+	lines := locations.FieldBuilder(6).(*array.ListBuilder)
 	line := lines.ValueBuilder().(*array.StructBuilder)
 	lineNumber := line.FieldBuilder(0).(*array.Int64Builder)
-	function := line.FieldBuilder(1).(*array.StructBuilder)
-	functionName := function.FieldBuilder(0).(*array.BinaryDictionaryBuilder)
-	functionSystemName := function.FieldBuilder(1).(*array.BinaryDictionaryBuilder)
-	functionFilename := function.FieldBuilder(2).(*array.BinaryDictionaryBuilder)
-	functionStartLine := function.FieldBuilder(3).(*array.Int64Builder)
+	functionName := line.FieldBuilder(1).(*array.BinaryDictionaryBuilder)
+	functionSystemName := line.FieldBuilder(2).(*array.BinaryDictionaryBuilder)
+	functionFilename := line.FieldBuilder(3).(*array.BinaryDictionaryBuilder)
+	functionStartLine := line.FieldBuilder(4).(*array.Int64Builder)
 
 	value := b.Field(labelNum + 1).(*array.Int64Builder)
 	diff := b.Field(labelNum + 2).(*array.Int64Builder)
@@ -95,7 +91,6 @@ func NewWriter(pool memory.Allocator, labelNames []string) Writer {
 		LocationsList:      locationsList,
 		Locations:          locations,
 		Addresses:          addresses,
-		Mapping:            mapping,
 		MappingStart:       mappingStart,
 		MappingLimit:       mappingLimit,
 		MappingOffset:      mappingOffset,
@@ -104,7 +99,6 @@ func NewWriter(pool memory.Allocator, labelNames []string) Writer {
 		Lines:              lines,
 		Line:               line,
 		LineNumber:         lineNumber,
-		Function:           function,
 		FunctionName:       functionName,
 		FunctionSystemName: functionSystemName,
 		FunctionFilename:   functionFilename,
@@ -121,7 +115,6 @@ type LocationsWriter struct {
 	LocationsList      *array.ListBuilder
 	Locations          *array.StructBuilder
 	Addresses          *array.Uint64Builder
-	Mapping            *array.StructBuilder
 	MappingStart       *array.Uint64Builder
 	MappingLimit       *array.Uint64Builder
 	MappingOffset      *array.Uint64Builder
@@ -130,7 +123,6 @@ type LocationsWriter struct {
 	Lines              *array.ListBuilder
 	Line               *array.StructBuilder
 	LineNumber         *array.Int64Builder
-	Function           *array.StructBuilder
 	FunctionName       *array.BinaryDictionaryBuilder
 	FunctionSystemName *array.BinaryDictionaryBuilder
 	FunctionFilename   *array.BinaryDictionaryBuilder
@@ -147,28 +139,25 @@ func NewLocationsWriter(pool memory.Allocator) LocationsWriter {
 
 	addresses := locations.FieldBuilder(0).(*array.Uint64Builder)
 
-	mapping := locations.FieldBuilder(1).(*array.StructBuilder)
-	mappingStart := mapping.FieldBuilder(0).(*array.Uint64Builder)
-	mappingLimit := mapping.FieldBuilder(1).(*array.Uint64Builder)
-	mappingOffset := mapping.FieldBuilder(2).(*array.Uint64Builder)
-	mappingFile := mapping.FieldBuilder(3).(*array.BinaryDictionaryBuilder)
-	mappingBuildID := mapping.FieldBuilder(4).(*array.BinaryDictionaryBuilder)
+	mappingStart := locations.FieldBuilder(1).(*array.Uint64Builder)
+	mappingLimit := locations.FieldBuilder(2).(*array.Uint64Builder)
+	mappingOffset := locations.FieldBuilder(3).(*array.Uint64Builder)
+	mappingFile := locations.FieldBuilder(4).(*array.BinaryDictionaryBuilder)
+	mappingBuildID := locations.FieldBuilder(5).(*array.BinaryDictionaryBuilder)
 
-	lines := locations.FieldBuilder(2).(*array.ListBuilder)
+	lines := locations.FieldBuilder(6).(*array.ListBuilder)
 	line := lines.ValueBuilder().(*array.StructBuilder)
 	lineNumber := line.FieldBuilder(0).(*array.Int64Builder)
-	function := line.FieldBuilder(1).(*array.StructBuilder)
-	functionName := function.FieldBuilder(0).(*array.BinaryDictionaryBuilder)
-	functionSystemName := function.FieldBuilder(1).(*array.BinaryDictionaryBuilder)
-	functionFilename := function.FieldBuilder(2).(*array.BinaryDictionaryBuilder)
-	functionStartLine := function.FieldBuilder(3).(*array.Int64Builder)
+	functionName := line.FieldBuilder(1).(*array.BinaryDictionaryBuilder)
+	functionSystemName := line.FieldBuilder(2).(*array.BinaryDictionaryBuilder)
+	functionFilename := line.FieldBuilder(3).(*array.BinaryDictionaryBuilder)
+	functionStartLine := line.FieldBuilder(4).(*array.Int64Builder)
 
 	return LocationsWriter{
 		RecordBuilder:      b,
 		LocationsList:      locationsList,
 		Locations:          locations,
 		Addresses:          addresses,
-		Mapping:            mapping,
 		MappingStart:       mappingStart,
 		MappingLimit:       mappingLimit,
 		MappingOffset:      mappingOffset,
@@ -177,7 +166,6 @@ func NewLocationsWriter(pool memory.Allocator) LocationsWriter {
 		Lines:              lines,
 		Line:               line,
 		LineNumber:         lineNumber,
-		Function:           function,
 		FunctionName:       functionName,
 		FunctionSystemName: functionSystemName,
 		FunctionFilename:   functionFilename,

--- a/pkg/query/columnquery.go
+++ b/pkg/query/columnquery.go
@@ -320,7 +320,7 @@ func filterRecord(
 			llOffsetStart, llOffsetEnd := r.Lines.ValueOffsets(j)
 
 			for k := int(llOffsetStart); k < int(llOffsetEnd); k++ {
-				if r.LineFunction.IsValid(k) && bytes.Contains(bytes.ToLower(r.LineFunctionNameDict.Value(r.LineFunctionName.GetValueIndex(k))), []byte(filterQuery)) {
+				if r.LineFunctionName.IsValid(k) && bytes.Contains(bytes.ToLower(r.LineFunctionNameDict.Value(r.LineFunctionName.GetValueIndex(k))), []byte(filterQuery)) {
 					keepRow = true
 					break
 				}
@@ -347,8 +347,7 @@ func filterRecord(
 					w.Locations.Append(true)
 					w.Addresses.Append(r.Address.Value(j))
 
-					if r.Mapping.IsValid(j) {
-						w.Mapping.Append(true)
+					if r.MappingStart.IsValid(j) {
 						w.MappingStart.Append(r.MappingStart.Value(j))
 						w.MappingLimit.Append(r.MappingLimit.Value(j))
 						w.MappingOffset.Append(r.MappingOffset.Value(j))
@@ -367,7 +366,11 @@ func filterRecord(
 							}
 						}
 					} else {
-						w.Mapping.AppendNull()
+						w.MappingStart.AppendNull()
+						w.MappingLimit.AppendNull()
+						w.MappingOffset.AppendNull()
+						w.MappingFile.AppendNull()
+						w.MappingBuildID.AppendNull()
 					}
 
 					if r.Lines.IsValid(j) {
@@ -377,9 +380,8 @@ func filterRecord(
 							for k := int(llOffsetStart); k < int(llOffsetEnd); k++ {
 								w.Line.Append(true)
 								w.LineNumber.Append(r.LineNumber.Value(k))
-								w.Function.Append(r.LineFunction.IsValid(k))
 
-								if r.LineFunction.IsValid(k) {
+								if r.LineFunctionName.IsValid(k) {
 									if r.LineFunctionNameDict.Len() == 0 {
 										w.FunctionName.AppendNull()
 									} else {
@@ -402,6 +404,11 @@ func filterRecord(
 										}
 									}
 									w.FunctionStartLine.Append(r.LineFunctionStartLine.Value(k))
+								} else {
+									w.FunctionName.AppendNull()
+									w.FunctionSystemName.AppendNull()
+									w.FunctionFilename.AppendNull()
+									w.FunctionStartLine.AppendNull()
 								}
 							}
 							continue

--- a/pkg/query/columnquery_test.go
+++ b/pkg/query/columnquery_test.go
@@ -1255,13 +1255,18 @@ func PprofToSymbolizedProfile(meta profile.Meta, prof *pprofprofile.Profile, ind
 				w.Locations.Append(true)
 				w.Addresses.Append(loc.Address)
 
-				w.Mapping.Append(loc.Mapping != nil)
 				if loc.Mapping != nil {
 					w.MappingStart.Append(loc.Mapping.Start)
 					w.MappingLimit.Append(loc.Mapping.Limit)
 					w.MappingOffset.Append(loc.Mapping.Offset)
 					w.MappingFile.Append([]byte(loc.Mapping.File))
 					w.MappingBuildID.Append([]byte(loc.Mapping.BuildID))
+				} else {
+					w.MappingStart.AppendNull()
+					w.MappingLimit.AppendNull()
+					w.MappingOffset.AppendNull()
+					w.MappingFile.AppendNull()
+					w.MappingBuildID.AppendNull()
 				}
 
 				w.Lines.Append(len(loc.Line) > 0)
@@ -1269,12 +1274,16 @@ func PprofToSymbolizedProfile(meta profile.Meta, prof *pprofprofile.Profile, ind
 					for _, line := range loc.Line {
 						w.Line.Append(true)
 						w.LineNumber.Append(line.Line)
-						w.Function.Append(line.Function != nil)
 						if line.Function != nil {
 							w.FunctionName.Append([]byte(line.Function.Name))
 							w.FunctionSystemName.Append([]byte(line.Function.SystemName))
 							w.FunctionFilename.Append([]byte(line.Function.Filename))
 							w.FunctionStartLine.Append(line.Function.StartLine)
+						} else {
+							w.FunctionName.AppendNull()
+							w.FunctionSystemName.AppendNull()
+							w.FunctionFilename.AppendNull()
+							w.FunctionStartLine.AppendNull()
 						}
 					}
 				}
@@ -1325,13 +1334,18 @@ func OldProfileToArrowProfile(p profile.OldProfile) (profile.Profile, error) {
 				w.Locations.Append(true)
 				w.Addresses.Append(loc.Address)
 
-				w.Mapping.Append(loc.Mapping != nil)
 				if loc.Mapping != nil {
 					w.MappingStart.Append(loc.Mapping.Start)
 					w.MappingLimit.Append(loc.Mapping.Limit)
 					w.MappingOffset.Append(loc.Mapping.Offset)
 					w.MappingFile.Append([]byte(loc.Mapping.File))
 					w.MappingBuildID.Append([]byte(loc.Mapping.BuildId))
+				} else {
+					w.MappingStart.AppendNull()
+					w.MappingLimit.AppendNull()
+					w.MappingOffset.AppendNull()
+					w.MappingFile.AppendNull()
+					w.MappingBuildID.AppendNull()
 				}
 
 				w.Lines.Append(len(loc.Lines) > 0)
@@ -1339,12 +1353,16 @@ func OldProfileToArrowProfile(p profile.OldProfile) (profile.Profile, error) {
 					for _, line := range loc.Lines {
 						w.Line.Append(true)
 						w.LineNumber.Append(line.Line)
-						w.Function.Append(line.Function != nil)
 						if line.Function != nil {
 							w.FunctionName.Append([]byte(line.Function.Name))
 							w.FunctionSystemName.Append([]byte(line.Function.SystemName))
 							w.FunctionFilename.Append([]byte(line.Function.Filename))
 							w.FunctionStartLine.Append(line.Function.StartLine)
+						} else {
+							w.FunctionName.AppendNull()
+							w.FunctionSystemName.AppendNull()
+							w.FunctionFilename.AppendNull()
+							w.FunctionStartLine.AppendNull()
 						}
 					}
 				}

--- a/pkg/query/flamegraph_arrow.go
+++ b/pkg/query/flamegraph_arrow.go
@@ -977,7 +977,7 @@ func (fb *flamegraphBuilder) appendRow(
 	fb.builderLabelsOnly.Append(false)
 
 	// Mapping
-	if r.Mapping.IsValid(locationRow) {
+	if r.MappingStart.IsValid(locationRow) {
 		fb.builderMappingStart.Append(r.MappingStart.Value(locationRow))
 		fb.builderMappingLimit.Append(r.MappingLimit.Value(locationRow))
 		fb.builderMappingOffset.Append(r.MappingOffset.Value(locationRow))
@@ -1004,7 +1004,7 @@ func (fb *flamegraphBuilder) appendRow(
 		// something has already gone terribly wrong.
 		fb.builderLocationLine.Append(r.LineNumber.Value(lineRow))
 
-		if r.LineFunction.IsValid(lineRow) {
+		if r.LineFunctionName.IsValid(lineRow) {
 			fb.builderFunctionStartLine.Append(r.LineFunctionStartLine.Value(lineRow))
 			fb.builderFunctionNameIndices.Append(t.functionName.indices.Value(r.LineFunctionName.GetValueIndex(lineRow)))
 			fb.builderFunctionSystemNameIndices.Append(t.functionSystemName.indices.Value(r.LineFunctionSystemName.GetValueIndex(lineRow)))

--- a/pkg/query/sources.go
+++ b/pkg/query/sources.go
@@ -148,12 +148,12 @@ func (b *sourceReportBuilder) addRecord(rec arrow.Record) {
 	for i := 0; i < int(rec.NumRows()); i++ {
 		lOffsetStart, lOffsetEnd := r.Locations.ValueOffsets(i)
 		for j := int(lOffsetStart); j < int(lOffsetEnd); j++ {
-			if r.Mapping.IsValid(j) && bytes.Equal(r.MappingBuildIDDict.Value(r.MappingBuildID.GetValueIndex(j)), b.buildID) {
+			if r.MappingStart.IsValid(j) && bytes.Equal(r.MappingBuildIDDict.Value(r.MappingBuildID.GetValueIndex(j)), b.buildID) {
 				llOffsetStart, llOffsetEnd := r.Lines.ValueOffsets(j)
 
 				for k := int(llOffsetStart); k < int(llOffsetEnd); k++ {
 					if r.Line.IsValid(k) && r.LineNumber.Value(k) <= b.numLines &&
-						r.LineFunction.IsValid(k) && bytes.Equal(r.LineFunctionFilenameDict.Value(r.LineFunctionFilename.GetValueIndex(k)), b.filename) {
+						r.LineFunctionName.IsValid(k) && bytes.Equal(r.LineFunctionFilenameDict.Value(r.LineFunctionFilename.GetValueIndex(k)), b.filename) {
 						b.cumulativeValues[r.LineNumber.Value(k)-1] += r.Value.Value(i)
 
 						isLeaf := j == int(lOffsetStart) && k == int(llOffsetStart)

--- a/pkg/query/table.go
+++ b/pkg/query/table.go
@@ -141,7 +141,7 @@ func generateTableArrowRecord(
 					for lineRow := int(llOffsetStart); lineRow < int(llOffsetEnd); lineRow++ {
 						isLeaf := locationRow == int(lOffsetStart) && lineRow == int(llOffsetStart)
 
-						if r.Line.IsValid(lineRow) && r.LineFunction.IsValid(lineRow) {
+						if r.Line.IsValid(lineRow) && r.LineFunctionName.IsValid(lineRow) {
 							fn := r.LineFunctionNameDict.Value(r.LineFunctionName.GetValueIndex(lineRow))
 							if cr, ok := tb.functions[unsafeString(fn)]; !ok {
 								if err := tb.appendRow(r, sampleRow, locationRow, lineRow, isLeaf); err != nil {
@@ -261,19 +261,19 @@ func (tb *tableBuilder) appendRow(
 		switch tb.schema.Field(j).Name {
 		// Mapping
 		case TableFieldMappingStart:
-			if r.Mapping.IsValid(locationRow) && r.MappingStart.Value(locationRow) > 0 {
+			if r.MappingStart.IsValid(locationRow) {
 				tb.builderMappingStart.Append(r.MappingStart.Value(locationRow))
 			} else {
 				tb.builderMappingStart.AppendNull()
 			}
 		case TableFieldMappingLimit:
-			if r.Mapping.IsValid(locationRow) && r.MappingLimit.Value(locationRow) > 0 {
+			if r.MappingLimit.IsValid(locationRow) {
 				tb.builderMappingLimit.Append(r.MappingLimit.Value(locationRow))
 			} else {
 				tb.builderMappingLimit.AppendNull()
 			}
 		case TableFieldMappingOffset:
-			if r.Mapping.IsValid(locationRow) && r.MappingOffset.Value(locationRow) > 0 {
+			if r.MappingOffset.IsValid(locationRow) {
 				tb.builderMappingOffset.Append(r.MappingOffset.Value(locationRow))
 			} else {
 				tb.builderMappingOffset.AppendNull()
@@ -282,7 +282,7 @@ func (tb *tableBuilder) appendRow(
 			if r.MappingFileDict.Len() == 0 {
 				tb.builderMappingFile.AppendNull()
 			} else {
-				if r.Mapping.IsValid(locationRow) && len(r.MappingFileDict.Value(r.MappingFile.GetValueIndex(locationRow))) > 0 {
+				if r.MappingFile.IsValid(locationRow) {
 					_ = tb.builderMappingFile.Append(r.MappingFileDict.Value(r.MappingFile.GetValueIndex(locationRow)))
 				} else {
 					tb.builderMappingFile.AppendNull()
@@ -292,7 +292,7 @@ func (tb *tableBuilder) appendRow(
 			if r.MappingBuildIDDict.Len() == 0 {
 				tb.builderMappingBuildID.AppendNull()
 			} else {
-				if r.Mapping.IsValid(locationRow) && len(r.MappingBuildIDDict.Value(r.MappingBuildID.GetValueIndex(locationRow))) > 0 {
+				if r.MappingBuildID.IsValid(locationRow) {
 					_ = tb.builderMappingBuildID.Append(r.MappingBuildIDDict.Value(r.MappingBuildID.GetValueIndex(locationRow)))
 				} else {
 					tb.builderMappingBuildID.AppendNull()
@@ -313,7 +313,7 @@ func (tb *tableBuilder) appendRow(
 			}
 		// Function
 		case TableFieldFunctionStartLine:
-			if lineRow >= 0 && r.LineFunction.IsValid(lineRow) && r.LineFunctionStartLine.Value(lineRow) > 0 {
+			if lineRow >= 0 && r.LineFunctionStartLine.Value(lineRow) > 0 {
 				tb.builderFunctionStartLine.Append(r.LineFunctionStartLine.Value(lineRow))
 			} else {
 				tb.builderFunctionStartLine.AppendNull()
@@ -322,7 +322,7 @@ func (tb *tableBuilder) appendRow(
 			if r.LineFunctionNameDict.Len() == 0 || lineRow == -1 {
 				tb.builderFunctionName.AppendNull()
 			} else {
-				if lineRow >= 0 && r.LineFunction.IsValid(lineRow) && len(r.LineFunctionNameDict.Value(r.LineFunctionName.GetValueIndex(lineRow))) > 0 {
+				if lineRow >= 0 && r.LineFunctionName.IsValid(lineRow) {
 					_ = tb.builderFunctionName.Append(r.LineFunctionNameDict.Value(r.LineFunctionName.GetValueIndex(lineRow)))
 				} else {
 					tb.builderFunctionName.AppendNull()
@@ -332,7 +332,7 @@ func (tb *tableBuilder) appendRow(
 			if r.LineFunctionSystemNameDict.Len() == 0 || lineRow == -1 {
 				tb.builderFunctionSystemName.AppendNull()
 			} else {
-				if lineRow >= 0 && r.LineFunction.IsValid(lineRow) && len(r.LineFunctionSystemNameDict.Value(r.LineFunctionSystemName.GetValueIndex(lineRow))) > 0 {
+				if lineRow >= 0 && r.LineFunctionSystemName.IsValid(lineRow) {
 					_ = tb.builderFunctionSystemName.Append(r.LineFunctionSystemNameDict.Value(r.LineFunctionSystemName.GetValueIndex(lineRow)))
 				} else {
 					tb.builderFunctionSystemName.AppendNull()
@@ -342,7 +342,7 @@ func (tb *tableBuilder) appendRow(
 			if r.LineFunctionFilenameDict.Len() == 0 || lineRow == -1 {
 				tb.builderFunctionFileName.AppendNull()
 			} else {
-				if lineRow >= 0 && r.LineFunction.IsValid(lineRow) && len(r.LineFunctionFilenameDict.Value(r.LineFunctionFilename.GetValueIndex(lineRow))) > 0 {
+				if lineRow >= 0 && r.LineFunctionFilename.IsValid(lineRow) {
 					_ = tb.builderFunctionFileName.Append(r.LineFunctionFilenameDict.Value(r.LineFunctionFilename.GetValueIndex(lineRow)))
 				} else {
 					tb.builderFunctionFileName.AppendNull()


### PR DESCRIPTION
Anything that needs to be built adds latency to the query path, and this removes a number of dynamic dispatch calls and prevents 2 validity bitmaps from being built.