### PR TITLE
config: Validate duplicate job names

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -56,7 +56,7 @@ type ObjectStorage struct {
 func (c *Config) Validate() error {
 	if err := validation.ValidateStruct(c,
 		validation.Field(&c.ObjectStorage, validation.Required, ObjectStorageValid),
-		validation.Field(&c.ScrapeConfigs, validation.Required, ScrapeConfigsValid),
+		validation.Field(&c.ScrapeConfigs, ScrapeConfigsValid),
 	); err != nil {
 		return err
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -56,6 +56,7 @@ type ObjectStorage struct {
 func (c *Config) Validate() error {
 	if err := validation.ValidateStruct(c,
 		validation.Field(&c.ObjectStorage, validation.Required, ObjectStorageValid),
+		validation.Field(&c.ScrapeConfigs, validation.Required, ScrapeConfigsValid),
 	); err != nil {
 		return err
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -262,3 +262,30 @@ scrape_configs:
 	require.Error(t, err)
 	require.Equal(t, "ScrapeConfigs: duplicate job_name found in scrape configs: parca.", err.Error())
 }
+
+func TestLoadMinimalConfig(t *testing.T) {
+	t.Parallel()
+
+	minimalYAML := `
+object_storage:
+  bucket:
+    type: "FILESYSTEM"
+    config:
+      directory: "./data"
+`
+
+	expected := &Config{
+		ObjectStorage: &ObjectStorage{
+			Bucket: &client.BucketConfig{
+				Type: client.FILESYSTEM,
+				Config: map[string]interface{}{
+					"directory": "./data",
+				},
+			},
+		},
+	}
+
+	c, err := Load(minimalYAML)
+	require.NoError(t, err)
+	require.Equal(t, expected, c)
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -234,3 +234,31 @@ func Test_Config_Validation(t *testing.T) {
 		})
 	}
 }
+
+func TestLoadDuplicateJobs(t *testing.T) {
+	t.Parallel()
+
+	complexYAML := `
+object_storage:
+  bucket:
+    type: "FILESYSTEM"
+    config:
+      directory: "./data"
+scrape_configs:
+  - job_name: 'parca'
+    scrape_interval: 5s
+    static_configs:
+      - targets: [ 'localhost:10902' ]
+  - job_name: 'parca'
+    scrape_interval: 5s
+    static_configs:
+      - targets: [ 'localhost:10903' ]
+`
+
+	config, err := Load(complexYAML)
+	require.NoError(t, err)
+
+	err = config.Validate()
+	require.Error(t, err)
+	require.Equal(t, "ScrapeConfigs: duplicate job_name found in scrape configs: parca.", err.Error())
+}


### PR DESCRIPTION
This commit fixes the problem when jobs with the same names are [compacted to a single target](https://github.com/parca-dev/parca/blob/912596987067593ddb69f7fe12dc6b43eae9d8d7/pkg/scrape/manager.go#L110-L114), leading to unexpected behavior: a user will only see the last target with this job name.

It is a breaking change for users who have duplicates in their configs, but for new users, it will be more transparent.