### PR TITLE
area/ui: Fix datetime picker bug when zooming on graph using mouse drag and drop

### DIFF
--- a/ui/packages/shared/components/src/DateTimeRangePicker/AbsoluteDatePicker/index.tsx
+++ b/ui/packages/shared/components/src/DateTimeRangePicker/AbsoluteDatePicker/index.tsx
@@ -44,6 +44,15 @@ const AbsoluteDatePicker = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [from, to]);
 
+  useEffect(() => {
+    setFrom(
+      range.from.isRelative() ? new AbsoluteDate(getDateHoursAgo(1)) : (range.from as AbsoluteDate)
+    );
+    setTo(
+      range.to.isRelative() ? new AbsoluteDate(getDateHoursAgo(0)) : (range.to as AbsoluteDate)
+    );
+  }, [range]);
+
   return (
     <div className="flex flex-col">
       <div className="flex justify-center gap-x-2">


### PR DESCRIPTION
When zooming in the metrics graph using the drag and drop interaction, everything is updated (graph and icicle) but not the time selector in UI.

![image](https://github.com/parca-dev/parca/assets/9016992/742533aa-386f-4760-8705-780a4cf89650)

After some investigation, I discovered the selector is updated after the first zoom but fails to do so for any other subsequent zooms. 

This was due to the `from` and `to` local states in the `ui/packages/shared/components/src/DateTimeRangePicker/AbsoluteDatePicker/index.tsx` file not being updated when the `range` prop changes. Adding a `useEffect` with a dependency of `range` to update the `from` and `to` seems to fix the bug.

_To recreate the original bug, zoom in on the metrics graph using the drag and drop interaction, then do another zoom and you'll notice the date and time isn't being updated._