### PR TITLE
pkg/query/flamegraph_arrow: Add testing flamegraphComparer

### DIFF
--- a/pkg/query/flamegraph_arrow_test.go
+++ b/pkg/query/flamegraph_arrow_test.go
@@ -538,16 +538,18 @@ func (c *flamegraphComparer) compare(expected flamegraphColumns) {
 			if labelsOnlyA && labelsOnlyB {
 				labelsA := labels.FromMap(c.actual.labels[children[a]]).String()
 				labelsB := labels.FromMap(c.actual.labels[children[b]]).String()
-				if labelsA < labelsB {
-					return true
-				}
-				return false
+				return labelsA < labelsB
 			}
 			if labelsOnlyA && !labelsOnlyB {
 				return true
 			}
 			if c.actual.functionNames[children[a]] < c.actual.functionNames[children[b]] {
 				return true
+			}
+			if c.actual.functionNames[children[a]] != "" && c.actual.functionNames[children[b]] != "" {
+				addrA := c.actual.locationAddresses[children[a]]
+				addrB := c.actual.locationAddresses[children[b]]
+				return addrA < addrB
 			}
 
 			return false
@@ -805,8 +807,8 @@ func TestGenerateFlamegraphArrowUnsymbolized(t *testing.T) {
 				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 6, Children: []uint32{2}},    // 1
 				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 6, Children: []uint32{3}},    // 2
 				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 4, Children: []uint32{4, 5}}, // 3
