### PR TITLE
Handle possible nil in profiling config

### DIFF
--- a/pkg/scrape/target.go
+++ b/pkg/scrape/target.go
@@ -230,7 +230,7 @@ func LabelsByProfiles(lb *labels.Builder, c *config.ProfilingConfig) ([]labels.L
 
 	if len(c.PprofConfig) > 0 {
 		for profilingType, profilingConfig := range c.PprofConfig {
-			if *profilingConfig.Enabled {
+			if profilingConfig.Enabled != nil && *profilingConfig.Enabled {
 				lb.Set(ProfilePath, profilingConfig.Path)
 				lb.Set(ProfileName, profilingType)
 				res = append(res, lb.Labels())


### PR DESCRIPTION
Hello!

I've been bitten by this panic:

```
goroutine 276 [running]:
github.com/parca-dev/parca/pkg/scrape.LabelsByProfiles(0x4007237d58?, 0x39bdb00?)
	github.com/parca-dev/parca/pkg/scrape/target.go:233 +0x120
github.com/parca-dev/parca/pkg/scrape.targetsFromGroup(0x400f5b6ea0, 0x400187c420, {0x0?, 0x46e?, 0x500?}, 0x4007237f10)
	github.com/parca-dev/parca/pkg/scrape/target.go:370 +0x158
github.com/parca-dev/parca/pkg/scrape.(*scrapePool).Sync(0x400ffa0b40, {0x40078ba000, 0x46e, 0x40073a8e40?})
	github.com/parca-dev/parca/pkg/scrape/scrape.go:218 +0x228
github.com/parca-dev/parca/pkg/scrape.(*Manager).reload.func1(0x0?, {0x40078ba000?, 0x4001880a90?, 0x4000fa8160?})
	github.com/parca-dev/parca/pkg/scrape/manager.go:217 +0x28
created by github.com/parca-dev/parca/pkg/scrape.(*Manager).reload in goroutine 62
	github.com/parca-dev/parca/pkg/scrape/manager.go:216 +0x1c4
```

while having a config file with a custom pprof:

```
scrape_configs:
      - job_name: kubernetes-nodejs
        scrape_interval: 60s
        scrape_timeout: 70s
        profiling_config:
          pprof_config:
            allocs:
              enabled: false
            block:
              enabled: false
            cpu:
              path: /api/debug/pprof/profile
            memory:
              enabled: false
            mutex:
              enabled: false
      ...
```

I think Go will short-circuit the condition and not evaluate the right expression right? 