### PR TITLE
protobuf: Declaring go_package as a potential fix for downstream usage

### DIFF
--- a/proto/parca/debuginfo/v1alpha1/debuginfo.proto
+++ b/proto/parca/debuginfo/v1alpha1/debuginfo.proto
@@ -4,6 +4,8 @@ package parca.debuginfo.v1alpha1;
 
 import "google/protobuf/timestamp.proto";
 
+option go_package = "github.com/parca-dev/parca/gen/go/debuginfo";
+
 // DebuginfoService is a service that allows storage of debug info
 service DebuginfoService {
   // Upload ingests debug info for a given build_id

--- a/proto/parca/metastore/v1alpha1/metastore.proto
+++ b/proto/parca/metastore/v1alpha1/metastore.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package parca.metastore.v1alpha1;
 
+option go_package = "github.com/parca-dev/parca/gen/go/metastore";
+
 // MetastoreService
 service MetastoreService {
   // GetOrCreateMappings checks if the mappings in the request are already

--- a/proto/parca/profilestore/v1alpha1/profilestore.proto
+++ b/proto/parca/profilestore/v1alpha1/profilestore.proto
@@ -6,6 +6,8 @@ import "google/api/annotations.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 
+option go_package = "github.com/parca-dev/parca/gen/go/profilestore";
+
 // ProfileStoreService is the service the accepts pprof writes
 service ProfileStoreService {
   // WriteRaw accepts a raw set of bytes of a pprof file

--- a/proto/parca/query/v1alpha1/query.proto
+++ b/proto/parca/query/v1alpha1/query.proto
@@ -8,6 +8,8 @@ import "google/protobuf/timestamp.proto";
 import "parca/metastore/v1alpha1/metastore.proto";
 import "parca/profilestore/v1alpha1/profilestore.proto";
 
+option go_package = "github.com/parca-dev/parca/gen/go/query";
+
 // QueryService is the service that provides APIs to retrieve and inspect profiles
 service QueryService {
   // QueryRange performs a profile query over a time range

--- a/proto/parca/scrape/v1alpha1/scrape.proto
+++ b/proto/parca/scrape/v1alpha1/scrape.proto
@@ -7,6 +7,8 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 import "parca/profilestore/v1alpha1/profilestore.proto";
 
+option go_package = "github.com/parca-dev/parca/gen/go/scrape";
+
 // ScrapeService maintains the set of scrape targets
 service ScrapeService {
   // Targets returns the set of scrape targets that are configured

--- a/proto/parca/share/v1alpha1/share.proto
+++ b/proto/parca/share/v1alpha1/share.proto
@@ -4,6 +4,8 @@ package parca.share.v1alpha1;
 
 import "parca/query/v1alpha1/query.proto";
 
+option go_package = "github.com/parca-dev/parca/gen/go/share";
+
 // Service that exposes APIs for sharing profiles.
 service ShareService {
   // Uploads the profile and returns the link that can be used to access it.

--- a/proto/parca/telemetry/v1alpha1/telemetry.proto
+++ b/proto/parca/telemetry/v1alpha1/telemetry.proto
@@ -4,6 +4,8 @@ package parca.telemetry.v1alpha1;
 
 import "google/api/annotations.proto";
 
+option go_package = "github.com/parca-dev/parca/gen/go/telemetry";
+
 // TelemetryService is the service that provides APIs to send information about the
 // Agents, such as unhandled panics and other relevant runtime data.
 service TelemetryService {


### PR DESCRIPTION
Note: This doesn't produce any changes to the generated code, so the `buf-breaking` lint error can be ignored. 