### PR TITLE
Fix sharing profile bug

### DIFF
--- a/ui/packages/shared/profile/src/GraphTooltipArrow/Content.tsx
+++ b/ui/packages/shared/profile/src/GraphTooltipArrow/Content.tsx
@@ -193,6 +193,8 @@ const TooltipMetaInfo = ({
     )
   );
 
+  const isMappingBuildIDAvailable = mappingBuildID !== null && mappingBuildID !== '';
+
   return (
     <>
       <tr>
@@ -254,7 +256,7 @@ const TooltipMetaInfo = ({
       <tr>
         <td className="w-1/4">Build Id</td>
         <td className="w-3/4 break-all">
-          {!mappingBuildID ? (
+          {!isMappingBuildIDAvailable ? (
             <NoData />
           ) : (
             <CopyToClipboard onCopy={onCopy} text={mappingBuildID}>

--- a/ui/packages/shared/profile/src/GraphTooltipArrow/Content.tsx
+++ b/ui/packages/shared/profile/src/GraphTooltipArrow/Content.tsx
@@ -254,7 +254,7 @@ const TooltipMetaInfo = ({
       <tr>
         <td className="w-1/4">Build Id</td>
         <td className="w-3/4 break-all">
-          {mappingBuildID === null ? (
+          {!mappingBuildID ? (
             <NoData />
           ) : (
             <CopyToClipboard onCopy={onCopy} text={mappingBuildID}>

--- a/ui/packages/shared/profile/src/components/ProfileShareButton/index.tsx
+++ b/ui/packages/shared/profile/src/components/ProfileShareButton/index.tsx
@@ -78,7 +78,7 @@ const ProfileShareModal = ({
 
   return (
     <Modal isOpen={isOpen} closeModal={onClose} title="Share Profile" className="w-[420px]">
-      <form className="py-2">
+      <div className="py-2">
         <p className="text-sm text-gray-500 dark:text-gray-300">
           Note: Shared profiles can be accessed by anyone with the link, even from people outside
           your organisation.
@@ -117,7 +117,7 @@ const ProfileShareModal = ({
             </div>
           </>
         )}
-      </form>
+      </div>
     </Modal>
   );
 };


### PR DESCRIPTION
This fixes a bug where clicking on the "Copy Link" button in the profile sharing modal refreshes the page and navigates to the homepage (`/`). The use of the `form` tag seemed to be the issue here.

This also fixes a bug I noticed where hovering on any part of the icicle graph causes the app to crash instantly, with the error seen in the screenshot below. Looks like the check `mappingBuildID === null` wasn't enough, changing it to `!mappingBuildID` worked.
<img width="1553" alt="image" src="https://github.com/parca-dev/parca/assets/9016992/74eb58ce-d5bf-488f-9bd6-3b390d395357">
