### PR TITLE
pkg/server: Update UI wildcard path

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -235,7 +235,7 @@ func (s *Server) uiHandler(uiFS fs.FS, pathPrefix string) (*http.ServeMux, error
 		paths := []string{fmt.Sprintf("/%s", path)}
 
 		if paths[0] == "/index.html" {
-			paths = append(paths, "/", "/*")
+			paths = append(paths, "/")
 		}
 
 		if paths[0] == "/targets/index.html" {


### PR DESCRIPTION
This panics otherwise. It seems like on Go 1.22 it still serves the `index.html` under other paths correctly.

The panic:
```
panic: non-nil leaf fields

goroutine 217 [running]:
net/http.(*routingNode).set(0xc0016a8500, 0xc0011dcf60, {0x63606e0, 0xc0011e9a10})
        /usr/lib/go/src/net/http/routing_tree.go:78 +0xd4
net/http.(*routingNode).addSegments(0xc0016a8500, {0xc000fc95f0, 0x0, 0x0}, 0xc0011dcf60, {0x63606e0, 0xc0011e9a10})
        /usr/lib/go/src/net/http/routing_tree.go:58 +0x74
net/http.(*routingNode).addSegments(0xc0016a8380, {0xc000fc95f0, 0x1, 0x1}, 0xc0011dcf60, {0x63606e0, 0xc0011e9a10})
        /usr/lib/go/src/net/http/routing_tree.go:70 +0x23a
net/http.(*routingNode).addPattern(0xc000fe17a8, 0xc0011dcf60, {0x63606e0, 0xc0011e9a10})
        /usr/lib/go/src/net/http/routing_tree.go:50 +0xd1
net/http.(*ServeMux).registerErr(0xc000fe1790, {0x555f2f2, 0x2}, {0x63606e0, 0xc0011e9a10})
        /usr/lib/go/src/net/http/server.go:2775 +0x7a9
net/http.(*ServeMux).register(0xc000fe1790, {0x555f2f2, 0x2}, {0x63606e0, 0xc0011e9a10})
        /usr/lib/go/src/net/http/server.go:2732 +0x38
net/http.(*ServeMux).HandleFunc(0xc000fe1790, {0x555f2f2, 0x2}, 0xc0011e9a10)
        /usr/lib/go/src/net/http/server.go:2707 +0x75
github.com/parca-dev/parca/pkg/server.(*Server).uiHandler.func1({0xc000fd1430, 0xa}, {0x639bb90, 0x63ecb58}, {0x0, 0x0})
        /home/metalmatze/src/github.com/parca-dev/parca/pkg/server/server.go:246 +0x11ed
io/fs.walkDir({0x635ff80, 0xc0011e4280}, {0xc000fd1430, 0xa}, {0x639bb90, 0x63ecb58}, 0xc0000694f8)
        /usr/lib/go/src/io/fs/walk.go:73 +0x8e
io/fs.walkDir({0x635ff80, 0xc0011e4280}, {0x634cd68, 0x1}, {0x639af10, 0xc000fd3680}, 0xc0000694f8)
        /usr/lib/go/src/io/fs/walk.go:95 +0x525
io/fs.WalkDir({0x635ff80, 0xc0011e4280}, {0x634cd68, 0x1}, 0xc0000694f8)
        /usr/lib/go/src/io/fs/walk.go:122 +0x194
github.com/parca-dev/parca/pkg/server.(*Server).uiHandler(0xc0011ac360, {0x635ff80, 0xc0011e4280}, {0x0, 0x0})
        /home/metalmatze/src/github.com/parca-dev/parca/pkg/server/server.go:193 +0x1e5
github.com/parca-dev/parca/pkg/server.(*Server).ListenAndServe(0xc0011ac360, {0x639ac38, 0xc00118dc80}, {0x6360340, 0xc0014a3400}, {0x635ff80, 0xc0011e4280}, {0xc0015d1bb8, 0x5}, 0x12a05f200, ...)
        /home/metalmatze/src/github.com/parca-dev/parca/pkg/server/server.go:149 +0xd35
github.com/glacier-dev/glacier/pkg/glacier.Run.func3.1({0x639ac38, 0xc00118dc80})
        /home/metalmatze/src/github.com/glacier-dev/glacier/pkg/glacier/glacier.go:185 +0x391
runtime/pprof.Do({0x639ac38, 0xc00118dc80}, {{0xc0011e4320, 0x1, 0x1}}, 0xc0000c0ec8)
        /usr/lib/go/src/runtime/pprof/runtime.go:51 +0x138
github.com/glacier-dev/glacier/pkg/glacier.Run.func3()
        /home/metalmatze/src/github.com/glacier-dev/glacier/pkg/glacier/glacier.go:184 +0x337
github.com/oklog/run.(*Group).Run.func1({0xc0011dc420, 0xc0011de540})
        /home/metalmatze/pkg/mod/github.com/oklog/run@v1.1.0/group.go:38 +0x2b
created by github.com/oklog/run.(*Group).Run in goroutine 1
        /home/metalmatze/pkg/mod/github.com/oklog/run@v1.1.0/group.go:37 +0x237
```