### PR TITLE
Persist `keep.go` file in the web `build` directory after building

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -9,6 +9,7 @@
     "type-check": "tsc --noEmit",
     "test": "jest --coverage --config jest.config.cjs",
     "build": "./scripts/run-yarn-build.sh",
+    "build-lerna": "lerna run build",
     "watch": "lerna run --parallel watch",
     "watch-parca-dev": "lerna run --parallel --include-dependencies --scope @parca/web watch",
     "publish:ci": "lerna publish --yes --no-verify-access",

--- a/ui/package.json
+++ b/ui/package.json
@@ -8,7 +8,7 @@
     "fix": "eslint --fix --ext .ts,.tsx,.js packages/*",
     "type-check": "tsc --noEmit",
     "test": "jest --coverage --config jest.config.cjs",
-    "build": "lerna run build",
+    "build": "./scripts/run-yarn-build.sh",
     "watch": "lerna run --parallel watch",
     "watch-parca-dev": "lerna run --parallel --include-dependencies --scope @parca/web watch",
     "publish:ci": "lerna publish --yes --no-verify-access",

--- a/ui/scripts/run-yarn-build.sh
+++ b/ui/scripts/run-yarn-build.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Copyright 2024 The Parca Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# this is done to prevent the yarn build command from removing the keep.go file
+# Create a temporary directory to store the keep.go file
+mkdir -p tmp/ui-keep
+
+# Copy the keep.go file to the temporary directory
+cp packages/app/web/build/keep.go tmp/ui-keep/keep.go
+
+# Run the yarn build command
+command yarn run build
+
+# Copy the keep.go file back to its original location
+cp tmp/ui-keep/keep.go ui/packages/app/web/build/keep.go
+
+# Remove the temporary directory
+rm -rf tmp/ui-keep
+
+exit 0

--- a/ui/scripts/run-yarn-build.sh
+++ b/ui/scripts/run-yarn-build.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 # Copyright 2024 The Parca Authors
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,18 +16,24 @@
 
 # this is done to prevent the yarn build command from removing the keep.go file
 # Create a temporary directory to store the keep.go file
+echo "Creating temporary directory"
 mkdir -p tmp/ui-keep
 
 # Copy the keep.go file to the temporary directory
+echo "Copying keep.go to temporary directory"
 cp packages/app/web/build/keep.go tmp/ui-keep/keep.go
 
 # Run the yarn build command
-command yarn run build
+echo "Running yarn build-lerna command"
+yarn build-lerna
 
 # Copy the keep.go file back to its original location
-cp tmp/ui-keep/keep.go ui/packages/app/web/build/keep.go
+echo "Copying keep.go back to original location"
+cp tmp/ui-keep/keep.go packages/app/web/build/keep.go
 
 # Remove the temporary directory
+echo "Removing temporary directory"
 rm -rf tmp/ui-keep
 
+echo "Done"
 exit 0


### PR DESCRIPTION
This PR ensures that the `keep.go` file that was introduced in this [PR](https://github.com/parca-dev/parca/pull/4105/files) is persisted in the `packages/app/web/build/keep.go` after building the packages with Lerna. 

This solves the recurring issue of our npm packages not being published.