### PR TITLE
pkg/query: Return invalid argument if merging non-delta profiles with time range

### DIFF
--- a/pkg/parcacol/querier.go
+++ b/pkg/parcacol/querier.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The Parca Authors
+// Copyright 2022-2024 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/parcacol/querier.go
+++ b/pkg/parcacol/querier.go
@@ -1027,6 +1027,10 @@ func (q *Querier) selectMerge(
 	start := timestamp.FromTime(startTime)
 	end := timestamp.FromTime(endTime)
 
+	if !queryParts.Delta && !startTime.Equal(endTime) {
+		return nil, "", profile.Meta{}, status.Error(codes.InvalidArgument, "merge queries with different timestamps are only supported for delta profiles")
+	}
+
 	filterExpr := logicalplan.And(
 		append(
 			selectorExprs,

--- a/pkg/query/query_test.go
+++ b/pkg/query/query_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The Parca Authors
+// Copyright 2022-2024 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at


### PR DESCRIPTION
This shouldn't be allowed. In fact, our UI will never do such queries, it's just that the backend is still fine with this.
