### PR TITLE
pkg/query: Don't use GetValueIndex, use raw underlying array

### DIFF
--- a/pkg/profile/reader.go
+++ b/pkg/profile/reader.go
@@ -36,26 +36,26 @@ type RecordReader struct {
 	LabelFields  []arrow.Field
 	LabelColumns []LabelColumn
 
-	Locations                  *array.List
-	Location                   *array.Struct
-	Address                    *array.Uint64
-	MappingStart               *array.Uint64
-	MappingLimit               *array.Uint64
-	MappingOffset              *array.Uint64
-	MappingFile                *array.Dictionary
-	MappingFileDict            *array.Binary
-	MappingBuildID             *array.Dictionary
-	MappingBuildIDDict         *array.Binary
-	Lines                      *array.List
-	Line                       *array.Struct
-	LineNumber                 *array.Int64
-	LineFunctionName           *array.Dictionary
-	LineFunctionNameDict       *array.Binary
-	LineFunctionSystemName     *array.Dictionary
-	LineFunctionSystemNameDict *array.Binary
-	LineFunctionFilename       *array.Dictionary
-	LineFunctionFilenameDict   *array.Binary
-	LineFunctionStartLine      *array.Int64
+	Locations                     *array.List
+	Location                      *array.Struct
+	Address                       *array.Uint64
+	MappingStart                  *array.Uint64
+	MappingLimit                  *array.Uint64
+	MappingOffset                 *array.Uint64
+	MappingFileIndices            *array.Uint32
+	MappingFileDict               *array.Binary
+	MappingBuildIDIndices         *array.Uint32
+	MappingBuildIDDict            *array.Binary
+	Lines                         *array.List
+	Line                          *array.Struct
+	LineNumber                    *array.Int64
+	LineFunctionNameIndices       *array.Uint32
+	LineFunctionNameDict          *array.Binary
+	LineFunctionSystemNameIndices *array.Uint32
+	LineFunctionSystemNameDict    *array.Binary
+	LineFunctionFilenameIndices   *array.Uint32
+	LineFunctionFilenameDict      *array.Binary
+	LineFunctionStartLine         *array.Int64
 
 	Value *array.Int64
 	Diff  *array.Int64
@@ -100,47 +100,52 @@ func NewRecordReader(ar arrow.Record) *RecordReader {
 	mappingLimit := location.Field(2).(*array.Uint64)
 	mappingOffset := location.Field(3).(*array.Uint64)
 	mappingFile := location.Field(4).(*array.Dictionary)
+	mappingFileIndices := mappingFile.Indices().(*array.Uint32)
 	mappingFileDict := mappingFile.Dictionary().(*array.Binary)
 	mappingBuildID := location.Field(5).(*array.Dictionary)
+	mappingBuildIDIndices := mappingBuildID.Indices().(*array.Uint32)
 	mappingBuildIDDict := mappingBuildID.Dictionary().(*array.Binary)
 	lines := location.Field(6).(*array.List)
 	line := lines.ListValues().(*array.Struct)
 	lineNumber := line.Field(0).(*array.Int64)
 	lineFunctionName := line.Field(1).(*array.Dictionary)
+	lineFunctionNameIndices := lineFunctionName.Indices().(*array.Uint32)
 	lineFunctionNameDict := lineFunctionName.Dictionary().(*array.Binary)
 	lineFunctionSystemName := line.Field(2).(*array.Dictionary)
+	lineFunctionSystemNameIndices := lineFunctionSystemName.Indices().(*array.Uint32)
 	lineFunctionSystemNameDict := lineFunctionSystemName.Dictionary().(*array.Binary)
 	lineFunctionFilename := line.Field(3).(*array.Dictionary)
+	lineFunctionFilenameIndices := lineFunctionFilename.Indices().(*array.Uint32)
 	lineFunctionFilenameDict := lineFunctionFilename.Dictionary().(*array.Binary)
 	lineFunctionStartLine := line.Field(4).(*array.Int64)
 	valueColumn := ar.Column(labelNum + 1).(*array.Int64)
 	diffColumn := ar.Column(labelNum + 2).(*array.Int64)
 
 	return &RecordReader{
-		Record:                     ar,
-		LabelFields:                labelFields,
-		LabelColumns:               labelColumns,
-		Locations:                  locations,
-		Location:                   location,
-		Address:                    address,
-		MappingStart:               mappingStart,
-		MappingLimit:               mappingLimit,
-		MappingOffset:              mappingOffset,
-		MappingFile:                mappingFile,
-		MappingFileDict:            mappingFileDict,
-		MappingBuildID:             mappingBuildID,
-		MappingBuildIDDict:         mappingBuildIDDict,
-		Lines:                      lines,
-		Line:                       line,
-		LineNumber:                 lineNumber,
-		LineFunctionName:           lineFunctionName,
-		LineFunctionNameDict:       lineFunctionNameDict,
-		LineFunctionSystemName:     lineFunctionSystemName,
-		LineFunctionSystemNameDict: lineFunctionSystemNameDict,
-		LineFunctionFilename:       lineFunctionFilename,
-		LineFunctionFilenameDict:   lineFunctionFilenameDict,
-		LineFunctionStartLine:      lineFunctionStartLine,
-		Value:                      valueColumn,
-		Diff:                       diffColumn,
+		Record:                        ar,
+		LabelFields:                   labelFields,
+		LabelColumns:                  labelColumns,
+		Locations:                     locations,
+		Location:                      location,
+		Address:                       address,
+		MappingStart:                  mappingStart,
+		MappingLimit:                  mappingLimit,
+		MappingOffset:                 mappingOffset,
+		MappingFileIndices:            mappingFileIndices,
+		MappingFileDict:               mappingFileDict,
+		MappingBuildIDIndices:         mappingBuildIDIndices,
+		MappingBuildIDDict:            mappingBuildIDDict,
+		Lines:                         lines,
+		Line:                          line,
+		LineNumber:                    lineNumber,
+		LineFunctionNameIndices:       lineFunctionNameIndices,
+		LineFunctionNameDict:          lineFunctionNameDict,
+		LineFunctionSystemNameIndices: lineFunctionSystemNameIndices,
+		LineFunctionSystemNameDict:    lineFunctionSystemNameDict,
+		LineFunctionFilenameIndices:   lineFunctionFilenameIndices,
+		LineFunctionFilenameDict:      lineFunctionFilenameDict,
+		LineFunctionStartLine:         lineFunctionStartLine,
+		Value:                         valueColumn,
+		Diff:                          diffColumn,
 	}
 }

--- a/pkg/query/columnquery.go
+++ b/pkg/query/columnquery.go
@@ -320,7 +320,7 @@ func filterRecord(
 			llOffsetStart, llOffsetEnd := r.Lines.ValueOffsets(j)
 
 			for k := int(llOffsetStart); k < int(llOffsetEnd); k++ {
-				if r.LineFunctionName.IsValid(k) && bytes.Contains(bytes.ToLower(r.LineFunctionNameDict.Value(r.LineFunctionName.GetValueIndex(k))), []byte(filterQuery)) {
+				if r.LineFunctionNameIndices.IsValid(k) && bytes.Contains(bytes.ToLower(r.LineFunctionNameDict.Value(int(r.LineFunctionNameIndices.Value(k)))), []byte(filterQuery)) {
 					keepRow = true
 					break
 				}
@@ -354,14 +354,14 @@ func filterRecord(
 						if r.MappingFileDict.Len() == 0 {
 							w.MappingFile.AppendNull()
 						} else {
-							if err := w.MappingFile.Append(r.MappingFileDict.Value(r.MappingFile.GetValueIndex(j))); err != nil {
+							if err := w.MappingFile.Append(r.MappingFileDict.Value(int(r.MappingFileIndices.Value(j)))); err != nil {
 								return nil, 0, 0, fmt.Errorf("append mapping file: %w", err)
 							}
 						}
 						if r.MappingBuildIDDict.Len() == 0 {
 							w.MappingBuildID.AppendNull()
 						} else {
-							if err := w.MappingBuildID.Append(r.MappingBuildIDDict.Value(r.MappingBuildID.GetValueIndex(j))); err != nil {
+							if err := w.MappingBuildID.Append(r.MappingBuildIDDict.Value(int(r.MappingBuildIDIndices.Value(j)))); err != nil {
 								return nil, 0, 0, fmt.Errorf("append mapping build id: %w", err)
 							}
 						}
@@ -381,25 +381,25 @@ func filterRecord(
 								w.Line.Append(true)
 								w.LineNumber.Append(r.LineNumber.Value(k))
 
-								if r.LineFunctionName.IsValid(k) {
+								if r.LineFunctionNameIndices.IsValid(k) {
 									if r.LineFunctionNameDict.Len() == 0 {
 										w.FunctionName.AppendNull()
 									} else {
-										if err := w.FunctionName.Append(r.LineFunctionNameDict.Value(r.LineFunctionName.GetValueIndex(k))); err != nil {
+										if err := w.FunctionName.Append(r.LineFunctionNameDict.Value(int(r.LineFunctionNameIndices.Value(k)))); err != nil {
 											return nil, 0, 0, fmt.Errorf("append function name: %w", err)
 										}
 									}
 									if r.LineFunctionSystemNameDict.Len() == 0 {
 										w.FunctionSystemName.AppendNull()
 									} else {
-										if err := w.FunctionSystemName.Append(r.LineFunctionSystemNameDict.Value(r.LineFunctionSystemName.GetValueIndex(k))); err != nil {
+										if err := w.FunctionSystemName.Append(r.LineFunctionSystemNameDict.Value(int(r.LineFunctionSystemNameIndices.Value(k)))); err != nil {
 											return nil, 0, 0, fmt.Errorf("append function system name: %w", err)
 										}
 									}
 									if r.LineFunctionFilenameDict.Len() == 0 {
 										w.FunctionFilename.AppendNull()
 									} else {
-										if err := w.FunctionFilename.Append(r.LineFunctionFilenameDict.Value(r.LineFunctionFilename.GetValueIndex(k))); err != nil {
+										if err := w.FunctionFilename.Append(r.LineFunctionFilenameDict.Value(int(r.LineFunctionFilenameIndices.Value(k)))); err != nil {
 											return nil, 0, 0, fmt.Errorf("append function filename: %w", err)
 										}
 									}

--- a/pkg/query/sources.go
+++ b/pkg/query/sources.go
@@ -148,12 +148,12 @@ func (b *sourceReportBuilder) addRecord(rec arrow.Record) {
 	for i := 0; i < int(rec.NumRows()); i++ {
 		lOffsetStart, lOffsetEnd := r.Locations.ValueOffsets(i)
 		for j := int(lOffsetStart); j < int(lOffsetEnd); j++ {
-			if r.MappingStart.IsValid(j) && bytes.Equal(r.MappingBuildIDDict.Value(r.MappingBuildID.GetValueIndex(j)), b.buildID) {
+			if r.MappingStart.IsValid(j) && bytes.Equal(r.MappingBuildIDDict.Value(int(r.MappingBuildIDIndices.Value(j))), b.buildID) {
 				llOffsetStart, llOffsetEnd := r.Lines.ValueOffsets(j)
 
 				for k := int(llOffsetStart); k < int(llOffsetEnd); k++ {
 					if r.Line.IsValid(k) && r.LineNumber.Value(k) <= b.numLines &&
-						r.LineFunctionName.IsValid(k) && bytes.Equal(r.LineFunctionFilenameDict.Value(r.LineFunctionFilename.GetValueIndex(k)), b.filename) {
+						r.LineFunctionNameIndices.IsValid(k) && bytes.Equal(r.LineFunctionFilenameDict.Value(int(r.LineFunctionFilenameIndices.Value(k))), b.filename) {
 						b.cumulativeValues[r.LineNumber.Value(k)-1] += r.Value.Value(i)
 
 						isLeaf := j == int(lOffsetStart) && k == int(llOffsetStart)

--- a/pkg/query/table.go
+++ b/pkg/query/table.go
@@ -112,7 +112,7 @@ func generateTableArrowRecord(
 					isLeaf := locationRow == int(lOffsetStart)
 					var buildID []byte
 					if r.MappingBuildIDDict.IsValid(locationRow) {
-						buildID = r.MappingBuildIDDict.Value(r.MappingBuildID.GetValueIndex(locationRow))
+						buildID = r.MappingBuildIDDict.Value(int(r.MappingBuildIDIndices.Value(locationRow)))
 					}
 					addr := r.Address.Value(locationRow)
 
@@ -141,8 +141,8 @@ func generateTableArrowRecord(
 					for lineRow := int(llOffsetStart); lineRow < int(llOffsetEnd); lineRow++ {
 						isLeaf := locationRow == int(lOffsetStart) && lineRow == int(llOffsetStart)
 
-						if r.Line.IsValid(lineRow) && r.LineFunctionName.IsValid(lineRow) {
-							fn := r.LineFunctionNameDict.Value(r.LineFunctionName.GetValueIndex(lineRow))
+						if r.Line.IsValid(lineRow) && r.LineFunctionNameIndices.IsValid(lineRow) {
+							fn := r.LineFunctionNameDict.Value(int(r.LineFunctionNameIndices.Value(lineRow)))
 							if cr, ok := tb.functions[unsafeString(fn)]; !ok {
 								if err := tb.appendRow(r, sampleRow, locationRow, lineRow, isLeaf); err != nil {
 									return nil, 0, err
@@ -282,8 +282,8 @@ func (tb *tableBuilder) appendRow(
 			if r.MappingFileDict.Len() == 0 {
 				tb.builderMappingFile.AppendNull()
 			} else {
-				if r.MappingFile.IsValid(locationRow) {
-					_ = tb.builderMappingFile.Append(r.MappingFileDict.Value(r.MappingFile.GetValueIndex(locationRow)))
+				if r.MappingFileIndices.IsValid(locationRow) {
+					_ = tb.builderMappingFile.Append(r.MappingFileDict.Value(int(r.MappingFileIndices.Value(locationRow))))
 				} else {
 					tb.builderMappingFile.AppendNull()
 				}
@@ -292,8 +292,8 @@ func (tb *tableBuilder) appendRow(
 			if r.MappingBuildIDDict.Len() == 0 {
 				tb.builderMappingBuildID.AppendNull()
 			} else {
-				if r.MappingBuildID.IsValid(locationRow) {
-					_ = tb.builderMappingBuildID.Append(r.MappingBuildIDDict.Value(r.MappingBuildID.GetValueIndex(locationRow)))
+				if r.MappingBuildIDIndices.IsValid(locationRow) {
+					_ = tb.builderMappingBuildID.Append(r.MappingBuildIDDict.Value(int(r.MappingBuildIDIndices.Value(locationRow))))
 				} else {
 					tb.builderMappingBuildID.AppendNull()
 				}
@@ -322,8 +322,8 @@ func (tb *tableBuilder) appendRow(
 			if r.LineFunctionNameDict.Len() == 0 || lineRow == -1 {
 				tb.builderFunctionName.AppendNull()
 			} else {
-				if lineRow >= 0 && r.LineFunctionName.IsValid(lineRow) {
-					_ = tb.builderFunctionName.Append(r.LineFunctionNameDict.Value(r.LineFunctionName.GetValueIndex(lineRow)))
+				if lineRow >= 0 && r.LineFunctionNameIndices.IsValid(lineRow) {
+					_ = tb.builderFunctionName.Append(r.LineFunctionNameDict.Value(int(r.LineFunctionNameIndices.Value(lineRow))))
 				} else {
 					tb.builderFunctionName.AppendNull()
 				}
@@ -332,8 +332,8 @@ func (tb *tableBuilder) appendRow(
 			if r.LineFunctionSystemNameDict.Len() == 0 || lineRow == -1 {
 				tb.builderFunctionSystemName.AppendNull()
 			} else {
-				if lineRow >= 0 && r.LineFunctionSystemName.IsValid(lineRow) {
-					_ = tb.builderFunctionSystemName.Append(r.LineFunctionSystemNameDict.Value(r.LineFunctionSystemName.GetValueIndex(lineRow)))
+				if lineRow >= 0 && r.LineFunctionSystemNameIndices.IsValid(lineRow) {
+					_ = tb.builderFunctionSystemName.Append(r.LineFunctionSystemNameDict.Value(int(r.LineFunctionSystemNameIndices.Value(lineRow))))
 				} else {
 					tb.builderFunctionSystemName.AppendNull()
 				}
@@ -342,8 +342,8 @@ func (tb *tableBuilder) appendRow(
 			if r.LineFunctionFilenameDict.Len() == 0 || lineRow == -1 {
 				tb.builderFunctionFileName.AppendNull()
 			} else {
-				if lineRow >= 0 && r.LineFunctionFilename.IsValid(lineRow) {
-					_ = tb.builderFunctionFileName.Append(r.LineFunctionFilenameDict.Value(r.LineFunctionFilename.GetValueIndex(lineRow)))
+				if lineRow >= 0 && r.LineFunctionFilenameIndices.IsValid(lineRow) {
+					_ = tb.builderFunctionFileName.Append(r.LineFunctionFilenameDict.Value(int(r.LineFunctionFilenameIndices.Value(lineRow))))
 				} else {
 					tb.builderFunctionFileName.AppendNull()
 				}


### PR DESCRIPTION
GetValueIndex performs some work to access the underlying array on every call. Since building the flamegraph accesses the underlying array a lot it makes sense to perform that once, and then access the array.

It turns out that ends up being a lot of work:

```
$ benchstat old.txt new.txt
name                old time/op  new time/op  delta
ArrowFlamegraph-10  1.55ms ± 1%  1.34ms ± 1%  -13.65%  (p=0.000 n=45+10)
```