### PR TITLE
.github/workflows: Remove podman container wrapper

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -52,12 +52,20 @@ jobs:
           skip_after_successful_duplicate: false
 
   build-binary:
-    name: Build binary using goreleaser
+    name:  using goreleaser
     needs: skip-check
     runs-on: ubuntu-latest
     timeout-minutes: 45
     if: ${{ needs.skip-check.outputs.should_skip != 'true' }}
     steps:
+      - name: Remove unnecessary files
+        run: |
+          du . -h
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          du . -h
       - name: Check out code into the Go module directory
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
         with:

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -120,7 +120,7 @@ jobs:
       contents: read
     steps:
       - name: Install dependencies
-        run: dnf install --assumeyes --repo fedora git make jq
+        run: apt install --yes git make jq
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -119,9 +119,6 @@ jobs:
       packages: write
       contents: read
     steps:
-      - name: Install dependencies
-        run: apt install --yes git make jq
-
       - name: Check out code into the Go module directory
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -106,16 +106,6 @@ jobs:
     needs: build-binary
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    container:
-      # https://github.com/containers/podman/tree/main/contrib/podmanimage
-      # Specifying SHA repeatedly fails:
-      # @sha256:421ac576cebff98e90c531e7b9ce4482370ecc7cee59abc2341714031bfb5f43
-      image: quay.io/containers/podman:v4.7.0@sha256:2c807522b6d66c61a64cf93de24ea5155e8995c3dd8bfedafb4702dff317b35d
-      options: >-
-        --device /dev/fuse:rw
-        --privileged
-        --security-opt label=disable
-        --security-opt seccomp=unconfined
     permissions:
       id-token: write
       packages: write

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -58,6 +58,8 @@ jobs:
     timeout-minutes: 45
     if: ${{ needs.skip-check.outputs.should_skip != 'true' }}
     steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
       - name: Remove unnecessary files
         run: |
           du . -h

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,16 +123,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: release
-    container:
-      # https://github.com/containers/podman/tree/main/contrib/podmanimage
-      # Specifying SHA repeatedly fails:
-      # @sha256:421ac576cebff98e90c531e7b9ce4482370ecc7cee59abc2341714031bfb5f43
-      image: quay.io/containers/podman:v4.7.0@sha256:2c807522b6d66c61a64cf93de24ea5155e8995c3dd8bfedafb4702dff317b35d
-      options: >-
-        --device /dev/fuse:rw
-        --privileged
-        --security-opt label=disable
-        --security-opt seccomp=unconfined
     permissions:
       id-token: write
       packages: write


### PR DESCRIPTION
We might be able to run our actions without this wrapper for a specific version going forward.
