### PR TITLE
Update index to not use /* anymore for Go 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/parca-dev/parca
 
-go 1.21
+go 1.22
 
 require (
 	cloud.google.com/go/storage v1.39.0

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -235,7 +235,7 @@ func (s *Server) uiHandler(uiFS fs.FS, pathPrefix string) (*http.ServeMux, error
 		paths := []string{fmt.Sprintf("/%s", path)}
 
 		if paths[0] == "/index.html" {
-			paths = append(paths, "/", "/*")
+			paths = append(paths, "/")
 		}
 
 		if paths[0] == "/targets/index.html" {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -108,13 +108,12 @@ func (s *Server) ListenAndServe(
 		// It is increased to 32MB to account for large protobuf messages (debug information uploads and downloads).
 		grpc.MaxSendMsgSize(debuginfo.MaxMsgSize),
 		grpc.MaxRecvMsgSize(debuginfo.MaxMsgSize),
+		grpc.StatsHandler(otelgrpc.NewServerHandler()),
 		grpc.ChainStreamInterceptor(
-			otelgrpc.StreamServerInterceptor(),
 			met.StreamServerInterceptor(),
 			grpc_logging.StreamServerInterceptor(InterceptorLogger(logger), logOpts...),
 		),
 		grpc.ChainUnaryInterceptor(
-			otelgrpc.UnaryServerInterceptor(),
 			met.UnaryServerInterceptor(),
 			grpc_logging.UnaryServerInterceptor(InterceptorLogger(logger), logOpts...),
 		),


### PR DESCRIPTION
This otherwise panics on Go 1.22 now.