### PR TITLE
pkg/query: Remove unused mapping columns from arrow table

### DIFF
--- a/pkg/query/table_test.go
+++ b/pkg/query/table_test.go
@@ -77,14 +77,10 @@ func TestGenerateTable(t *testing.T) {
 	require.Equal(t, int64(310797348), cumulative)
 	// require.Equal(t, 899, rec.NumRows())
 
-	mappingStartColumn := rec.Column(rec.Schema().FieldIndices(TableFieldMappingStart)[0]).(*array.Uint64)
-	mappingLimitColumn := rec.Column(rec.Schema().FieldIndices(TableFieldMappingLimit)[0]).(*array.Uint64)
-	mappingOffsetColumn := rec.Column(rec.Schema().FieldIndices(TableFieldMappingOffset)[0]).(*array.Uint64)
 	mappingFileColumn := rec.Column(rec.Schema().FieldIndices(TableFieldMappingFile)[0]).(*array.Dictionary)
 	mappingFileColumnDict := mappingFileColumn.Dictionary().(*array.String)
 	mappingBuildIDColumn := rec.Column(rec.Schema().FieldIndices(TableFieldMappingBuildID)[0]).(*array.Dictionary)
 	locationAddressColumn := rec.Column(rec.Schema().FieldIndices(TableFieldLocationAddress)[0]).(*array.Uint64)
-	locationFolded := rec.Column(rec.Schema().FieldIndices(TableFieldLocationFolded)[0]).(*array.Boolean)
 	locationLineColumn := rec.Column(rec.Schema().FieldIndices(TableFieldLocationLine)[0]).(*array.Int64)
 	functionStartLineColumn := rec.Column(rec.Schema().FieldIndices(TableFieldFunctionStartLine)[0]).(*array.Int64)
 	functionNameColumn := rec.Column(rec.Schema().FieldIndices(TableFieldFunctionName)[0]).(*array.Dictionary)
@@ -102,14 +98,10 @@ func TestGenerateTable(t *testing.T) {
 	for i := 0; i < int(rec.NumRows()); i++ {
 		if locationAddressColumn.Value(i) == uint64(7578561) {
 			// mapping
-			require.Equal(t, uint64(4194304), mappingStartColumn.Value(i))
-			require.Equal(t, uint64(23252992), mappingLimitColumn.Value(i))
-			require.Equal(t, uint64(0), mappingOffsetColumn.Value(i))
 			require.Equal(t, "/bin/operator", mappingFileColumnDict.Value(mappingFileColumn.GetValueIndex(i)))
 			require.True(t, mappingBuildIDColumn.IsNull(i))
 			// location
 			// address is already checked above
-			require.False(t, locationFolded.Value(i))
 			require.Equal(t, int64(107), locationLineColumn.Value(i))
 			// function
 			require.Equal(t, int64(0), functionStartLineColumn.Value(i))
@@ -230,13 +222,9 @@ func TestGenerateTableAggregateFlat(t *testing.T) {
 	require.Equal(t, int64(10), cumulative)
 
 	expectedColumns := tableColumns{
-		mappingStart:       []uint64{1, 1, 1, 1},
-		mappingLimit:       []uint64{1, 1, 1, 1},
-		mappingOffset:      []uint64{1, 1, 1, 1},
 		mappingFile:        []string{"1", "1", "1", "1"},
 		mappingBuildID:     []string{"1", "1", "1", "1"},
 		locationAddress:    []uint64{2, 1, 3, 4},
-		locationFolded:     []bool{false, false, false, false},
 		locationLine:       []int64{0, 0, 0, 0},
 		functionStartLine:  []int64{0, 0, 0, 0},
 		functionName:       []string{"(null)", "(null)", "(null)", "(null)"},
@@ -253,13 +241,9 @@ func TestGenerateTableAggregateFlat(t *testing.T) {
 }
 
 type tableColumns struct {
-	mappingStart       []uint64
-	mappingLimit       []uint64
-	mappingOffset      []uint64
 	mappingFile        []string
 	mappingBuildID     []string
 	locationAddress    []uint64
-	locationFolded     []bool
 	locationLine       []int64
 	functionStartLine  []int64
 	functionName       []string
@@ -273,13 +257,9 @@ type tableColumns struct {
 
 func tableRecordToColumns(t *testing.T, r arrow.Record) tableColumns {
 	return tableColumns{
-		mappingStart:       extractColumn(t, r, TableFieldMappingStart).([]uint64),
-		mappingLimit:       extractColumn(t, r, TableFieldMappingLimit).([]uint64),
-		mappingOffset:      extractColumn(t, r, TableFieldMappingOffset).([]uint64),
 		mappingFile:        extractColumn(t, r, TableFieldMappingFile).([]string),
 		mappingBuildID:     extractColumn(t, r, TableFieldMappingBuildID).([]string),
 		locationAddress:    extractColumn(t, r, TableFieldLocationAddress).([]uint64),
-		locationFolded:     extractColumn(t, r, TableFieldLocationFolded).([]bool),
 		locationLine:       extractColumn(t, r, TableFieldLocationLine).([]int64),
 		functionStartLine:  extractColumn(t, r, TableFieldFunctionStartLine).([]int64),
 		functionName:       extractColumn(t, r, TableFieldFunctionName).([]string),

--- a/ui/packages/shared/profile/src/Table/index.tsx
+++ b/ui/packages/shared/profile/src/Table/index.tsx
@@ -27,6 +27,14 @@ import {
 
 import {hexifyAddress} from '../utils';
 
+const FIELD_MAPPING_FILE = 'mapping_file';
+const FIELD_LOCATION_ADDRESS = 'location_address';
+const FIELD_FUNCTION_NAME = 'function_name';
+const FIELD_FLAT = 'flat';
+const FIELD_FLAT_DIFF = 'flat_diff';
+const FIELD_CUMULATIVE = 'cumulative';
+const FIELD_CUMULATIVE_DIFF = 'cumulative_diff';
+
 const columnHelper = createColumnHelper<row>();
 
 interface row {
@@ -211,10 +219,10 @@ export const Table = React.memo(function Table({
   if (data === undefined) return <div className="mx-auto text-center">Profile has no samples</div>;
 
   const table = tableFromIPC(data);
-  const flatColumn = table.getChild('flat');
-  const flatDiffColumn = table.getChild('flat_diff');
-  const cumulativeColumn = table.getChild('cumulative');
-  const cumulativeDiffColumn = table.getChild('cumulative_diff');
+  const flatColumn = table.getChild(FIELD_FLAT);
+  const flatDiffColumn = table.getChild(FIELD_FLAT_DIFF);
+  const cumulativeColumn = table.getChild(FIELD_CUMULATIVE);
+  const cumulativeDiffColumn = table.getChild(FIELD_CUMULATIVE_DIFF);
 
   if (table.numRows === 0) return <div className="mx-auto text-center">Profile has no samples</div>;
 
@@ -261,7 +269,7 @@ const addPlusSign = (num: string): string => {
 };
 
 export const RowName = (table: ArrowTable, row: number): string => {
-  const mappingFileColumn = table.getChild('mapping_file');
+  const mappingFileColumn = table.getChild(FIELD_MAPPING_FILE);
   if (mappingFileColumn === null) {
     console.error('mapping_file column not found');
     return '';
@@ -273,12 +281,12 @@ export const RowName = (table: ArrowTable, row: number): string => {
   if (mappingFile != null && mappingFileColumn.data.length > 1) {
     mapping = `[${getLastItem(mappingFile) ?? ''}]`;
   }
-  const functionName: string | null = table.getChild('function_name')?.get(row) ?? '';
+  const functionName: string | null = table.getChild(FIELD_FUNCTION_NAME)?.get(row) ?? '';
   if (functionName !== null && functionName !== '') {
     return `${mapping} ${functionName}`;
   }
 
-  const address: bigint = table.getChild('location_address')?.get(row) ?? 0;
+  const address: bigint = table.getChild(FIELD_LOCATION_ADDRESS)?.get(row) ?? 0;
 
   return hexifyAddress(address);
 };


### PR DESCRIPTION
We don't use these mapping columns anywhere in the UI. 
Similar to the flame graph this won't most likely be ever used.
