### PR TITLE
ui: Add percentage to flat and cumulative columns in table

### DIFF
--- a/ui/packages/shared/profile/src/ProfileView/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileView/index.tsx
@@ -295,6 +295,8 @@ export const ProfileView = ({
       case 'table': {
         return topTableData != null ? (
           <Table
+            total={total}
+            filtered={filtered}
             loading={topTableData.loading}
             data={topTableData.arrow?.record}
             sampleUnit={sampleUnit}

--- a/ui/packages/shared/profile/src/Table/index.tsx
+++ b/ui/packages/shared/profile/src/Table/index.tsx
@@ -80,20 +80,20 @@ export const Table = React.memo(function Table({
     return ['icicle'];
   }, [rawDashboardItems]);
 
-  const ratioString = (value: bigint | number):string => {
+  const ratioString = (value: bigint | number): string => {
     if (filtered === 0n) {
-      return ` (${percentageString(value, total)})`
+      return ` (${percentageString(value, total)})`;
     }
 
-    return ` (${percentageString(value, total)} / ${percentageString(value, filtered)})`
+    return ` (${percentageString(value, total)} / ${percentageString(value, filtered)})`;
   };
 
-  const percentageString = (value: bigint | number, total: bigint | number):string => {
+  const percentageString = (value: bigint | number, total: bigint | number): string => {
     if (total === 0n) {
       return '0%';
     }
 
-    const percentage = Number(value) / Number(total) * 100;
+    const percentage = (Number(value) / Number(total)) * 100;
     return `${percentage.toFixed(2)}%`;
   };
 
@@ -110,7 +110,8 @@ export const Table = React.memo(function Table({
       }),
       columnHelper.accessor('flatDiff', {
         header: () => 'Flat Diff',
-        cell: info => addPlusSign(valueFormatter(info.getValue(), unit, 2)) + ratioString(info.getValue()),
+        cell: info =>
+          addPlusSign(valueFormatter(info.getValue(), unit, 2)) + ratioString(info.getValue()),
         size: 120,
         meta: {
           align: 'right',
@@ -128,7 +129,8 @@ export const Table = React.memo(function Table({
       }),
       columnHelper.accessor('cumulativeDiff', {
         header: () => 'Cumulative Diff',
-        cell: info => addPlusSign(valueFormatter(info.getValue(), unit, 2)) + ratioString(info.getValue()),
+        cell: info =>
+          addPlusSign(valueFormatter(info.getValue(), unit, 2)) + ratioString(info.getValue()),
         size: 170,
         meta: {
           align: 'right',

--- a/ui/packages/shared/profile/src/Table/index.tsx
+++ b/ui/packages/shared/profile/src/Table/index.tsx
@@ -47,6 +47,8 @@ interface row {
 
 interface TableProps {
   data?: Uint8Array;
+  total: bigint;
+  filtered: bigint;
   sampleUnit: string;
   navigateTo?: NavigateFunction;
   loading: boolean;
@@ -56,6 +58,8 @@ interface TableProps {
 
 export const Table = React.memo(function Table({
   data,
+  total,
+  filtered,
   sampleUnit: unit,
   navigateTo,
   loading,
@@ -76,11 +80,28 @@ export const Table = React.memo(function Table({
     return ['icicle'];
   }, [rawDashboardItems]);
 
+  const ratioString = (value: bigint | number):string => {
+    if (filtered === 0n) {
+      return ` (${percentageString(value, total)})`
+    }
+
+    return ` (${percentageString(value, total)} / ${percentageString(value, filtered)})`
+  };
+
+  const percentageString = (value: bigint | number, total: bigint | number):string => {
+    if (total === 0n) {
+      return '0%';
+    }
+
+    const percentage = Number(value) / Number(total) * 100;
+    return `${percentage.toFixed(2)}%`;
+  };
+
   const columns = useMemo(() => {
     const cols: Array<ColumnDef<row, any>> = [
       columnHelper.accessor('flat', {
         header: () => 'Flat',
-        cell: info => valueFormatter(info.getValue(), unit, 2),
+        cell: info => valueFormatter(info.getValue(), unit, 2) + ratioString(info.getValue()),
         size: 80,
         meta: {
           align: 'right',
@@ -89,7 +110,7 @@ export const Table = React.memo(function Table({
       }),
       columnHelper.accessor('flatDiff', {
         header: () => 'Flat Diff',
-        cell: info => addPlusSign(valueFormatter(info.getValue(), unit, 2)),
+        cell: info => addPlusSign(valueFormatter(info.getValue(), unit, 2)) + ratioString(info.getValue()),
         size: 120,
         meta: {
           align: 'right',
@@ -98,7 +119,7 @@ export const Table = React.memo(function Table({
       }),
       columnHelper.accessor('cumulative', {
         header: () => 'Cumulative',
-        cell: info => valueFormatter(info.getValue(), unit, 2),
+        cell: info => valueFormatter(info.getValue(), unit, 2) + ratioString(info.getValue()),
         size: 130,
         meta: {
           align: 'right',
@@ -107,7 +128,7 @@ export const Table = React.memo(function Table({
       }),
       columnHelper.accessor('cumulativeDiff', {
         header: () => 'Cumulative Diff',
-        cell: info => addPlusSign(valueFormatter(info.getValue(), unit, 2)),
+        cell: info => addPlusSign(valueFormatter(info.getValue(), unit, 2)) + ratioString(info.getValue()),
         size: 170,
         meta: {
           align: 'right',


### PR DESCRIPTION
This is a start of #3880, but we should separate it out to separate columns instead as the line breaks are not very good this way.

@metalmatze had some WIP work that allowed dynamically adding columns, I think that would be the right thing to do here.

![Screenshot_2023-09-26_at_14 02 32](https://github.com/parca-dev/parca/assets/4546722/df4dc804-a785-4409-a988-48d7d1632f21)
