### PR TITLE
filterRecord: don't return an empty profile when dict is empty

### DIFF
--- a/pkg/query/columnquery.go
+++ b/pkg/query/columnquery.go
@@ -372,7 +372,7 @@ func filterRecord(
 		}
 	}
 
-	if len(indexMatches) == 0 {
+	if r.LineFunctionNameDict.Len() > 0 && len(indexMatches) == 0 {
 		return nil, math.Int64.Sum(r.Value), 0, nil
 	}
 


### PR DESCRIPTION
If the LineFunctionNameDict is empty we will return an empty profile. This changes the index matches check to only trigger if there were values in the dictionary to match against.