### PR TITLE
Fix bug when loading Metrics graph

### DIFF
--- a/ui/packages/shared/profile/src/ProfileSelector/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileSelector/index.tsx
@@ -107,18 +107,21 @@ const ProfileSelector = ({
   const [timeRangeSelection, setTimeRangeSelection] = useState(
     DateTimeRange.fromRangeKey(querySelection.timeSelection)
   );
+
   const [queryExpressionString, setQueryExpressionString] = useState(querySelection.expression);
 
   useEffect(() => {
-    setIsDataLoading(true);
-    const handleNewTimeRange = async (): Promise<void> => {
-      await setQueryExpression();
-      await setIsDataLoading(false);
-    };
+    if (querySelection.expression === undefined) {
+      return;
+    }
 
-    void handleNewTimeRange();
+    setIsDataLoading(true);
+
+    setQueryExpression();
+    setIsDataLoading(false);
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [timeRangeSelection]);
+  }, [timeRangeSelection, querySelection.expression]);
 
   useEffect(() => {
     if (enforcedProfileName !== '') {


### PR DESCRIPTION
Fixes a bug where the ProfileSelector component is trying to set the query expression before it has been successfully fetched from the URL. Adding an early return to the useEffect, and adding `queryExpression` to the dependency array fixes this.