### PR TITLE
ui: Unify date time format in Metrics graph

### DIFF
--- a/ui/packages/shared/profile/src/ProfileSource.tsx
+++ b/ui/packages/shared/profile/src/ProfileSource.tsx
@@ -38,8 +38,7 @@ export interface ProfileSelection {
   Type: () => string;
 }
 
-export const timeFormat = "MMM d, 'at' h:mm:s a '(UTC)'";
-export const timeFormatShort = 'MMM d, h:mma';
+export const timeFormat = "MMM d, 'at' HH:mm:ss '(UTC)'";
 
 export function ParamsString(params: {[key: string]: string}): string {
   return Object.keys(params)

--- a/ui/packages/shared/utilities/src/time.ts
+++ b/ui/packages/shared/utilities/src/time.ts
@@ -139,15 +139,15 @@ export const formatForTimespan = (from: number, to: number): string => {
   const durationInSeconds = getTotalSeconds(duration);
 
   if (durationInSeconds <= getTotalSeconds({minutes: 4})) {
-    return 'H:mm:ss';
+    return 'HH:mm:ss';
   }
   if (durationInSeconds <= getTotalSeconds({hours: 13})) {
-    return 'H:mm';
+    return 'HH:mm';
   }
   if (durationInSeconds <= getTotalSeconds({hours: 25})) {
-    return 'H:mm d/M';
+    return 'HH:mm M/d';
   }
-  return 'd/M';
+  return 'M/d';
 };
 
 export const getStepDuration = (start: number, end: number, stepCount = 1000): Duration => {


### PR DESCRIPTION
Changes in this PR:

- Ensures the x-axis date-time format uses the American format (month before the day).
- Make use of the 24H clock across board.
- When zooming in on the metrics graph, show the hour and seconds in the 24H format, as opposed to just the hour only.