### PR TITLE
fix(#2598): Support to query QueryRange non-delta profiles buckets from FrostDB

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -245,3 +245,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.3.0 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+replace github.com/polarsignals/frostdb => /home/albertlockett/Development/arcticdb

--- a/go.mod
+++ b/go.mod
@@ -245,5 +245,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.3.0 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
-
-replace github.com/polarsignals/frostdb => /home/albertlockett/Development/arcticdb

--- a/pkg/parcacol/querier.go
+++ b/pkg/parcacol/querier.go
@@ -645,11 +645,6 @@ func (q *Querier) queryRangeNonDelta(ctx context.Context, filterExpr logicalplan
 			// If we have seen a MetricsSample for this bucket before, we'll ignore this one.
 			// If we haven't seen one we'll add this sample to the response.
 
-			// TODO: This still queries way too much data from the underlying database.
-			// This needs to be moved to FrostDB to not even query all of this data in the first place.
-			// With a scrape interval of 10s and a query range of 1d we'd query 8640 samples and at most return 960.
-			// Even worse for a week, we'd query 60480 samples and only return 1000.
-
 			tsBucket := ts / 1000 / int64(step.Seconds())
 			if _, found := resSeriesBuckets[index][tsBucket]; found {
 				// We already have a MetricsSample for this timestamp bucket, ignore it.

--- a/pkg/parcacol/querier.go
+++ b/pkg/parcacol/querier.go
@@ -552,7 +552,6 @@ func (q *Querier) queryRangeNonDelta(ctx context.Context, filterExpr logicalplan
 			r.Retain()
 			records = append(records, r)
 			rows += int(r.NumRows())
-			fmt.Printf("%v\n", r)
 			return nil
 		})
 	if err != nil {


### PR DESCRIPTION
fixes https://github.com/parca-dev/parca/issues/2598

Opening this as draft as it depends on https://github.com/polarsignals/frostdb/pull/504