-				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa5, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 1, Children: nil},            // 4
-				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa4, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 3, Children: nil},            // 5
+				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa4, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 3, Children: nil},            // 4
+				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa5, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 1, Children: nil},            // 5
 			},
 		},
 	} {

--- a/pkg/query/flamegraph_arrow_test.go
+++ b/pkg/query/flamegraph_arrow_test.go
@@ -704,11 +704,11 @@ func TestGenerateFlamegraphArrowWithInlined(t *testing.T) {
 	require.Equal(t, int64(5), record.NumRows())
 
 	rows := []flamegraphRow{
-		{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0, LocationLine: 0, FunctionStartLine: 0, FunctionName: "(null)", FunctionSystemName: "(null)", FunctionFilename: "(null)", Cumulative: 1, Labels: nil, Children: []uint32{1}},                                                                                             // 0
-		{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationLine: 173, FunctionStartLine: 0, FunctionName: "net.(*netFD).accept", FunctionSystemName: "net.(*netFD).accept", FunctionFilename: "net/fd_unix.go", Cumulative: 1, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{2}},                 // 1
-		{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationLine: 402, FunctionStartLine: 0, FunctionName: "internal/poll.(*pollDesc).waitRead", FunctionSystemName: "internal/poll.(*pollDesc).waitRead", FunctionFilename: "internal/poll/fd_poll_runtime.go", Cumulative: 1, Labels: nil, Children: []uint32{3}}, // 2
-		{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationLine: 89, FunctionStartLine: 0, FunctionName: "internal/poll.(*FD).Accept", FunctionSystemName: "internal/poll.(*FD).Accept", FunctionFilename: "internal/poll/fd_unix.go", Cumulative: 1, Labels: nil, Children: []uint32{4}},                          // 3
-		{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationLine: 84, FunctionStartLine: 0, FunctionName: "internal/poll.(*pollDesc).wait", FunctionSystemName: "internal/poll.(*pollDesc).wait", FunctionFilename: "internal/poll/fd_poll_runtime.go", Cumulative: 1, Labels: nil, Children: nil},                  // 4
+		{MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0, LocationLine: 0, FunctionStartLine: 0, FunctionName: "(null)", FunctionSystemName: "(null)", FunctionFilename: "(null)", Cumulative: 1, Labels: nil, Children: []uint32{1}},                                                                                        // 0
+		{MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0xa1, LocationLine: 173, FunctionStartLine: 0, FunctionName: "net.(*netFD).accept", FunctionSystemName: "net.(*netFD).accept", FunctionFilename: "net/fd_unix.go", Cumulative: 1, Labels: nil, Children: []uint32{2}},                                                 // 1
+		{MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0xa2, LocationLine: 402, FunctionStartLine: 0, FunctionName: "internal/poll.(*pollDesc).waitRead", FunctionSystemName: "internal/poll.(*pollDesc).waitRead", FunctionFilename: "internal/poll/fd_poll_runtime.go", Cumulative: 1, Labels: nil, Children: []uint32{3}}, // 2
+		{MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0xa2, LocationLine: 89, FunctionStartLine: 0, FunctionName: "internal/poll.(*FD).Accept", FunctionSystemName: "internal/poll.(*FD).Accept", FunctionFilename: "internal/poll/fd_unix.go", Cumulative: 1, Labels: nil, Children: []uint32{4}},                          // 3
+		{MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0xa3, LocationLine: 84, FunctionStartLine: 0, FunctionName: "internal/poll.(*pollDesc).wait", FunctionSystemName: "internal/poll.(*pollDesc).wait", FunctionFilename: "internal/poll/fd_poll_runtime.go", Cumulative: 1, Labels: nil, Children: nil},                  // 4
 	}
 	expectedColumns := rowsToColumn(rows)
 
@@ -801,12 +801,12 @@ func TestGenerateFlamegraphArrowUnsymbolized(t *testing.T) {
 			height:     5,
 			trimmed:    0,
 			rows: []flamegraphRow{
-				{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: "(null)", MappingBuildID: "(null)", LocationAddress: 0, LocationLine: 0, Cumulative: 6, Children: []uint32{1}},    // 0
-				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationLine: 1, Cumulative: 6, Children: []uint32{2}},    // 1
-				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationLine: 2, Cumulative: 6, Children: []uint32{3}},    // 2
-				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationLine: 3, Cumulative: 4, Children: []uint32{4, 5}}, // 3
-				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa5, LocationLine: 5, Cumulative: 1, Children: nil},            // 4
-				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa4, LocationLine: 4, Cumulative: 3, Children: nil},            // 5
+				{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: "(null)", MappingBuildID: "(null)", LocationAddress: 0, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 6, Children: []uint32{1}},    // 0
+				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 6, Children: []uint32{2}},    // 1
+				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 6, Children: []uint32{3}},    // 2
+				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 4, Children: []uint32{4, 5}}, // 3
+				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa5, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 1, Children: nil},            // 4
+				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa4, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 3, Children: nil},            // 5
 			},
 		},
 	} {
@@ -949,10 +949,11 @@ func TestGenerateFlamegraphArrowTrimming(t *testing.T) {
 	require.Equal(t, int64(3), fa.NumRows())
 	require.Equal(t, int64(15), fa.NumCols())
 
+	// TODO: MappingBuildID and FunctionSystemNames shouldn't be "" but null?
 	rows := []flamegraphRow{
-		{FunctionName: "(null)", Cumulative: 14, Children: []uint32{1}}, // 0
-		{FunctionName: "1", Cumulative: 14, Children: []uint32{2}},      // 1
-		{FunctionName: "2", Cumulative: 14, Children: nil},              // 2
+		{MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 14, Children: []uint32{1}}, // 0
+		{MappingFile: "a", MappingBuildID: "", FunctionName: "1", FunctionSystemName: "", FunctionFilename: "", Cumulative: 14, Children: []uint32{2}},                                                                               // 1
+		{MappingFile: "a", MappingBuildID: "", FunctionName: "2", FunctionSystemName: "", FunctionFilename: "", Cumulative: 14, Children: nil},                                                                                       // 2
 	}
 	expectedColumns := rowsToColumn(rows)
 

--- a/pkg/query/flamegraph_arrow_test.go
+++ b/pkg/query/flamegraph_arrow_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -30,6 +31,7 @@ import (
 	pprofprofile "github.com/google/pprof/profile"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/trace"
 
@@ -118,23 +120,6 @@ func (c flamegraphColumns) swap(i, j int) {
 	c.children[i], c.children[j] = c.children[j], c.children[i]
 	c.cumulative[i], c.cumulative[j] = c.cumulative[j], c.cumulative[i]
 	c.diff[i], c.diff[j] = c.diff[j], c.diff[i]
-}
-
-type flamegraphColumnSorter struct {
-	columns flamegraphColumns
-	less    func(c flamegraphColumns, a, b int) bool
-	slices  [][2]int
-}
-
-func (s *flamegraphColumnSorter) Len() int           { return len(s.columns.labelsOnly) }
-func (s *flamegraphColumnSorter) Swap(i, j int)      { s.columns.swap(i, j) }
-func (s *flamegraphColumnSorter) Less(i, j int) bool { return s.less(s.columns, i, j) }
-
-func (s *flamegraphColumnSorter) sort(columns flamegraphColumns) {
-	for _, slice := range s.slices {
-		s.columns = columns.slice(slice[0], slice[1])
-		sort.Sort(s)
-	}
 }
 
 func rowsToColumn(rows []flamegraphRow) flamegraphColumns {
@@ -404,7 +389,6 @@ func TestGenerateFlamegraphArrow(t *testing.T) {
 		aggregate []string
 		// expectations
 		rows       []flamegraphRow
-		sorter     *flamegraphColumnSorter
 		cumulative int64
 		height     int32
 		trimmed    int64
@@ -415,19 +399,13 @@ func TestGenerateFlamegraphArrow(t *testing.T) {
 		cumulative: 10,
 		height:     5,
 		trimmed:    0,
-		sorter: &flamegraphColumnSorter{
-			slices: [][2]int{{4, 6}}, // lines 4 and 5 are not in stable order in the result so we need to sort them for the test to be deterministic, so the range we want to sort is [4, 6)
-			less: func(columns flamegraphColumns, i, j int) bool {
-				return columns.functionNames[i] > columns.functionNames[j]
-			},
-		},
 		rows: []flamegraphRow{
 			{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0, LocationLine: 0, FunctionStartLine: 0, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 10, Labels: nil, Children: []uint32{1}}, // 0
 			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 10, Labels: nil, Children: []uint32{2}},                                                                  // 1
 			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationLine: 2, FunctionStartLine: 2, FunctionName: "2", FunctionSystemName: "2", FunctionFilename: "2", Cumulative: 10, Labels: nil, Children: []uint32{3}},                                                                  // 2
 			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationLine: 3, FunctionStartLine: 3, FunctionName: "3", FunctionSystemName: "3", FunctionFilename: "3", Cumulative: 8, Labels: nil, Children: []uint32{4, 5}},                                                                // 3
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa5, LocationLine: 5, FunctionStartLine: 5, FunctionName: "5", FunctionSystemName: "5", FunctionFilename: "5", Cumulative: 5, Labels: nil, Children: nil},                                                                           // 4
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa4, LocationLine: 4, FunctionStartLine: 4, FunctionName: "4", FunctionSystemName: "4", FunctionFilename: "4", Cumulative: 3, Labels: nil, Children: nil},                                                                           // 5
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa4, LocationLine: 4, FunctionStartLine: 4, FunctionName: "4", FunctionSystemName: "4", FunctionFilename: "4", Cumulative: 3, Labels: nil, Children: nil},                                                                           // 4
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa5, LocationLine: 5, FunctionStartLine: 5, FunctionName: "5", FunctionSystemName: "5", FunctionFilename: "5", Cumulative: 5, Labels: nil, Children: nil},                                                                           // 5
 		},
 	}, {
 		name:      "aggregate-pprof-labels",
@@ -437,27 +415,25 @@ func TestGenerateFlamegraphArrow(t *testing.T) {
 		height:     6,
 		trimmed:    0,
 		rows: []flamegraphRow{
-			// level 0 - root
-			{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0, LocationLine: 0, FunctionStartLine: 0, FunctionName: `(null)`, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 10, Labels: nil, Children: []uint32{1, 2, 3}}, // 0
-			// level 1
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 3, Labels: nil, Children: []uint32{4}},                                                                                                          // 1
-			{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0, LocationLine: 0, FunctionStartLine: 0, FunctionName: `(null)`, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 4, Labels: map[string]string{"goroutine": "2"}, Children: []uint32{5}, LabelsOnly: true}, // 2
-			{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0, LocationLine: 0, FunctionStartLine: 0, FunctionName: `(null)`, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 3, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{6}, LabelsOnly: true}, // 3
-			// level 2
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationLine: 2, FunctionStartLine: 2, FunctionName: "2", FunctionSystemName: "2", FunctionFilename: "2", Cumulative: 3, Labels: nil, Children: []uint32{7}},                                 // 4
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 4, Labels: map[string]string{"goroutine": "2"}, Children: []uint32{8}}, // 6
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 3, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{9}}, // 5
-			// level 3
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationLine: 3, FunctionStartLine: 3, FunctionName: "3", FunctionSystemName: "3", FunctionFilename: "3", Cumulative: 3, Labels: nil, Children: []uint32{10}},                                 // 7
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationLine: 2, FunctionStartLine: 2, FunctionName: "2", FunctionSystemName: "2", FunctionFilename: "2", Cumulative: 4, Labels: map[string]string{"goroutine": "2"}, Children: []uint32{11}}, // 9
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationLine: 2, FunctionStartLine: 2, FunctionName: "2", FunctionSystemName: "2", FunctionFilename: "2", Cumulative: 3, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{12}}, // 8
-			// level 4
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa4, LocationLine: 4, FunctionStartLine: 4, FunctionName: "4", FunctionSystemName: "4", FunctionFilename: "4", Cumulative: 3, Labels: nil, Children: nil},                                          // 10
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationLine: 3, FunctionStartLine: 3, FunctionName: "3", FunctionSystemName: "3", FunctionFilename: "3", Cumulative: 4, Labels: map[string]string{"goroutine": "2"}, Children: []uint32{13}}, // 12
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationLine: 3, FunctionStartLine: 3, FunctionName: "3", FunctionSystemName: "3", FunctionFilename: "3", Cumulative: 1, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{14}}, // 11
-			// level 5
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa5, LocationLine: 5, FunctionStartLine: 5, FunctionName: "5", FunctionSystemName: "5", FunctionFilename: "5", Cumulative: 4, Labels: map[string]string{"goroutine": "2"}, Children: nil}, // 13
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa5, LocationLine: 5, FunctionStartLine: 5, FunctionName: "5", FunctionSystemName: "5", FunctionFilename: "5", Cumulative: 1, Labels: map[string]string{"goroutine": "1"}, Children: nil}, // 14
+			// root
+			{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0, LocationLine: 0, FunctionStartLine: 0, FunctionName: `(null)`, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 10, Labels: nil, Children: []uint32{1, 6, 11}}, // 0
+			// stack 1
+			{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0, LocationLine: 0, FunctionStartLine: 0, FunctionName: `(null)`, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 3, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{2}, LabelsOnly: true}, // 1
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 3, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{3}},                                                                          // 2
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationLine: 2, FunctionStartLine: 2, FunctionName: "2", FunctionSystemName: "2", FunctionFilename: "2", Cumulative: 3, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{4}},                                                                          // 3
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationLine: 3, FunctionStartLine: 3, FunctionName: "3", FunctionSystemName: "3", FunctionFilename: "3", Cumulative: 1, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{5}},                                                                          // 4
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa5, LocationLine: 5, FunctionStartLine: 5, FunctionName: "5", FunctionSystemName: "5", FunctionFilename: "5", Cumulative: 1, Labels: map[string]string{"goroutine": "1"}, Children: nil},                                                                                  // 5
+			// stack 2
+			{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0, LocationLine: 0, FunctionStartLine: 0, FunctionName: `(null)`, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 4, Labels: map[string]string{"goroutine": "2"}, Children: []uint32{7}, LabelsOnly: true}, // 6
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 4, Labels: map[string]string{"goroutine": "2"}, Children: []uint32{8}},                                                                          // 7
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationLine: 2, FunctionStartLine: 2, FunctionName: "2", FunctionSystemName: "2", FunctionFilename: "2", Cumulative: 4, Labels: map[string]string{"goroutine": "2"}, Children: []uint32{9}},                                                                          // 8
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationLine: 3, FunctionStartLine: 3, FunctionName: "3", FunctionSystemName: "3", FunctionFilename: "3", Cumulative: 4, Labels: map[string]string{"goroutine": "2"}, Children: []uint32{10}},                                                                         // 9
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa5, LocationLine: 5, FunctionStartLine: 5, FunctionName: "5", FunctionSystemName: "5", FunctionFilename: "5", Cumulative: 4, Labels: map[string]string{"goroutine": "2"}, Children: nil},                                                                                  // 10
+			// stack 3
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 3, Labels: nil, Children: []uint32{12}}, // 11
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationLine: 2, FunctionStartLine: 2, FunctionName: "2", FunctionSystemName: "2", FunctionFilename: "2", Cumulative: 3, Labels: nil, Children: []uint32{13}}, // 12
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationLine: 3, FunctionStartLine: 3, FunctionName: "3", FunctionSystemName: "3", FunctionFilename: "3", Cumulative: 3, Labels: nil, Children: []uint32{14}}, // 13
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa4, LocationLine: 4, FunctionStartLine: 4, FunctionName: "4", FunctionSystemName: "4", FunctionFilename: "4", Cumulative: 3, Labels: nil, Children: nil},          // 14
 		},
 	}, {
 		name:      "aggregate-mapping-file",
@@ -465,27 +441,18 @@ func TestGenerateFlamegraphArrow(t *testing.T) {
 		// expectations
 		cumulative: 10,
 		height:     5,
-		trimmed:    0, // TODO
-		sorter: &flamegraphColumnSorter{
-			slices: [][2]int{{4, 6}}, // lines 4 and 5 are not in stable order in the result so we need to sort them for the test to be deterministic, so the range we want to sort is [4, 6)
-			less: func(columns flamegraphColumns, i, j int) bool {
-				return columns.functionNames[i] > columns.functionNames[j]
-			},
-		},
+		trimmed:    0,
 		rows: []flamegraphRow{
 			// This aggregates all the rows with the same mapping file, meaning that we only keep one flamegraphRow per stack depth in this example.
 			{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0, LocationLine: 0, FunctionStartLine: 0, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 10, Labels: nil, Children: []uint32{1}}, // 0
 			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 10, Labels: nil, Children: []uint32{2}},                                                                  // 1
 			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationLine: 2, FunctionStartLine: 2, FunctionName: "2", FunctionSystemName: "2", FunctionFilename: "2", Cumulative: 10, Labels: nil, Children: []uint32{3}},                                                                  // 2
 			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationLine: 3, FunctionStartLine: 3, FunctionName: "3", FunctionSystemName: "3", FunctionFilename: "3", Cumulative: 8, Labels: nil, Children: []uint32{4, 5}},                                                                // 3
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa5, LocationLine: 5, FunctionStartLine: 5, FunctionName: "5", FunctionSystemName: "5", FunctionFilename: "5", Cumulative: 5, Labels: nil, Children: nil},                                                                           // 4
 			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa4, LocationLine: 4, FunctionStartLine: 4, FunctionName: "4", FunctionSystemName: "4", FunctionFilename: "4", Cumulative: 3, Labels: nil, Children: nil},                                                                           // 4
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa5, LocationLine: 5, FunctionStartLine: 5, FunctionName: "5", FunctionSystemName: "5", FunctionFilename: "5", Cumulative: 5, Labels: nil, Children: nil},                                                                           // 5
 		},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.name == "aggregate-pprof-labels" {
-				t.Skip("TODO: requires custom comparison logic due to ordering")
-			}
 			np, err := OldProfileToArrowProfile(p)
 			require.NoError(t, err)
 
