### PR TITLE
Improve filter profile data

### DIFF
--- a/pkg/parcacol/arrow.go
+++ b/pkg/parcacol/arrow.go
@@ -129,6 +129,10 @@ func (c *ArrowToProfileConverter) Convert(
 			lOffsetEnd := locationOffsets[i+1]
 			stacktrace := make([]*profile.Location, 0, lOffsetEnd-lOffsetStart)
 			for j := int(lOffsetStart); j < int(lOffsetEnd); j++ {
+				if locations.ListValues().IsNull(j) { // Ignore null locations; they have been filtered out.
+					continue
+				}
+
 				llOffsetStart := lineOffsets[j]
 				llOffsetEnd := lineOffsets[j+1]
 				lines := make([]profile.LocationLine, 0, llOffsetEnd-llOffsetStart)

--- a/pkg/parcacol/arrow.go
+++ b/pkg/parcacol/arrow.go
@@ -113,6 +113,9 @@ func (c *ArrowToProfileConverter) Convert(
 		}
 
 		for i := 0; i < int(ar.NumRows()); i++ {
+			if locations.IsNull(i) { // Skip null rows
+				continue
+			}
 			labels := make(map[string]string, len(labelIndexes))
 			for name, index := range labelIndexes {
 				c := ar.Column(index).(*array.Dictionary)

--- a/pkg/parcacol/arrow.go
+++ b/pkg/parcacol/arrow.go
@@ -113,9 +113,6 @@ func (c *ArrowToProfileConverter) Convert(
 		}
 
 		for i := 0; i < int(ar.NumRows()); i++ {
-			if locations.IsNull(i) { // Skip null rows
-				continue
-			}
 			labels := make(map[string]string, len(labelIndexes))
 			for name, index := range labelIndexes {
 				c := ar.Column(index).(*array.Dictionary)
@@ -128,8 +125,8 @@ func (c *ArrowToProfileConverter) Convert(
 				}
 			}
 
-			lOffsetStart := locationOffsets[i]
-			lOffsetEnd := locationOffsets[i+1]
+			lOffsetStart := locationOffsets[i+locations.Offset()]
+			lOffsetEnd := locationOffsets[i+1+locations.Offset()]
 			stacktrace := make([]*profile.Location, 0, lOffsetEnd-lOffsetStart)
 			for j := int(lOffsetStart); j < int(lOffsetEnd); j++ {
 				llOffsetStart := lineOffsets[j]

--- a/pkg/profile/writer.go
+++ b/pkg/profile/writer.go
@@ -42,6 +42,30 @@ type Writer struct {
 	Diff               *array.Int64Builder
 }
 
+func (w *Writer) Release() {
+	w.RecordBuilder.Release()
+	for _, b := range w.LabelBuilders {
+		b.Release()
+	}
+	w.LocationsList.Release()
+	w.Locations.Release()
+	w.Addresses.Release()
+	w.MappingStart.Release()
+	w.MappingLimit.Release()
+	w.MappingOffset.Release()
+	w.MappingFile.Release()
+	w.MappingBuildID.Release()
+	w.Lines.Release()
+	w.Line.Release()
+	w.LineNumber.Release()
+	w.FunctionName.Release()
+	w.FunctionSystemName.Release()
+	w.FunctionFilename.Release()
+	w.FunctionStartLine.Release()
+	w.Value.Release()
+	w.Diff.Release()
+}
+
 func NewWriter(pool memory.Allocator, labelNames []string) Writer {
 	labelFields := make([]arrow.Field, len(labelNames))
 	for i, name := range labelNames {

--- a/pkg/profile/writer.go
+++ b/pkg/profile/writer.go
@@ -44,26 +44,6 @@ type Writer struct {
 
 func (w *Writer) Release() {
 	w.RecordBuilder.Release()
-	for _, b := range w.LabelBuilders {
-		b.Release()
-	}
-	w.LocationsList.Release()
-	w.Locations.Release()
-	w.Addresses.Release()
-	w.MappingStart.Release()
-	w.MappingLimit.Release()
-	w.MappingOffset.Release()
-	w.MappingFile.Release()
-	w.MappingBuildID.Release()
-	w.Lines.Release()
-	w.Line.Release()
-	w.LineNumber.Release()
-	w.FunctionName.Release()
-	w.FunctionSystemName.Release()
-	w.FunctionFilename.Release()
-	w.FunctionStartLine.Release()
-	w.Value.Release()
-	w.Diff.Release()
 }
 
 func NewWriter(pool memory.Allocator, labelNames []string) Writer {

--- a/pkg/query/columnquery.go
+++ b/pkg/query/columnquery.go
@@ -275,11 +275,6 @@ func (q *ColumnQueryAPI) Query(ctx context.Context, req *pb.QueryRequest) (*pb.Q
 	if err != nil {
 		return nil, fmt.Errorf("filtering profile: %w", err)
 	}
-	defer func() {
-		for _, r := range p.Samples {
-			r.Release()
-		}
-	}()
 
 	return q.renderReport(
 		ctx,
@@ -304,6 +299,12 @@ func FilterProfileData(
 ) ([]arrow.Record, int64, error) {
 	_, span := tracer.Start(ctx, "filterByFunction")
 	defer span.End()
+
+	defer func() {
+		for _, r := range records {
+			r.Release()
+		}
+	}()
 
 	// We want to filter by function name case-insensitive, so we need to lowercase the query.
 	// We lower case the query here, so we don't have to do it for every sample.

--- a/pkg/query/columnquery.go
+++ b/pkg/query/columnquery.go
@@ -338,7 +338,9 @@ func FilterProfileData(
 			return nil, 0, fmt.Errorf("filter record: %w", err)
 		}
 
-		res = append(res, filteredRecord)
+		if filteredRecord != nil {
+			res = append(res, filteredRecord)
+		}
 		allValues += valueSum
 		allFiltered += filteredSum
 	}
@@ -356,12 +358,6 @@ func filterRecord(
 	showInterpretedOnly bool,
 ) (arrow.Record, int64, int64, error) {
 	r := profile.NewRecordReader(rec)
-
-	// Builders for the result profile.
-	labelNames := make([]string, 0, len(r.LabelFields))
-	for _, lf := range r.LabelFields {
-		labelNames = append(labelNames, strings.TrimPrefix(lf.Name, profile.ColumnPprofLabelsPrefix))
-	}
 
 	indexMatches := map[uint32]struct{}{}
 	for i := 0; i < r.LineFunctionNameDict.Len(); i++ {

--- a/pkg/query/columnquery_test.go
+++ b/pkg/query/columnquery_test.go
@@ -1420,7 +1420,9 @@ func OldProfileToArrowProfile(p profile.OldProfile) (profile.Profile, error) {
 
 func TestFilterData(t *testing.T) {
 	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
 	w := profile.NewWriter(mem, nil)
+	defer w.Release()
 
 	w.LocationsList.Append(true)
 	w.Locations.Append(true)
@@ -1471,6 +1473,7 @@ func TestFilterData(t *testing.T) {
 	w.Diff.Append(0)
 
 	originalRecord := w.RecordBuilder.NewRecord()
+	defer originalRecord.Release()
 	recs, _, err := FilterProfileData(
 		context.Background(),
 		noop.NewTracerProvider().Tracer(""),
@@ -1483,14 +1486,22 @@ func TestFilterData(t *testing.T) {
 	)
 	require.NoError(t, err)
 	r := profile.NewRecordReader(recs[0])
-	require.Equal(t, 2, r.Location.Len())
+	valid := 0
+	for i := 0; i < r.Location.Len(); i++ {
+		if r.Location.IsValid(i) {
+			valid++
+		}
+	}
+	require.Equal(t, 2, valid)
 	require.Equal(t, "test", string(r.LineFunctionNameDict.Value(int(r.LineFunctionNameIndices.Value(0)))))
 	require.Equal(t, "test1", string(r.LineFunctionNameDict.Value(int(r.LineFunctionNameIndices.Value(1)))))
 }
 
 func TestFilterDataWithPath(t *testing.T) {
 	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
 	w := profile.NewWriter(mem, nil)
+	defer w.Release()
 
 	w.LocationsList.Append(true)
 	w.Locations.Append(true)
@@ -1541,6 +1552,7 @@ func TestFilterDataWithPath(t *testing.T) {
 	w.Diff.Append(0)
 
 	originalRecord := w.RecordBuilder.NewRecord()
+	defer originalRecord.Release()
 	recs, _, err := FilterProfileData(
 		context.Background(),
 		noop.NewTracerProvider().Tracer(""),
@@ -1551,14 +1563,22 @@ func TestFilterDataWithPath(t *testing.T) {
 	)
 	require.NoError(t, err)
 	r := profile.NewRecordReader(recs[0])
-	require.Equal(t, 2, r.Location.Len())
+	valid := 0
+	for i := 0; i < r.Location.Len(); i++ {
+		if r.Location.IsValid(i) {
+			valid++
+		}
+	}
+	require.Equal(t, 2, valid)
 	require.Equal(t, "__libc_start_main", string(r.LineFunctionNameDict.Value(int(r.LineFunctionNameIndices.Value(0)))))
-	require.Equal(t, "test", string(r.LineFunctionNameDict.Value(int(r.LineFunctionNameIndices.Value(1)))))
+	require.Equal(t, "test", string(r.LineFunctionNameDict.Value(int(r.LineFunctionNameIndices.Value(2)))))
 }
 
 func TestFilterDataInterpretedOnly(t *testing.T) {
 	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
 	w := profile.NewWriter(mem, nil)
+	defer w.Release()
 
 	w.LocationsList.Append(true)
 	w.Locations.Append(true)
@@ -1609,6 +1629,7 @@ func TestFilterDataInterpretedOnly(t *testing.T) {
 	w.Diff.Append(0)
 
 	originalRecord := w.RecordBuilder.NewRecord()
+	defer originalRecord.Release()
 	recs, _, err := FilterProfileData(
 		context.Background(),
 		noop.NewTracerProvider().Tracer(""),
@@ -1621,6 +1642,86 @@ func TestFilterDataInterpretedOnly(t *testing.T) {
 	)
 	require.NoError(t, err)
 	r := profile.NewRecordReader(recs[0])
-	require.Equal(t, 1, r.Location.Len())
-	require.Equal(t, "test", string(r.LineFunctionNameDict.Value(int(r.LineFunctionNameIndices.Value(0)))))
+	valid := 0
+	for i := 0; i < r.Location.Len(); i++ {
+		if r.Location.IsValid(i) {
+			valid++
+		}
+	}
+	require.Equal(t, 1, valid)
+	require.Equal(t, "test", string(r.LineFunctionNameDict.Value(int(r.LineFunctionNameIndices.Value(2)))))
+}
+
+func BenchmarkFilterData(t *testing.B) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+	w := profile.NewWriter(mem, nil)
+	defer w.Release()
+
+	for i := 0; i < 10000; i++ {
+		w.LocationsList.Append(true)
+		w.Locations.Append(true)
+		w.Addresses.Append(0x1234)
+		w.MappingStart.Append(0x1000)
+		w.MappingLimit.Append(0x2000)
+		w.MappingOffset.Append(0x0)
+		w.MappingFile.Append([]byte("test"))
+		w.MappingBuildID.Append([]byte("test"))
+		w.Lines.Append(true)
+		w.Line.Append(true)
+		w.LineNumber.Append(1)
+		w.FunctionName.Append([]byte("test"))
+		w.FunctionSystemName.Append([]byte("test"))
+		w.FunctionFilename.Append([]byte("test"))
+		w.FunctionStartLine.Append(1)
+
+		w.Locations.Append(true)
+		w.Addresses.Append(0x1234)
+		w.MappingStart.Append(0x1000)
+		w.MappingLimit.Append(0x2000)
+		w.MappingOffset.Append(0x0)
+		w.MappingFile.Append([]byte("libpython3.11.so.1.0"))
+		w.MappingBuildID.Append([]byte("test"))
+		w.Lines.Append(true)
+		w.Line.Append(true)
+		w.LineNumber.Append(1)
+		w.FunctionName.Append([]byte("test1"))
+		w.FunctionSystemName.Append([]byte("test"))
+		w.FunctionFilename.Append([]byte("test"))
+		w.FunctionStartLine.Append(1)
+
+		w.Locations.Append(true)
+		w.Addresses.Append(0x1234)
+		w.MappingStart.Append(0x1000)
+		w.MappingLimit.Append(0x2000)
+		w.MappingOffset.Append(0x0)
+		w.MappingFile.Append([]byte("test"))
+		w.MappingBuildID.Append([]byte("test"))
+		w.Lines.Append(true)
+		w.Line.Append(true)
+		w.LineNumber.Append(1)
+		w.FunctionName.Append([]byte("test1"))
+		w.FunctionSystemName.Append([]byte("test"))
+		w.FunctionFilename.Append([]byte("test"))
+		w.FunctionStartLine.Append(1)
+		w.Value.Append(1)
+		w.Diff.Append(0)
+	}
+
+	originalRecord := w.RecordBuilder.NewRecord()
+	defer originalRecord.Release()
+
+	for i := 0; i < t.N; i++ {
+		_, _, err := FilterProfileData(
+			context.Background(),
+			noop.NewTracerProvider().Tracer(""),
+			mem,
+			[]arrow.Record{originalRecord},
+			"",
+			&pb.RuntimeFilter{
+				ShowPython: false,
+			},
+		)
+		require.NoError(t, err)
+	}
 }

--- a/pkg/query/flamegraph_arrow.go
+++ b/pkg/query/flamegraph_arrow.go
@@ -192,6 +192,9 @@ func generateFlamegraphArrowRecord(ctx context.Context, mem memory.Allocator, tr
 			// every new sample resets the childRow to -1 indicating that we start with a leaf again.
 			// pprof stores locations in reverse order, thus we loop over locations in reverse order.
 			for j := int(end - 1); j >= int(beg); j-- {
+				if r.Locations.ListValues().IsNull(j) {
+					continue // skip null values; these have been filtered out.
+				}
 				// If the location has no lines, it's not symbolized.
 				// We work with the location address instead.
 

--- a/pkg/query/pprof.go
+++ b/pkg/query/pprof.go
@@ -162,6 +162,9 @@ func (w *PprofWriter) sample(
 		}
 
 		for j := int(locStart); j < int(locEnd); j++ {
+			if !r.Locations.ListValues().IsValid(j) {
+				continue
+			}
 			l := w.location(r, t, j)
 			if l != 0 {
 				s.LocationId = append(s.LocationId, l)

--- a/pkg/query/sources.go
+++ b/pkg/query/sources.go
@@ -149,6 +149,9 @@ func (b *sourceReportBuilder) addRecord(rec arrow.Record) {
 	for i := 0; i < int(rec.NumRows()); i++ {
 		lOffsetStart, lOffsetEnd := r.Locations.ValueOffsets(i)
 		for j := int(lOffsetStart); j < int(lOffsetEnd); j++ {
+			if !r.Locations.ListValues().IsValid(j) {
+				continue // Skip null locations; they have been filtered out
+			}
 			if r.MappingStart.IsValid(j) && bytes.Equal(r.MappingBuildIDDict.Value(int(r.MappingBuildIDIndices.Value(j))), b.buildID) {
 				llOffsetStart, llOffsetEnd := r.Lines.ValueOffsets(j)
 

--- a/pkg/query/table.go
+++ b/pkg/query/table.go
@@ -108,6 +108,9 @@ func generateTableArrowRecord(
 		for sampleRow := 0; sampleRow < int(r.Record.NumRows()); sampleRow++ {
 			lOffsetStart, lOffsetEnd := r.Locations.ValueOffsets(sampleRow)
 			for locationRow := int(lOffsetStart); locationRow < int(lOffsetEnd); locationRow++ {
+				if r.Locations.ListValues().IsNull(locationRow) {
+					continue // Skip null locations; they have been filtered out.
+				}
 				if r.Lines.IsNull(locationRow) {
 					// The location has no lines, we therefore compare its address.
 


### PR DESCRIPTION
Mark fields as null instead of rebuilding record during filtering.

```bash
thor@thors-MacBook-Pro ~/.../parca/pkg/query % benchstat before.txt after.txt
name           old time/op    new time/op    delta
FilterData-10    5.00ms ± 2%    0.38ms ± 1%  -92.37%  (p=0.000 n=10+10)

name           old alloc/op   new alloc/op   delta
FilterData-10    6.28MB ± 0%    0.00MB ± 1%  -99.94%  (p=0.000 n=10+10)

name           old allocs/op  new allocs/op  delta
FilterData-10     3.91k ± 1%     0.07k ± 2%  -98.19%  (p=0.000 n=10+10)
```