### PR TITLE
Various small arrow flamegraph perf improvements

### DIFF
--- a/pkg/profile/reader.go
+++ b/pkg/profile/reader.go
@@ -21,7 +21,7 @@ import (
 )
 
 type LabelColumn struct {
-	Col  *array.Dictionary
+	Col  *array.Uint16
 	Dict *array.Binary
 }
 
@@ -86,7 +86,7 @@ func NewRecordReader(ar arrow.Record) *RecordReader {
 	for i := range labelFields {
 		col := ar.Column(i).(*array.Dictionary)
 		labelColumns[i] = LabelColumn{
-			Col:  col,
+			Col:  col.Indices().(*array.Uint16),
 			Dict: col.Dictionary().(*array.Binary),
 		}
 	}

--- a/pkg/profile/reader.go
+++ b/pkg/profile/reader.go
@@ -21,7 +21,7 @@ import (
 )
 
 type LabelColumn struct {
-	Col  *array.Uint16
+	Col  *array.Uint32
 	Dict *array.Binary
 }
 
@@ -86,7 +86,7 @@ func NewRecordReader(ar arrow.Record) *RecordReader {
 	for i := range labelFields {
 		col := ar.Column(i).(*array.Dictionary)
 		labelColumns[i] = LabelColumn{
-			Col:  col.Indices().(*array.Uint16),
+			Col:  col.Indices().(*array.Uint32),
 			Dict: col.Dictionary().(*array.Binary),
 		}
 	}

--- a/pkg/profile/writer.go
+++ b/pkg/profile/writer.go
@@ -47,7 +47,7 @@ func NewWriter(pool memory.Allocator, labelNames []string) Writer {
 	for i, name := range labelNames {
 		labelFields[i] = arrow.Field{
 			Name:     ColumnPprofLabelsPrefix + name,
-			Type:     &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Uint16, ValueType: arrow.BinaryTypes.Binary},
+			Type:     &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Uint32, ValueType: arrow.BinaryTypes.Binary},
 			Nullable: true,
 		}
 	}

--- a/pkg/query/columnquery.go
+++ b/pkg/query/columnquery.go
@@ -333,7 +333,7 @@ func filterRecord(
 
 			for j, label := range r.LabelColumns {
 				if label.Col.IsValid(i) {
-					if err := w.LabelBuilders[j].Append([]byte(label.Dict.Value(label.Col.GetValueIndex(i)))); err != nil {
+					if err := w.LabelBuilders[j].Append([]byte(label.Dict.Value(int(label.Col.Value(i))))); err != nil {
 						return nil, 0, 0, fmt.Errorf("append label: %w", err)
 					}
 				} else {

--- a/pkg/query/flamegraph_arrow.go
+++ b/pkg/query/flamegraph_arrow.go
@@ -1521,6 +1521,14 @@ func compactDictionary(mem memory.Allocator, arr *array.Dictionary) (*array.Dict
 	case *array.String:
 		stringBuilder := array.NewStringBuilder(mem)
 		stringBuilder.Reserve(newLen)
+		numBytes := 0
+		for i, count := range keepValues {
+			if count == 0 {
+				continue
+			}
+			numBytes += len(dict.Value(i))
+		}
+		stringBuilder.ReserveData(numBytes)
 		for i, count := range keepValues {
 			if count == 0 {
 				continue
@@ -1533,6 +1541,14 @@ func compactDictionary(mem memory.Allocator, arr *array.Dictionary) (*array.Dict
 	case *array.Binary:
 		binaryBuilder := array.NewBinaryBuilder(mem, arrow.BinaryTypes.Binary)
 		binaryBuilder.Reserve(newLen)
+		numBytes := 0
+		for i, count := range keepValues {
+			if count == 0 {
+				continue
+			}
+			numBytes += dict.ValueLen(i)
+		}
+		binaryBuilder.ReserveData(numBytes)
 		for i, count := range keepValues {
 			if count == 0 {
 				continue


### PR DESCRIPTION
Surprising how much more perf improvements we keep finding:

```
$ benchstat old.txt new.txt
name                old time/op  new time/op  delta
ArrowFlamegraph-10  1.35ms ± 1%  1.15ms ± 1%  -14.25%  (p=0.000 n=10+10)
```