### PR TITLE
fix(snap): correct debuginfod upstream servers option

### DIFF
--- a/snap/parca-wrapper
+++ b/snap/parca-wrapper
@@ -24,7 +24,7 @@ log_level="$(snapctl get log-level)"
 storage_persist="$(snapctl get enable-persistence)"
 http_address="$(snapctl get http-address)"
 http_path_prefix="$(snapctl get http-path-prefix)"
-debuginfod_upstream_servers="$(snapctl get debuginfod-upstream-server)"
+debuginfod_upstream_servers="$(snapctl get debuginfod-upstream-servers)"
 
 store="$(snapctl get remote-store-address)"
 insecure="$(snapctl get remote-store-insecure)"
@@ -42,7 +42,7 @@ if [ -n "$http_path_prefix" ]; then
 fi
 
 if [ -n "$debuginfod_upstream_servers" ]; then
-    opts+=("--debuginfod-upstream-servers")
+    opts+=("--debuginfod-upstream-servers=${debuginfod_upstream_servers}")
 fi
 
 # If there is a token set for a store, then enable sending profiles to a remote store.


### PR DESCRIPTION
This corrects #4069 where I missed to add some late changes to correct the option to specify custom debuginfod servers.