### PR TITLE
pkg/query/flamegraph_arrow: Remove mapping start,limit,offset

### DIFF
--- a/pkg/query/flamegraph_arrow.go
+++ b/pkg/query/flamegraph_arrow.go
@@ -1209,9 +1209,6 @@ func (fb *flamegraphBuilder) trim(ctx context.Context, tracer trace.Tracer, thre
 
 	trimmedLabelsOnly.Reserve(row)
 	trimmedLabelsExist.Reserve(row)
-	trimmedMappingStart.Reserve(row)
-	trimmedMappingLimit.Reserve(row)
-	trimmedMappingOffset.Reserve(row)
 	trimmedMappingFileIndices.Reserve(row)
 	trimmedMappingBuildIDIndices.Reserve(row)
 	trimmedLocationAddress.Reserve(row)

--- a/pkg/query/flamegraph_arrow.go
+++ b/pkg/query/flamegraph_arrow.go
@@ -40,9 +40,6 @@ import (
 const (
 	FlamegraphFieldLabelsOnly = "labels_only"
 
-	FlamegraphFieldMappingStart   = "mapping_start"
-	FlamegraphFieldMappingLimit   = "mapping_limit"
-	FlamegraphFieldMappingOffset  = "mapping_offset"
 	FlamegraphFieldMappingFile    = "mapping_file"
 	FlamegraphFieldMappingBuildID = "mapping_build_id"
 
@@ -638,9 +635,6 @@ type flamegraphBuilder struct {
 	height int32
 
 	builderLabelsOnly                    *array.BooleanBuilder
-	builderMappingStart                  *array.Uint64Builder
-	builderMappingLimit                  *array.Uint64Builder
-	builderMappingOffset                 *array.Uint64Builder
 	builderMappingFileIndices            *array.Int32Builder
 	builderMappingFileDictUnifier        array.DictionaryUnifier
 	builderMappingBuildIDIndices         *array.Int32Builder
@@ -713,9 +707,6 @@ func newFlamegraphBuilder(
 		builderLabelsOnly:  array.NewBooleanBuilder(pool),
 		builderLabelsExist: builder.NewOptBooleanBuilder(arrow.FixedWidthTypes.Boolean),
 
-		builderMappingStart:              array.NewUint64Builder(pool),
-		builderMappingLimit:              array.NewUint64Builder(pool),
-		builderMappingOffset:             array.NewUint64Builder(pool),
 		builderMappingFileIndices:        array.NewInt32Builder(pool),
 		builderMappingFileDictUnifier:    array.NewBinaryDictionaryUnifier(pool),
 		builderMappingBuildIDIndices:     array.NewInt32Builder(pool),
@@ -755,9 +746,6 @@ func newFlamegraphBuilder(
 	// It only contains the root cumulative value and list of children (which are actual roots).
 	fb.builderLabelsExist.AppendSingle(false)
 	fb.builderLabelsOnly.AppendNull()
-	fb.builderMappingStart.AppendNull()
-	fb.builderMappingLimit.AppendNull()
-	fb.builderMappingOffset.AppendNull()
 	fb.builderMappingFileIndices.AppendNull()
 	fb.builderMappingBuildIDIndices.AppendNull()
 
@@ -902,9 +890,6 @@ func (fb *flamegraphBuilder) NewRecord() (arrow.Record, error) {
 
 	fields := []arrow.Field{
 		{Name: FlamegraphFieldLabelsOnly, Type: arrow.FixedWidthTypes.Boolean},
-		{Name: FlamegraphFieldMappingStart, Type: arrow.PrimitiveTypes.Uint64},
-		{Name: FlamegraphFieldMappingLimit, Type: arrow.PrimitiveTypes.Uint64},
-		{Name: FlamegraphFieldMappingOffset, Type: arrow.PrimitiveTypes.Uint64},
 		{Name: FlamegraphFieldMappingFile, Type: fb.mappingFile.DataType()},
 		{Name: FlamegraphFieldMappingBuildID, Type: fb.mappingBuildID.DataType()},
 		// Location
@@ -921,37 +906,31 @@ func (fb *flamegraphBuilder) NewRecord() (arrow.Record, error) {
 		{Name: FlamegraphFieldDiff, Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	}
 
-	arrays := make([]arrow.Array, 15+len(fb.labels))
+	arrays := make([]arrow.Array, 12+len(fb.labels))
 	arrays[0] = fb.builderLabelsOnly.NewArray()
 	cleanupArrs = append(cleanupArrs, arrays[0])
-	arrays[1] = fb.builderMappingStart.NewArray()
-	cleanupArrs = append(cleanupArrs, arrays[1])
-	arrays[2] = fb.builderMappingLimit.NewArray()
-	cleanupArrs = append(cleanupArrs, arrays[2])
-	arrays[3] = fb.builderMappingOffset.NewArray()
+	arrays[1] = fb.mappingFile
+	arrays[2] = fb.mappingBuildID
+	arrays[3] = fb.builderLocationAddress.NewArray()
 	cleanupArrs = append(cleanupArrs, arrays[3])
-	arrays[4] = fb.mappingFile
-	arrays[5] = fb.mappingBuildID
-	arrays[6] = fb.builderLocationAddress.NewArray()
-	cleanupArrs = append(cleanupArrs, arrays[6])
-	arrays[7] = fb.builderLocationLine.NewArray()
-	cleanupArrs = append(cleanupArrs, arrays[7])
-	arrays[8] = fb.builderFunctionStartLine.NewArray()
-	cleanupArrs = append(cleanupArrs, arrays[8])
-	arrays[9] = fb.functionName
-	arrays[10] = fb.functionSystemName
-	arrays[11] = fb.functionFilename
-	arrays[12] = fb.builderChildren.NewArray()
-	cleanupArrs = append(cleanupArrs, arrays[12])
-	arrays[13] = fb.builderCumulative.NewArray()
-	cleanupArrs = append(cleanupArrs, arrays[13])
-	arrays[14] = fb.builderDiff.NewArray()
-	cleanupArrs = append(cleanupArrs, arrays[14])
+	arrays[4] = fb.builderLocationLine.NewArray()
+	cleanupArrs = append(cleanupArrs, arrays[4])
+	arrays[5] = fb.builderFunctionStartLine.NewArray()
+	cleanupArrs = append(cleanupArrs, arrays[5])
+	arrays[6] = fb.functionName
+	arrays[7] = fb.functionSystemName
+	arrays[8] = fb.functionFilename
+	arrays[9] = fb.builderChildren.NewArray()
+	cleanupArrs = append(cleanupArrs, arrays[9])
+	arrays[10] = fb.builderCumulative.NewArray()
+	cleanupArrs = append(cleanupArrs, arrays[10])
+	arrays[11] = fb.builderDiff.NewArray()
+	cleanupArrs = append(cleanupArrs, arrays[11])
 
 	for i, field := range fb.builderLabelFields {
 		field.Type = fb.labels[i].DataType() // overwrite for variable length uint types
 		fields = append(fields, field)
-		arrays[15+i] = fb.labels[i]
+		arrays[12+i] = fb.labels[i]
 	}
 
 	return array.NewRecord(
@@ -965,9 +944,6 @@ func (fb *flamegraphBuilder) Release() {
 	fb.builderLabelsOnly.Release()
 	fb.builderLabelsExist.Release()
 
-	fb.builderMappingStart.Release()
-	fb.builderMappingLimit.Release()
-	fb.builderMappingOffset.Release()
 	fb.builderMappingFileIndices.Release()
 	fb.builderMappingFileDictUnifier.Release()
 	fb.builderMappingBuildIDIndices.Release()
@@ -1017,15 +993,9 @@ func (fb *flamegraphBuilder) appendRow(
 
 	// Mapping
 	if r.MappingStart.IsValid(locationRow) {
-		fb.builderMappingStart.Append(r.MappingStart.Value(locationRow))
-		fb.builderMappingLimit.Append(r.MappingLimit.Value(locationRow))
-		fb.builderMappingOffset.Append(r.MappingOffset.Value(locationRow))
 		fb.builderMappingFileIndices.Append(t.mappingFile.indices.Value(int(r.MappingFileIndices.Value(locationRow))))
 		fb.builderMappingBuildIDIndices.Append(t.mappingBuildID.indices.Value(int(r.MappingBuildIDIndices.Value(locationRow))))
 	} else {
-		fb.builderMappingStart.AppendNull()
-		fb.builderMappingLimit.AppendNull()
-		fb.builderMappingOffset.AppendNull()
 		fb.builderMappingFileIndices.AppendNull()
 		fb.builderMappingBuildIDIndices.AppendNull()
 	}
@@ -1150,9 +1120,6 @@ func (fb *flamegraphBuilder) AppendLabelRow(
 	fb.children[row] = children
 
 	fb.builderLabelsOnly.Append(true)
-	fb.builderMappingStart.AppendNull()
-	fb.builderMappingLimit.AppendNull()
-	fb.builderMappingOffset.AppendNull()
 	fb.builderMappingFileIndices.AppendNull()
 	fb.builderMappingBuildIDIndices.AppendNull()
 	fb.builderLocationAddress.AppendNull()
@@ -1189,9 +1156,6 @@ func (fb *flamegraphBuilder) trim(ctx context.Context, tracer trace.Tracer, thre
 
 	trimmedLabelsOnly := array.NewBooleanBuilder(fb.pool)
 	trimmedLabelsExist := builder.NewOptBooleanBuilder(arrow.FixedWidthTypes.Boolean)
-	trimmedMappingStart := array.NewUint64Builder(fb.pool)
-	trimmedMappingLimit := array.NewUint64Builder(fb.pool)
-	trimmedMappingOffset := array.NewUint64Builder(fb.pool)
 	trimmedMappingFileIndices := array.NewInt32Builder(fb.pool)
 	trimmedMappingBuildIDIndices := array.NewInt32Builder(fb.pool)
 	trimmedLocationAddress := array.NewUint64Builder(fb.pool)
@@ -1273,9 +1237,6 @@ func (fb *flamegraphBuilder) trim(ctx context.Context, tracer trace.Tracer, thre
 
 		copyBoolBuilderValue(fb.builderLabelsOnly, trimmedLabelsOnly, te.row)
 		copyOptBooleanBuilderValue(fb.builderLabelsExist, trimmedLabelsExist, te.row)
-		copyUint64BuilderValue(fb.builderMappingStart, trimmedMappingStart, te.row)
-		copyUint64BuilderValue(fb.builderMappingLimit, trimmedMappingLimit, te.row)
-		copyUint64BuilderValue(fb.builderMappingOffset, trimmedMappingOffset, te.row)
 		appendDictionaryIndexInt32(fb.mappingFileIndices, trimmedMappingFileIndices, te.row)
 		appendDictionaryIndexInt32(fb.mappingBuildIDIndices, trimmedMappingBuildIDIndices, te.row)
 		copyUint64BuilderValue(fb.builderLocationAddress, trimmedLocationAddress, te.row)
@@ -1410,9 +1371,6 @@ func (fb *flamegraphBuilder) trim(ctx context.Context, tracer trace.Tracer, thre
 	release(
 		fb.builderLabelsOnly,
 		fb.builderLabelsExist,
-		fb.builderMappingStart,
-		fb.builderMappingLimit,
-		fb.builderMappingOffset,
 		fb.builderLocationAddress,
 		fb.builderLocationLine,
 		fb.builderFunctionStartLine,
@@ -1421,9 +1379,6 @@ func (fb *flamegraphBuilder) trim(ctx context.Context, tracer trace.Tracer, thre
 	)
 	fb.builderLabelsOnly = trimmedLabelsOnly
 	fb.builderLabelsExist = trimmedLabelsExist
-	fb.builderMappingStart = trimmedMappingStart
-	fb.builderMappingLimit = trimmedMappingLimit
-	fb.builderMappingOffset = trimmedMappingOffset
 	fb.builderLocationAddress = trimmedLocationAddress
 	fb.builderLocationLine = trimmedLocationLine
 	fb.builderFunctionStartLine = trimmedFunctionStartLine

--- a/pkg/query/flamegraph_arrow_test.go
+++ b/pkg/query/flamegraph_arrow_test.go
@@ -67,9 +67,6 @@ type flamegraphRow struct {
 
 type flamegraphColumns struct {
 	labelsOnly          []bool
-	mappingStart        []uint64
-	mappingLimit        []uint64
-	mappingOffset       []uint64
 	mappingFiles        []string
 	mappingBuildIDs     []string
 	locationAddresses   []uint64
@@ -88,9 +85,6 @@ func rowsToColumn(rows []flamegraphRow) flamegraphColumns {
 	columns := flamegraphColumns{}
 	for _, row := range rows {
 		columns.labelsOnly = append(columns.labelsOnly, row.LabelsOnly)
-		columns.mappingStart = append(columns.mappingStart, row.MappingStart)
-		columns.mappingLimit = append(columns.mappingLimit, row.MappingLimit)
-		columns.mappingOffset = append(columns.mappingOffset, row.MappingOffset)
 		columns.mappingFiles = append(columns.mappingFiles, row.MappingFile)
 		columns.mappingBuildIDs = append(columns.mappingBuildIDs, row.MappingBuildID)
 		columns.locationAddresses = append(columns.locationAddresses, row.LocationAddress)
@@ -409,7 +403,7 @@ func TestGenerateFlamegraphArrow(t *testing.T) {
 			require.Equal(t, tc.cumulative, cumulative)
 			require.Equal(t, tc.height, height)
 			require.Equal(t, tc.trimmed, trimmed)
-			require.Equal(t, int64(16), fa.NumCols())
+			require.Equal(t, int64(13), fa.NumCols())
 
 			// Convert the numRows to columns for easier access when testing below.
 			expectedColumns := rowsToColumn(tc.rows)
@@ -438,9 +432,6 @@ func (c *flamegraphComparer) convert(r arrow.Record) {
 	c.t.Helper()
 	c.actual = flamegraphColumns{
 		labelsOnly:          extractColumn(c.t, r, FlamegraphFieldLabelsOnly).([]bool),
-		mappingStart:        extractColumn(c.t, r, FlamegraphFieldMappingStart).([]uint64),
-		mappingLimit:        extractColumn(c.t, r, FlamegraphFieldMappingLimit).([]uint64),
-		mappingOffset:       extractColumn(c.t, r, FlamegraphFieldMappingOffset).([]uint64),
 		mappingFiles:        extractColumn(c.t, r, FlamegraphFieldMappingFile).([]string),
 		mappingBuildIDs:     extractColumn(c.t, r, FlamegraphFieldMappingBuildID).([]string),
 		locationAddresses:   extractColumn(c.t, r, FlamegraphFieldLocationAddress).([]uint64),
@@ -504,9 +495,6 @@ func (c *flamegraphComparer) compare(expected flamegraphColumns) {
 	}
 
 	require.Equal(c.t, expected.labelsOnly, reorder(c.actual.labelsOnly, order))
-	require.Equal(c.t, expected.mappingStart, reorder(c.actual.mappingStart, order))
-	require.Equal(c.t, expected.mappingLimit, reorder(c.actual.mappingLimit, order))
-	require.Equal(c.t, expected.mappingOffset, reorder(c.actual.mappingOffset, order))
 	require.Equal(c.t, expected.mappingFiles, reorder(c.actual.mappingFiles, order))
 	require.Equal(c.t, expected.mappingBuildIDs, reorder(c.actual.mappingBuildIDs, order))
 	require.Equal(c.t, expected.locationAddresses, reorder(c.actual.locationAddresses, order))
@@ -570,7 +558,7 @@ func TestGenerateFlamegraphArrowEmpty(t *testing.T) {
 	require.Equal(t, int64(0), total)
 	require.Equal(t, int32(1), height)
 	require.Equal(t, int64(0), trimmed)
-	require.Equal(t, int64(15), record.NumCols())
+	require.Equal(t, int64(12), record.NumCols())
 	require.Equal(t, int64(1), record.NumRows())
 }
 
@@ -643,7 +631,7 @@ func TestGenerateFlamegraphArrowWithInlined(t *testing.T) {
 	require.Equal(t, int32(5), height)
 	require.Equal(t, int64(0), trimmed)
 
-	require.Equal(t, int64(15), record.NumCols())
+	require.Equal(t, int64(12), record.NumCols())
 	require.Equal(t, int64(5), record.NumRows())
 
 	rows := []flamegraphRow{
@@ -764,7 +752,7 @@ func TestGenerateFlamegraphArrowUnsymbolized(t *testing.T) {
 			require.Equal(t, tc.height, height)
 			require.Equal(t, tc.trimmed, trimmed)
 			require.Equal(t, int64(len(tc.rows)), fa.NumRows())
-			require.Equal(t, int64(15), fa.NumCols())
+			require.Equal(t, int64(12), fa.NumCols())
 
 			// Convert the numRows to columns for easier access when testing below.
 			expectedColumns := rowsToColumn(tc.rows)
@@ -890,7 +878,7 @@ func TestGenerateFlamegraphArrowTrimming(t *testing.T) {
 	require.Equal(t, int32(5), height)
 	require.Equal(t, int64(4), trimmed)
 	require.Equal(t, int64(3), fa.NumRows())
-	require.Equal(t, int64(15), fa.NumCols())
+	require.Equal(t, int64(12), fa.NumCols())
 
 	// TODO: MappingBuildID and FunctionSystemNames shouldn't be "" but null?
 	rows := []flamegraphRow{


### PR DESCRIPTION
Given those are unused in the UI and make up almost 20% of bytes in the arrow record, it's time to finally remove them.

```
name                old time/op    new time/op    delta
ArrowFlamegraph-24    1.88ms ± 6%    1.56ms ±15%  -16.62%  (p=0.000 n=10+10)

name                old alloc/op   new alloc/op   delta
ArrowFlamegraph-24    2.49MB ± 0%    2.00MB ± 1%  -19.84%  (p=0.000 n=10+10)

name                old allocs/op  new allocs/op  delta
ArrowFlamegraph-24     7.31k ± 0%     7.11k ± 1%   -2.72%  (p=0.000 n=10+10)
```