### PR TITLE
Fix root leaf calc

### DIFF
--- a/pkg/query/flamegraph_arrow.go
+++ b/pkg/query/flamegraph_arrow.go
@@ -199,9 +199,9 @@ func generateFlamegraphArrowRecord(ctx context.Context, mem memory.Allocator, tr
 				// We work with the location address instead.
 
 				// This returns whether this location is a root of a stacktrace.
-				isLocationRoot := isLocationRoot(beg, end, int64(j), r.Locations)
+				locationRoot := isLocationRoot(beg, end, int64(j), r.Locations)
 				// Depending on whether we aggregate the labels (and thus inject node labels), we either compare the rows or not.
-				isRoot := isLocationRoot && !(fb.aggregationConfig.aggregateByLabels && hasLabels)
+				isRoot := locationRoot && !(fb.aggregationConfig.aggregateByLabels && hasLabels)
 
 				llOffsetStart, llOffsetEnd := r.Lines.ValueOffsets(j)
 				if !r.Lines.IsValid(j) || llOffsetEnd-llOffsetStart <= 0 {
@@ -248,10 +248,10 @@ func generateFlamegraphArrowRecord(ctx context.Context, mem memory.Allocator, tr
 
 				// just like locations, pprof stores lines in reverse order.
 				for k := int(llOffsetEnd - 1); k >= int(llOffsetStart); k-- {
-					isInlineRoot := k == int(llOffsetEnd-1)
+					isInlineRoot := isLocationRoot(llOffsetStart, llOffsetEnd, int64(k), r.Lines)
 					isInlined := !isInlineRoot
 
-					isRoot = isLocationRoot && !(fb.aggregationConfig.aggregateByLabels && hasLabels) && isInlineRoot
+					isRoot = locationRoot && !(fb.aggregationConfig.aggregateByLabels && hasLabels) && isInlineRoot
 					// We only want to compare the rows if this is the root, and we don't aggregate the labels.
 					if isRoot {
 						fb.compareRows = rootRowChildren

--- a/pkg/query/flamegraph_arrow.go
+++ b/pkg/query/flamegraph_arrow.go
@@ -199,7 +199,7 @@ func generateFlamegraphArrowRecord(ctx context.Context, mem memory.Allocator, tr
 				// We work with the location address instead.
 
 				// This returns whether this location is a root of a stacktrace.
-				isLocationRoot := isLocationRoot(int(end), j)
+				isLocationRoot := isLocationRoot(beg, end, int64(j), r.Locations)
 				// Depending on whether we aggregate the labels (and thus inject node labels), we either compare the rows or not.
 				isRoot := isLocationRoot && !(fb.aggregationConfig.aggregateByLabels && hasLabels)
 
@@ -1714,8 +1714,13 @@ func appendDictionaryIndexInt32(dict *array.Int32, index *array.Int32Builder, ro
 	index.Append(dict.Value(row))
 }
 
-func isLocationRoot(end, i int) bool {
-	return i == end-1
+func isLocationRoot(beg, end, i int64, list *array.List) bool {
+	for j := end - 1; j >= beg; j-- {
+		if !list.ListValues().IsNull(int(j)) {
+			return j == i
+		}
+	}
+	return false
 }
 
 // parent stores the parent's row number of a stack.

--- a/pkg/query/sources.go
+++ b/pkg/query/sources.go
@@ -160,7 +160,7 @@ func (b *sourceReportBuilder) addRecord(rec arrow.Record) {
 						r.LineFunctionNameIndices.IsValid(k) && bytes.Equal(r.LineFunctionFilenameDict.Value(int(r.LineFunctionFilenameIndices.Value(k))), b.filename) {
 						b.cumulativeValues[r.LineNumber.Value(k)-1] += r.Value.Value(i)
 
-						isLeaf := j == int(lOffsetStart) && k == int(llOffsetStart)
+						isLeaf := isFirstNonNil(i, j, r.Locations) && isFirstNonNil(j, k, r.Lines)
 						if isLeaf {
 							b.flatValues[r.LineNumber.Value(k)-1] += r.Value.Value(i)
 						}


### PR DESCRIPTION
Moving to using nulls for locations instead of rebuilding means we can no longer rely on the location position to determine if it's a leaf or root. 

This changes the calculation to exclude null locations to determine leaf/root.