### PR TITLE
pkg: Move the uiFS out of the server package

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -68,4 +68,4 @@ jobs:
       - name: Docs check
         run: |
           make README.md
-          git diff --exit-code ':!deploy' ':!ui/packages/app/web/build/keep.go'
+          git diff --exit-code ':!deploy' ':!ui/packages/app/web/build'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -68,4 +68,4 @@ jobs:
       - name: Docs check
         run: |
           make README.md
-          git diff --exit-code ':!deploy'
+          git diff --exit-code ':!deploy' ':!ui/packages/app/web/build/keep.go'

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -80,7 +80,7 @@ jobs:
         run: make go/build
 
       - name: Format
-        run: make go/fmt && git diff --exit-code ':!ui/packages/app/web/build/keep.go'
+        run: make go/fmt && git diff --exit-code ':!ui/packages/app/web/build'
 
       - name: Lint
         run: make go/lint

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -80,7 +80,7 @@ jobs:
         run: make go/build
 
       - name: Format
-        run: make go/fmt && git diff --exit-code
+        run: make go/fmt && git diff --exit-code ':!ui/packages/app/web/build/keep.go'
 
       - name: Lint
         run: make go/lint

--- a/.github/workflows/proto-gen.yaml
+++ b/.github/workflows/proto-gen.yaml
@@ -49,4 +49,4 @@ jobs:
 
       - name: Generate
         run:
-          make proto/generate && git diff --exit-code
+          make proto/generate && git diff --exit-code ':!ui/packages/app/web/build/keep.go'

--- a/pkg/parca/parca.go
+++ b/pkg/parca/parca.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The Parca Authors
+// Copyright 2022-2024 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/parca/parca.go
+++ b/pkg/parca/parca.go
@@ -18,6 +18,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"io/fs"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -60,6 +61,7 @@ import (
 	scrapepb "github.com/parca-dev/parca/gen/proto/go/parca/scrape/v1alpha1"
 	sharepb "github.com/parca-dev/parca/gen/proto/go/parca/share/v1alpha1"
 	telemetry "github.com/parca-dev/parca/gen/proto/go/parca/telemetry/v1alpha1"
+	"github.com/parca-dev/parca/ui"
 
 	"github.com/parca-dev/parca/pkg/config"
 	"github.com/parca-dev/parca/pkg/debuginfo"
@@ -209,12 +211,18 @@ func Run(ctx context.Context, logger log.Logger, reg *prometheus.Registry, flags
 		return err
 	}
 
+	// Strip the subpath
+	uiFS, err := fs.Sub(ui.FS, "packages/app/web/build")
+	if err != nil {
+		return fmt.Errorf("failed to initialize UI filesystem: %w", err)
+	}
+
 	if flags.StoreAddress != "" && flags.Mode != flagModeScraperOnly {
 		return fmt.Errorf("the mode should be set as `--mode=scraper-only`, if `StoreAddress` is set")
 	}
 
 	if flags.Mode == flagModeScraperOnly {
-		return runScraper(ctx, logger, reg, tracerProvider, flags, version, cfg)
+		return runScraper(ctx, logger, reg, tracerProvider, uiFS, flags, version, cfg)
 	}
 
 	bucketCfg, err := yaml.Marshal(cfg.ObjectStorage.Bucket)
@@ -574,6 +582,7 @@ func Run(ctx context.Context, logger log.Logger, reg *prometheus.Registry, flags
 				err = parcaserver.ListenAndServe(
 					ctx,
 					logger,
+					uiFS,
 					flags.HTTPAddress,
 					flags.HTTPReadTimeout,
 					flags.HTTPWriteTimeout,
@@ -653,6 +662,7 @@ func runScraper(
 	logger log.Logger,
 	reg *prometheus.Registry,
 	tracer trace.TracerProvider,
+	uiFS fs.FS,
 	flags *Flags,
 	version string,
 	cfg *config.Config,
@@ -796,6 +806,7 @@ func runScraper(
 				return parcaserver.ListenAndServe(
 					serveCtx,
 					logger,
+					uiFS,
 					flags.HTTPAddress,
 					flags.HTTPReadTimeout,
 					flags.HTTPWriteTimeout,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The Parca Authors
+// Copyright 2022-2024 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -47,7 +47,6 @@ import (
 
 	"github.com/parca-dev/parca/pkg/debuginfo"
 	"github.com/parca-dev/parca/pkg/prober"
-	"github.com/parca-dev/parca/ui"
 )
 
 type Registerable interface {
@@ -80,6 +79,7 @@ func NewServer(reg *prometheus.Registry, version string) *Server {
 func (s *Server) ListenAndServe(
 	ctx context.Context,
 	logger log.Logger,
+	uiFS fs.FS,
 	addr string,
 	readTimeout time.Duration,
 	writeTimeout time.Duration,
@@ -145,12 +145,6 @@ func (s *Server) ListenAndServe(
 		r.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 		r.HandleFunc("/debug/pprof/trace", pprof.Trace)
 	})
-
-	// Strip the subpath
-	uiFS, err := fs.Sub(ui.FS, "packages/app/web/build")
-	if err != nil {
-		return fmt.Errorf("failed to initialize UI filesystem: %w", err)
-	}
 
 	uiHandler, err := s.uiHandler(uiFS, pathPrefix)
 	if err != nil {

--- a/proto/buf.lock
+++ b/proto/buf.lock
@@ -4,8 +4,8 @@ deps:
   - remote: buf.build
     owner: googleapis
     repository: googleapis
-    commit: b30c5775bfb3485d9da2e87b26590ac9
-    digest: shake256:9d0caaf056949a0e1c883b9849d8a2fa66e22f18a2a48f867d1a8c700aa22abee50ad3ef0d8171637457cadc43c584998bdf3adac55da0f9e4614c72686b057d
+    commit: a86849a25cc04f4dbe9b15ddddfbc488
+    digest: shake256:e19143328f8cbfe13fc226aeee5e63773ca494693a72740a7560664270039a380d94a1344234b88c7691311460df9a9b1c2982190d0a2612eae80368718e1943
   - remote: buf.build
     owner: grpc-ecosystem
     repository: grpc-gateway

--- a/ui/packages/app/web/build/keep.go
+++ b/ui/packages/app/web/build/keep.go
@@ -1,4 +1,4 @@
-// Copyright 2023 The Parca Authors
+// Copyright 2023-2024 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/ui/packages/app/web/build/keep.go
+++ b/ui/packages/app/web/build/keep.go
@@ -1,0 +1,16 @@
+// Copyright 2023 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+// this file is empty and only exists so that the embed.FS variable is populated.


### PR DESCRIPTION
This will make it easier to consume the server outside of parca itself.