@@ -505,30 +472,141 @@ func TestGenerateFlamegraphArrow(t *testing.T) {
 
 			// Convert the numRows to columns for easier access when testing below.
 			expectedColumns := rowsToColumn(tc.rows)
-			actualColumns := fgRecordToColumns(t, fa)
 
-			if tc.sorter != nil {
-				tc.sorter.sort(actualColumns)
-			}
-
-			require.Equal(t, expectedColumns.labelsOnly, actualColumns.labelsOnly)
-			require.Equal(t, expectedColumns.mappingStart, actualColumns.mappingStart)
-			require.Equal(t, expectedColumns.mappingLimit, actualColumns.mappingLimit)
-			require.Equal(t, expectedColumns.mappingOffset, actualColumns.mappingOffset)
-			require.Equal(t, expectedColumns.mappingFiles, actualColumns.mappingFiles)
-			require.Equal(t, expectedColumns.mappingBuildIDs, actualColumns.mappingBuildIDs)
-			require.Equal(t, expectedColumns.locationAddresses, actualColumns.locationAddresses)
-			require.Equal(t, expectedColumns.locationLines, actualColumns.locationLines)
-			require.Equal(t, expectedColumns.functionStartLines, actualColumns.functionStartLines)
-			require.Equal(t, expectedColumns.functionNames, actualColumns.functionNames)
-			require.Equal(t, expectedColumns.functionSystemNames, actualColumns.functionSystemNames)
-			require.Equal(t, expectedColumns.functionFileNames, actualColumns.functionFileNames)
-			require.Equal(t, expectedColumns.labels, actualColumns.labels)
-			require.Equal(t, expectedColumns.children, actualColumns.children)
-			require.Equal(t, expectedColumns.cumulative, actualColumns.cumulative)
-			require.Equal(t, expectedColumns.diff, actualColumns.diff)
+			fc := newFlamegraphComparer(t)
+			fc.convert(fa)
+			fc.compare(expectedColumns)
 		})
 	}
