### PR TITLE
ui: Fixed the bug that was resetting the profile selection state on page load

### DIFF
--- a/ui/packages/shared/profile/src/ProfileSelector/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileSelector/index.tsx
@@ -110,18 +110,6 @@ const ProfileSelector = ({
   const [queryExpressionString, setQueryExpressionString] = useState(querySelection.expression);
 
   useEffect(() => {
-    if (querySelection.expression === undefined) {
-      return;
-    }
-
-    setIsDataLoading(true);
-    setQueryExpression();
-    setIsDataLoading(false);
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [timeRangeSelection]);
-
-  useEffect(() => {
     if (enforcedProfileName !== '') {
       const [q, changed] = Query.parse(querySelection.expression).setProfileName(
         enforcedProfileName

--- a/ui/packages/shared/profile/src/ProfileSelector/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileSelector/index.tsx
@@ -99,7 +99,6 @@ const ProfileSelector = ({
     data: profileTypesData,
     error,
   } = useProfileTypes(queryClient);
-  const [isDataLoading, setIsDataLoading] = useState<boolean>(false);
   const {heightStyle} = useMetricsGraphDimensions(comparing);
   const {viewComponent} = useParcaContext();
 
@@ -284,8 +283,7 @@ const ProfileSelector = ({
       </div>
       <div className="rounded bg-white shadow dark:border-gray-500 dark:bg-gray-700">
         <div style={{height: heightStyle}}>
-          {!isDataLoading &&
-          querySelection.expression !== undefined &&
+          {querySelection.expression !== undefined &&
           querySelection.expression.length > 0 &&
           querySelection.from !== undefined &&
           querySelection.to !== undefined ? (


### PR DESCRIPTION
This `useEffect` was causing the state reset of the selected profile on page load. 

Also, this effect seems unnecessary as it was just causing a new search effect, we could have added this as a workaround to some edge case, but the app works fine without this. So we can re-visit if any problem surfaces.