### PR TITLE
pkg/scrape: Fix scraping without executable info

### DIFF
--- a/pkg/scrape/scrape.go
+++ b/pkg/scrape/scrape.go
@@ -502,7 +502,7 @@ mainLoop:
 				continue
 			}
 
-			executableInfo := []*profilepb.ExecutableInfo{}
+			var executableInfo []*profilepb.ExecutableInfo
 			for _, comment := range p.Comments {
 				if strings.HasPrefix(comment, "executableInfo=") {
 					ei, err := parseExecutableInfo(comment)


### PR DESCRIPTION
A storage expects that when executable infos are set, that they are equal to the amount of mappings in a sample.