+}
+
+type flamegraphComparer struct {
+	t      *testing.T
+	stack  *flamegraphComparerStack
+	actual flamegraphColumns
+}
+
+func newFlamegraphComparer(t *testing.T) *flamegraphComparer {
+	return &flamegraphComparer{
+		t:     t,
+		stack: &flamegraphComparerStack{elements: []flamegraphCompareElement{{row: 0}}}, // start with the root
+	}
+}
+
+func (c *flamegraphComparer) convert(r arrow.Record) {
+	c.t.Helper()
+	c.actual = flamegraphColumns{
+		labelsOnly:          extractColumn(c.t, r, FlamegraphFieldLabelsOnly).([]bool),
+		mappingStart:        extractColumn(c.t, r, FlamegraphFieldMappingStart).([]uint64),
+		mappingLimit:        extractColumn(c.t, r, FlamegraphFieldMappingLimit).([]uint64),
+		mappingOffset:       extractColumn(c.t, r, FlamegraphFieldMappingOffset).([]uint64),
+		mappingFiles:        extractColumn(c.t, r, FlamegraphFieldMappingFile).([]string),
+		mappingBuildIDs:     extractColumn(c.t, r, FlamegraphFieldMappingBuildID).([]string),
+		locationAddresses:   extractColumn(c.t, r, FlamegraphFieldLocationAddress).([]uint64),
+		locationLines:       extractColumn(c.t, r, FlamegraphFieldLocationLine).([]int64),
+		functionStartLines:  extractColumn(c.t, r, FlamegraphFieldFunctionStartLine).([]int64),
+		functionNames:       extractColumn(c.t, r, FlamegraphFieldFunctionName).([]string),
+		functionSystemNames: extractColumn(c.t, r, FlamegraphFieldFunctionSystemName).([]string),
+		functionFileNames:   extractColumn(c.t, r, FlamegraphFieldFunctionFileName).([]string),
+		labels:              extractLabelColumns(c.t, r),
+		children:            extractChildrenColumn(c.t, r),
+		cumulative:          extractColumn(c.t, r, FlamegraphFieldCumulative).([]int64),
+		diff:                extractColumn(c.t, r, FlamegraphFieldDiff).([]int64),
+	}
+}
+
+func (c *flamegraphComparer) compare(expected flamegraphColumns) {
+	c.t.Helper()
+
+	order := make([]int, 0, len(c.actual.cumulative))
+	sortedChildren := make([][]uint32, len(c.actual.cumulative))
+
+	var i int
+	for c.stack.Len() > 0 {
+		r := c.stack.Pop()
+		order = append(order, r.row)
+		if r.row != 0 {
+			sortedChildren[r.parent] = append(sortedChildren[r.parent], uint32(i))
+		}
+
+		children := c.actual.children[r.row]
+		// This will sort the children by their values to guarantee a deterministic order for tests.
+		sort.Slice(children, func(a, b int) bool {
+			labelsOnlyA := c.actual.labelsOnly[children[a]]
+			labelsOnlyB := c.actual.labelsOnly[children[b]]
+
+			if labelsOnlyA && labelsOnlyB {
+				labelsA := labels.FromMap(c.actual.labels[children[a]]).String()
+				labelsB := labels.FromMap(c.actual.labels[children[b]]).String()
+				if labelsA < labelsB {
+					return true
+				}
+				return false
+			}
+			if labelsOnlyA && !labelsOnlyB {
+				return true
+			}
+			if c.actual.functionNames[children[a]] < c.actual.functionNames[children[b]] {
+				return true
+			}
+
+			return false
+		})
+
+		slices.Reverse(children) // since using a stack, we need to reverse the children to get the correct order
+		for _, child := range children {
+			c.stack.Push(flamegraphCompareElement{parent: i, row: int(child)})
+		}
+		i++
+	}
+
+	require.Equal(c.t, expected.labelsOnly, reorder(c.actual.labelsOnly, order))
+	require.Equal(c.t, expected.mappingStart, reorder(c.actual.mappingStart, order))
+	require.Equal(c.t, expected.mappingLimit, reorder(c.actual.mappingLimit, order))
+	require.Equal(c.t, expected.mappingOffset, reorder(c.actual.mappingOffset, order))
+	require.Equal(c.t, expected.mappingFiles, reorder(c.actual.mappingFiles, order))
+	require.Equal(c.t, expected.mappingBuildIDs, reorder(c.actual.mappingBuildIDs, order))
+	require.Equal(c.t, expected.locationAddresses, reorder(c.actual.locationAddresses, order))
+	require.Equal(c.t, expected.locationLines, reorder(c.actual.locationLines, order))
+	require.Equal(c.t, expected.functionStartLines, reorder(c.actual.functionStartLines, order))
+	require.Equal(c.t, expected.functionNames, reorder(c.actual.functionNames, order))
+	require.Equal(c.t, expected.functionSystemNames, reorder(c.actual.functionSystemNames, order))
+	require.Equal(c.t, expected.functionFileNames, reorder(c.actual.functionFileNames, order))
+	require.Equal(c.t, expected.labels, reorder(c.actual.labels, order))
+	require.Equal(c.t, expected.cumulative, reorder(c.actual.cumulative, order), order)
+	require.Equal(c.t, expected.diff, reorder(c.actual.diff, order))
+	require.Equal(c.t, expected.children, sortedChildren)
+}
+
+func reorder[T any](slice []T, order []int) []T {
+	res := make([]T, len(slice))
+	for i, o := range order {
+		res[i] = slice[o]
+	}
+	return res
+}
+
+type flamegraphCompareElement struct {
+	parent int
+	row    int
+}
+
+type flamegraphComparerStack struct {
+	elements []flamegraphCompareElement
+}
+
+func (s *flamegraphComparerStack) Push(e flamegraphCompareElement) {
+	s.elements = append(s.elements, e)
+}
+
+func (s *flamegraphComparerStack) Pop() flamegraphCompareElement {
+	e := s.elements[len(s.elements)-1]
+	s.elements = s.elements[:len(s.elements)-1]
+	return e
+}
+
+func (s *flamegraphComparerStack) Len() int {
+	return len(s.elements)
 }
 
 func TestGenerateFlamegraphArrowEmpty(t *testing.T) {
@@ -633,17 +711,10 @@ func TestGenerateFlamegraphArrowWithInlined(t *testing.T) {
 		{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationLine: 84, FunctionStartLine: 0, FunctionName: "internal/poll.(*pollDesc).wait", FunctionSystemName: "internal/poll.(*pollDesc).wait", FunctionFilename: "internal/poll/fd_poll_runtime.go", Cumulative: 1, Labels: nil, Children: nil},                  // 4
 	}
 	expectedColumns := rowsToColumn(rows)
-	actualColumns := fgRecordToColumns(t, record)
 
-	// mapping fields are all null here
-	require.Equal(t, expectedColumns.locationAddresses, actualColumns.locationAddresses)
-	require.Equal(t, expectedColumns.locationLines, actualColumns.locationLines)
-	require.Equal(t, expectedColumns.functionStartLines, actualColumns.functionStartLines)
-	require.Equal(t, expectedColumns.functionNames, actualColumns.functionNames)
-	require.Equal(t, expectedColumns.functionSystemNames, actualColumns.functionSystemNames)
-	require.Equal(t, expectedColumns.functionFileNames, actualColumns.functionFileNames)
-	require.Equal(t, expectedColumns.cumulative, actualColumns.cumulative)
-	require.Equal(t, expectedColumns.children, actualColumns.children)
+	fc := newFlamegraphComparer(t)
+	fc.convert(record)
+	fc.compare(expectedColumns)
 }
 
 func TestGenerateFlamegraphArrowUnsymbolized(t *testing.T) {
@@ -718,7 +789,6 @@ func TestGenerateFlamegraphArrowUnsymbolized(t *testing.T) {
 		aggregate []string
 		// expectations
 		rows       []flamegraphRow
-		sorter     *flamegraphColumnSorter
 		cumulative int64
 		height     int32
 		trimmed    int64
@@ -729,13 +799,7 @@ func TestGenerateFlamegraphArrowUnsymbolized(t *testing.T) {
 			// expectations
 			cumulative: 6,
 			height:     5,
-			trimmed:    0, // TODO
-			sorter: &flamegraphColumnSorter{
-				slices: [][2]int{{4, 6}}, // lines 4 and 5 are not in stable order in the result so we need to sort them for the test to be deterministic, so the range we want to sort is [4, 6)
-				less: func(columns flamegraphColumns, i, j int) bool {
-					return columns.locationAddresses[i] > columns.locationAddresses[j]
-				},
-			},
+			trimmed:    0,
 			rows: []flamegraphRow{
 				{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: "(null)", MappingBuildID: "(null)", LocationAddress: 0, LocationLine: 0, Cumulative: 6, Children: []uint32{1}},    // 0
 				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationLine: 1, Cumulative: 6, Children: []uint32{2}},    // 1
@@ -761,20 +825,10 @@ func TestGenerateFlamegraphArrowUnsymbolized(t *testing.T) {
 
 			// Convert the numRows to columns for easier access when testing below.
 			expectedColumns := rowsToColumn(tc.rows)
-			actualColumns := fgRecordToColumns(t, fa)
 
-			if tc.sorter != nil {
-				tc.sorter.sort(actualColumns)
-			}
-
-			require.Equal(t, expectedColumns.mappingStart, actualColumns.mappingStart)
-			require.Equal(t, expectedColumns.mappingLimit, actualColumns.mappingLimit)
-			require.Equal(t, expectedColumns.mappingOffset, actualColumns.mappingOffset)
-			require.Equal(t, expectedColumns.mappingFiles, actualColumns.mappingFiles)
-			require.Equal(t, expectedColumns.mappingBuildIDs, actualColumns.mappingBuildIDs)
-			require.Equal(t, expectedColumns.locationAddresses, actualColumns.locationAddresses)
-			require.Equal(t, expectedColumns.cumulative, actualColumns.cumulative)
-			require.Equal(t, expectedColumns.children, actualColumns.children)
+			fc := newFlamegraphComparer(t)
+			fc.convert(fa)
+			fc.compare(expectedColumns)
 		})
 	}
 }
