### PR TITLE
fix relative time picker minus click

### DIFF
--- a/ui/packages/shared/components/src/DateTimeRangePicker/RelativeDatePicker/index.tsx
+++ b/ui/packages/shared/components/src/DateTimeRangePicker/RelativeDatePicker/index.tsx
@@ -52,11 +52,14 @@ const presetRanges = [
 const NOW = new RelativeDate(UNITS.MINUTE, 0);
 
 const parseInput = (input: string): {value: number; unit: string} | null => {
+  const value = parseFloat(input);
   const match = input.match(/(\d+)([mhd])/);
-  if (match == null) {
+
+  // handle parseFloat edge cases and non-valid input
+  if (Number.isNaN(value) || input.includes('Infinity') || input.includes('e') || match == null) {
     return null;
   }
-  const value = parseInt(match[1], 10);
+
   const unit = match[2];
   return {value, unit: unitLong[unit]};
 };
@@ -105,12 +108,11 @@ const RelativeDatePicker = ({
     });
 
     const currentTotalMinutes = getMultiplyFactor(date.unit) * date.value;
-    const closestPresetIndex =
-      [...presetRangesTotalMinutes, currentTotalMinutes]
-        .sort((a, b) => a - b)
-        .findIndex(totalMinutes => {
-          return totalMinutes === currentTotalMinutes;
-        }) - 1;
+    const closestPresetIndex = [...presetRangesTotalMinutes, currentTotalMinutes]
+      .sort((a, b) => a - b)
+      .findIndex(totalMinutes => {
+        return totalMinutes === currentTotalMinutes;
+      });
 
     return closestPresetIndex;
   };


### PR DESCRIPTION
Clicking minus too many times (when the value was very small) caused an error to occur. This PR resolves this issue by disabling the minus button in the relative time picker when the current value is below the minimum default values (in other words, below 1m).