@@ -901,12 +955,10 @@ func TestGenerateFlamegraphArrowTrimming(t *testing.T) {
 		{FunctionName: "2", Cumulative: 14, Children: nil},              // 2
 	}
 	expectedColumns := rowsToColumn(rows)
-	actualColumns := fgRecordToColumns(t, fa)
 
-	require.Equal(t, expectedColumns.functionNames, actualColumns.functionNames)
-	require.Equal(t, expectedColumns.cumulative, actualColumns.cumulative)
-	require.Equal(t, expectedColumns.diff, actualColumns.diff)
-	require.Equal(t, expectedColumns.children, actualColumns.children)
+	fc := newFlamegraphComparer(t)
+	fc.convert(fa)
+	fc.compare(expectedColumns)
 }
 
 func TestParents(t *testing.T) {

--- a/pkg/query/flamegraph_arrow_test.go
+++ b/pkg/query/flamegraph_arrow_test.go
@@ -82,46 +82,6 @@ type flamegraphColumns struct {
 	diff                []int64
 }
 
-func (c flamegraphColumns) slice(start, end int) flamegraphColumns {
-	return flamegraphColumns{
-		labelsOnly:          c.labelsOnly[start:end],
-		mappingStart:        c.mappingStart[start:end],
-		mappingLimit:        c.mappingLimit[start:end],
-		mappingOffset:       c.mappingOffset[start:end],
-		mappingFiles:        c.mappingFiles[start:end],
-		mappingBuildIDs:     c.mappingBuildIDs[start:end],
-		locationAddresses:   c.locationAddresses[start:end],
-		locationLines:       c.locationLines[start:end],
-		functionStartLines:  c.functionStartLines[start:end],
-		functionNames:       c.functionNames[start:end],
-		functionSystemNames: c.functionSystemNames[start:end],
-		functionFileNames:   c.functionFileNames[start:end],
-		labels:              c.labels[start:end],
-		children:            c.children[start:end],
-		cumulative:          c.cumulative[start:end],
-		diff:                c.diff[start:end],
-	}
-}
-
-func (c flamegraphColumns) swap(i, j int) {
-	c.labelsOnly[i], c.labelsOnly[j] = c.labelsOnly[j], c.labelsOnly[i]
-	c.mappingStart[i], c.mappingStart[j] = c.mappingStart[j], c.mappingStart[i]
-	c.mappingLimit[i], c.mappingLimit[j] = c.mappingLimit[j], c.mappingLimit[i]
-	c.mappingOffset[i], c.mappingOffset[j] = c.mappingOffset[j], c.mappingOffset[i]
-	c.mappingFiles[i], c.mappingFiles[j] = c.mappingFiles[j], c.mappingFiles[i]
-	c.mappingBuildIDs[i], c.mappingBuildIDs[j] = c.mappingBuildIDs[j], c.mappingBuildIDs[i]
-	c.locationAddresses[i], c.locationAddresses[j] = c.locationAddresses[j], c.locationAddresses[i]
-	c.locationLines[i], c.locationLines[j] = c.locationLines[j], c.locationLines[i]
-	c.functionStartLines[i], c.functionStartLines[j] = c.functionStartLines[j], c.functionStartLines[i]
-	c.functionNames[i], c.functionNames[j] = c.functionNames[j], c.functionNames[i]
-	c.functionSystemNames[i], c.functionSystemNames[j] = c.functionSystemNames[j], c.functionSystemNames[i]
-	c.functionFileNames[i], c.functionFileNames[j] = c.functionFileNames[j], c.functionFileNames[i]
-	c.labels[i], c.labels[j] = c.labels[j], c.labels[i]
-	c.children[i], c.children[j] = c.children[j], c.children[i]
-	c.cumulative[i], c.cumulative[j] = c.cumulative[j], c.cumulative[i]
-	c.diff[i], c.diff[j] = c.diff[j], c.diff[i]
-}
-
 func rowsToColumn(rows []flamegraphRow) flamegraphColumns {
 	columns := flamegraphColumns{}
 	for _, row := range rows {
@@ -143,27 +103,6 @@ func rowsToColumn(rows []flamegraphRow) flamegraphColumns {
 		columns.diff = append(columns.diff, row.Diff)
 	}
 	return columns
-}
-
-func fgRecordToColumns(t *testing.T, r arrow.Record) flamegraphColumns {
-	return flamegraphColumns{
-		labelsOnly:          extractColumn(t, r, FlamegraphFieldLabelsOnly).([]bool),
-		mappingStart:        extractColumn(t, r, FlamegraphFieldMappingStart).([]uint64),
-		mappingLimit:        extractColumn(t, r, FlamegraphFieldMappingLimit).([]uint64),
-		mappingOffset:       extractColumn(t, r, FlamegraphFieldMappingOffset).([]uint64),
-		mappingFiles:        extractColumn(t, r, FlamegraphFieldMappingFile).([]string),
-		mappingBuildIDs:     extractColumn(t, r, FlamegraphFieldMappingBuildID).([]string),
-		locationAddresses:   extractColumn(t, r, FlamegraphFieldLocationAddress).([]uint64),
-		locationLines:       extractColumn(t, r, FlamegraphFieldLocationLine).([]int64),
-		functionStartLines:  extractColumn(t, r, FlamegraphFieldFunctionStartLine).([]int64),
-		functionNames:       extractColumn(t, r, FlamegraphFieldFunctionName).([]string),
-		functionSystemNames: extractColumn(t, r, FlamegraphFieldFunctionSystemName).([]string),
-		functionFileNames:   extractColumn(t, r, FlamegraphFieldFunctionFileName).([]string),
-		labels:              extractLabelColumns(t, r),
-		children:            extractChildrenColumn(t, r),
-		cumulative:          extractColumn(t, r, FlamegraphFieldCumulative).([]int64),
-		diff:                extractColumn(t, r, FlamegraphFieldDiff).([]int64),
-	}
 }
 
 func extractLabelColumns(t *testing.T, r arrow.Record) []map[string]string {


### PR DESCRIPTION
This is going to walk the flamegraph depth first and sort each row's children based on pprof labels and then function names.
