### PR TITLE
Query valuePerSecond for delta profiles

### DIFF
--- a/pkg/parcacol/querier_test.go
+++ b/pkg/parcacol/querier_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/apache/arrow/go/v15/arrow"
+	"github.com/apache/arrow/go/v15/arrow/array"
 	"github.com/apache/arrow/go/v15/arrow/memory"
 	"github.com/go-kit/log"
 	"github.com/polarsignals/frostdb/dynparquet"
@@ -154,4 +155,151 @@ func TestQueryDeltaRange(t *testing.T) {
 	require.Equal(t, 0.999999982, res[0].Samples[0].ValuePerSecond) // This uses the step for calculating per-second, because there are multiple samples in the step
 	require.Equal(t, int64(4999999910), res[0].Samples[1].Value)    // Rounding mistakes are expected
 	require.Equal(t, 0.499999991, res[0].Samples[1].ValuePerSecond) // This uses the duration for calculating per-second, because there is only one sample in the step
+}
+
+func TestQueryMerge(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	tracer := noop.NewTracerProvider().Tracer("")
+
+	schema, err := dynparquet.SchemaFromDefinition(profile.SchemaDefinition())
+	require.NoError(t, err)
+
+	meta := profile.Meta{
+		Name: "cpu",
+		SampleType: profile.ValueType{
+			Type: "samples",
+			Unit: "count",
+		},
+		PeriodType: profile.ValueType{
+			Type: "cpu",
+			Unit: "nanoseconds",
+		},
+		Duration: (10 * time.Second).Nanoseconds(),
+		Period:   time.Second.Nanoseconds() / 19,
+	}
+
+	r1, err := SeriesToArrowRecord(
+		mem,
+		schema,
+		[]normalizer.Series{{
+			Labels: map[string]string{"test": "test"},
+			Samples: [][]*profile.NormalizedProfile{{{
+				Samples: []*profile.NormalizedSample{{
+					StacktraceID: "1",
+					Value:        19 * 10, // 19 samples per second for 10 seconds is 1 core
+				}, {
+					StacktraceID: "2",
+					Value:        19 * 5, // 19 samples per second for 10 seconds is 0.5 cores
+				}},
+				Meta: profile.Meta{
+					Name:       meta.Name,
+					SampleType: meta.SampleType,
+					PeriodType: meta.PeriodType,
+					Duration:   meta.Duration,
+					Period:     meta.Period,
+					Timestamp:  (1 * time.Second).Milliseconds(),
+				},
+			}}},
+		}},
+		[]string{"test"}, nil, nil,
+	)
+	require.NoError(t, err)
+
+	r2, err := SeriesToArrowRecord(
+		mem,
+		schema,
+		[]normalizer.Series{{
+			Labels: map[string]string{"test": "test"},
+			Samples: [][]*profile.NormalizedProfile{{{
+				Samples: []*profile.NormalizedSample{{
+					StacktraceID: "1",
+					Value:        19 * 5, // 19 samples per second for 10 seconds is 0.5 cores
+				}},
+				Meta: profile.Meta{
+					Name:       meta.Name,
+					SampleType: meta.SampleType,
+					PeriodType: meta.PeriodType,
+					Duration:   meta.Duration,
+					Period:     meta.Period,
+					Timestamp:  (11 * time.Second).Milliseconds(), // 10 seconds later
+				},
+			}}},
+		}},
+		[]string{"test"}, nil, nil,
+	)
+	require.NoError(t, err)
+
+	r3, err := SeriesToArrowRecord(
+		mem,
+		schema,
+		[]normalizer.Series{{
+			Labels: map[string]string{"test": "test"},
+			Samples: [][]*profile.NormalizedProfile{{{
+				Samples: []*profile.NormalizedSample{{
+					StacktraceID: "1",
+					Value:        19 * 5, // 19 samples per second for 10 seconds is 0.5 cores
+				}},
+				Meta: profile.Meta{
+					Name:       meta.Name,
+					SampleType: meta.SampleType,
+					PeriodType: meta.PeriodType,
+					Duration:   meta.Duration,
+					Period:     meta.Period,
+					Timestamp:  (21 * time.Second).Milliseconds(), // 10 seconds later
+				},
+			}}},
+		}},
+		[]string{"test"}, nil, nil,
+	)
+	require.NoError(t, err)
+
+	q := NewQuerier(
+		log.NewNopLogger(),
+		tracer,
+		query.NewEngine(
+			mem,
+			&query.FakeTableProvider{
+				Tables: map[string]logicalplan.TableReader{
+					"stacktraces": &query.FakeTableReader{
+						FrostdbSchema: schema,
+						Records:       []arrow.Record{r1, r2, r3},
+					},
+				},
+			},
+		),
+		"stacktraces",
+		nil,
+		mem,
+	)
+	records, _, _, err := q.selectMerge(
+		context.Background(),
+		`cpu:samples:count:cpu:nanoseconds:delta`,
+		time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC),
+		time.Date(3000, 0, 0, 0, 0, 0, 0, time.UTC),
+		false,
+	)
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+
+	require.Equal(t, int64(2), records[0].NumRows())
+	require.Equal(t, int64(3), records[0].NumCols())
+
+	stacktraces := records[0].Column(0).(*array.Binary)
+	require.Equal(t, []string{"1", "2"}, append(
+		[]string{},
+		stacktraces.ValueString(0),
+		stacktraces.ValueString(1),
+	))
+
+	require.Equal(t, []int64{
+		19*5*meta.Period + 19*5*meta.Period + 19*10*meta.Period, // 3 samples
+		19 * 5 * meta.Period, // 1 sample
+	}, records[0].Column(1).(*array.Int64).Int64Values())
+
+	require.Equal(t, []float64{
+		// All 3 samples a seen over a total duration of 30s. Therefore, divide by 30s.
+		float64(19*5*meta.Period+19*5*meta.Period+19*10*meta.Period) / float64((30 * time.Second).Nanoseconds()),
+		// There is just one sample that was seen during a duration of 10s. Therefore, divide by 10s.
+		float64(19*5*meta.Period) / float64(10*time.Second.Nanoseconds()),
+	}, records[0].Column(2).(*array.Float64).Float64Values())
 }

--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -73,17 +73,25 @@ func LocationsArrowSchema() *arrow.Schema {
 }
 
 func ArrowSamplesField(profileLabelFields []arrow.Field) []arrow.Field {
-	numFields := len(profileLabelFields) + 3 // +3 for stacktraces, value and diff
+	numFields := len(profileLabelFields) + 5 // +5 for stacktraces, value, value_per_second, diff and diff_per_second
 	fields := make([]arrow.Field, numFields)
 	copy(fields, profileLabelFields)
-	fields[numFields-3] = LocationsField
-	fields[numFields-2] = arrow.Field{
+	fields[numFields-5] = LocationsField
+	fields[numFields-4] = arrow.Field{
 		Name: "value",
 		Type: arrow.PrimitiveTypes.Int64,
 	}
-	fields[numFields-1] = arrow.Field{
+	fields[numFields-3] = arrow.Field{
+		Name: "value_per_second",
+		Type: arrow.PrimitiveTypes.Float64,
+	}
+	fields[numFields-2] = arrow.Field{
 		Name: "diff",
 		Type: arrow.PrimitiveTypes.Int64,
+	}
+	fields[numFields-1] = arrow.Field{
+		Name: "diff_per_second",
+		Type: arrow.PrimitiveTypes.Float64,
 	}
 
 	return fields

--- a/pkg/profile/reader.go
+++ b/pkg/profile/reader.go
@@ -57,8 +57,10 @@ type RecordReader struct {
 	LineFunctionFilenameDict      *array.Binary
 	LineFunctionStartLine         *array.Int64
 
-	Value *array.Int64
-	Diff  *array.Int64
+	Value          *array.Int64
+	ValuePerSecond *array.Float64
+	Diff           *array.Int64
+	DiffPerSecond  *array.Float64
 }
 
 func NewReader(p Profile) Reader {
@@ -119,7 +121,9 @@ func NewRecordReader(ar arrow.Record) *RecordReader {
 	lineFunctionFilenameDict := lineFunctionFilename.Dictionary().(*array.Binary)
 	lineFunctionStartLine := line.Field(4).(*array.Int64)
 	valueColumn := ar.Column(labelNum + 1).(*array.Int64)
-	diffColumn := ar.Column(labelNum + 2).(*array.Int64)
+	valuePerSecondColumn := ar.Column(labelNum + 2).(*array.Float64)
+	diffColumn := ar.Column(labelNum + 3).(*array.Int64)
+	diffPerSecondColumn := ar.Column(labelNum + 4).(*array.Float64)
 
 	return &RecordReader{
 		Record:                        ar,
@@ -146,6 +150,8 @@ func NewRecordReader(ar arrow.Record) *RecordReader {
 		LineFunctionFilenameDict:      lineFunctionFilenameDict,
 		LineFunctionStartLine:         lineFunctionStartLine,
 		Value:                         valueColumn,
+		ValuePerSecond:                valuePerSecondColumn,
 		Diff:                          diffColumn,
+		DiffPerSecond:                 diffPerSecondColumn,
 	}
 }

--- a/pkg/profile/writer.go
+++ b/pkg/profile/writer.go
@@ -39,7 +39,9 @@ type Writer struct {
 	FunctionFilename   *array.BinaryDictionaryBuilder
 	FunctionStartLine  *array.Int64Builder
 	Value              *array.Int64Builder
+	ValuePerSecond     *array.Float64Builder
 	Diff               *array.Int64Builder
+	DiffPerSecond      *array.Float64Builder
 }
 
 func (w *Writer) Release() {
@@ -86,7 +88,9 @@ func NewWriter(pool memory.Allocator, labelNames []string) Writer {
 	functionStartLine := line.FieldBuilder(4).(*array.Int64Builder)
 
 	value := b.Field(labelNum + 1).(*array.Int64Builder)
-	diff := b.Field(labelNum + 2).(*array.Int64Builder)
+	valuePerSecond := b.Field(labelNum + 2).(*array.Float64Builder)
+	diff := b.Field(labelNum + 3).(*array.Int64Builder)
+	diffPerSecond := b.Field(labelNum + 4).(*array.Float64Builder)
 
 	return Writer{
 		RecordBuilder:      b,
@@ -108,7 +112,9 @@ func NewWriter(pool memory.Allocator, labelNames []string) Writer {
 		FunctionFilename:   functionFilename,
 		FunctionStartLine:  functionStartLine,
 		Value:              value,
+		ValuePerSecond:     valuePerSecond,
 		Diff:               diff,
+		DiffPerSecond:      diffPerSecond,
 	}
 }
 
@@ -132,7 +138,9 @@ type LocationsWriter struct {
 	FunctionFilename   *array.BinaryDictionaryBuilder
 	FunctionStartLine  *array.Int64Builder
 	Value              *array.Int64Builder
+	ValuePerSecond     *array.Float64Builder
 	Diff               *array.Int64Builder
+	DiffPerSecond      *array.Float64Builder
 }
 
 func NewLocationsWriter(pool memory.Allocator) LocationsWriter {

--- a/pkg/query/columnquery_test.go
+++ b/pkg/query/columnquery_test.go
@@ -1279,7 +1279,9 @@ func PprofToSymbolizedProfile(meta profile.Meta, prof *pprofprofile.Profile, ind
 		}
 
 		w.Value.Append(prof.Sample[i].Value[index])
+		w.ValuePerSecond.Append(0)
 		w.Diff.Append(0)
+		w.DiffPerSecond.Append(0)
 
 		for labelName, labelBuilder := range w.LabelBuildersMap {
 			if prof.Sample[i].Label == nil {
@@ -1358,7 +1360,9 @@ func OldProfileToArrowProfile(p profile.OldProfile) (profile.Profile, error) {
 	defer w.RecordBuilder.Release()
 	for i := range p.Samples {
 		w.Value.Append(p.Samples[i].Value)
+		w.ValuePerSecond.Append(float64(p.Samples[i].Value))
 		w.Diff.Append(p.Samples[i].DiffValue)
+		w.DiffPerSecond.Append(float64(p.Samples[i].DiffValue))
 
 		for labelName, labelBuilder := range w.LabelBuildersMap {
 			if p.Samples[i].Label == nil {
@@ -1470,7 +1474,9 @@ func TestFilterData(t *testing.T) {
 	w.FunctionFilename.Append([]byte("test"))
 	w.FunctionStartLine.Append(1)
 	w.Value.Append(1)
+	w.ValuePerSecond.Append(1)
 	w.Diff.Append(0)
+	w.DiffPerSecond.Append(0)
 
 	originalRecord := w.RecordBuilder.NewRecord()
 	recs, _, err := FilterProfileData(
@@ -1517,7 +1523,9 @@ func TestFilterUnsymbolized(t *testing.T) {
 	w.MappingBuildID.Append([]byte("test"))
 	w.Lines.Append(false)
 	w.Value.Append(1)
+	w.ValuePerSecond.Append(1)
 	w.Diff.Append(0)
+	w.DiffPerSecond.Append(0)
 
 	originalRecord := w.RecordBuilder.NewRecord()
 	recs, _, err := FilterProfileData(
@@ -1599,7 +1607,9 @@ func TestFilterDataWithPath(t *testing.T) {
 	w.FunctionFilename.Append([]byte("test.py"))
 	w.FunctionStartLine.Append(0)
 	w.Value.Append(1)
+	w.ValuePerSecond.Append(1)
 	w.Diff.Append(0)
+	w.DiffPerSecond.Append(0)
 
 	originalRecord := w.RecordBuilder.NewRecord()
 	recs, _, err := FilterProfileData(
@@ -1680,7 +1690,9 @@ func TestFilterDataInterpretedOnly(t *testing.T) {
 	w.FunctionFilename.Append([]byte("test.py"))
 	w.FunctionStartLine.Append(0)
 	w.Value.Append(1)
+	w.ValuePerSecond.Append(1)
 	w.Diff.Append(0)
+	w.DiffPerSecond.Append(0)
 
 	originalRecord := w.RecordBuilder.NewRecord()
 	recs, _, err := FilterProfileData(
@@ -1763,7 +1775,9 @@ func BenchmarkFilterData(t *testing.B) {
 		w.FunctionFilename.Append([]byte("test"))
 		w.FunctionStartLine.Append(1)
 		w.Value.Append(1)
+		w.ValuePerSecond.Append(1)
 		w.Diff.Append(0)
+		w.DiffPerSecond.Append(0)
 	}
 
 	originalRecord := w.RecordBuilder.NewRecord()

--- a/pkg/query/flamegraph_arrow.go
+++ b/pkg/query/flamegraph_arrow.go
@@ -52,10 +52,12 @@ const (
 	FlamegraphFieldFunctionSystemName = "function_system_name"
 	FlamegraphFieldFunctionFileName   = "function_file_name"
 
-	FlamegraphFieldLabels     = "labels"
-	FlamegraphFieldChildren   = "children"
-	FlamegraphFieldCumulative = "cumulative"
-	FlamegraphFieldDiff       = "diff"
+	FlamegraphFieldLabels              = "labels"
+	FlamegraphFieldChildren            = "children"
+	FlamegraphFieldCumulative          = "cumulative"
+	FlamegraphFieldCumulativePerSecond = "cumulative_per_second"
+	FlamegraphFieldDiff                = "diff"
+	FlamegraphFieldDiffPerSecond       = "diff_per_second"
 )
 
 func GenerateFlamegraphArrow(
@@ -122,7 +124,9 @@ func generateFlamegraphArrowRecord(ctx context.Context, mem memory.Allocator, tr
 	labelHasher := xxh3.New()
 	for _, r := range profileReader.RecordReaders {
 		fb.cumulative += math.Int64.Sum(r.Value)
+		fb.cumulativePerSecond += math.Float64.Sum(r.ValuePerSecond)
 		fb.diff += math.Int64.Sum(r.Diff)
+		fb.diffPerSecond += math.Float64.Sum(r.DiffPerSecond)
 
 		if err := fb.ensureLabelColumns(r.LabelFields); err != nil {
 			return nil, 0, 0, 0, fmt.Errorf("ensure label columns: %w", err)
@@ -337,8 +341,12 @@ func generateFlamegraphArrowRecord(ctx context.Context, mem memory.Allocator, tr
 		fb.trimmedFunctionStartLine.AppendNull()
 		fb.trimmedCumulative = array.NewUint8Builder(fb.pool)
 		fb.trimmedCumulative.AppendNull()
+		fb.trimmedCumulativePerSecond = builder.NewOptFloat64Builder(arrow.PrimitiveTypes.Float64)
+		fb.trimmedCumulativePerSecond.AppendNull()
 		fb.trimmedDiff = array.NewUint8Builder(fb.pool)
 		fb.trimmedDiff.AppendNull()
+		fb.trimmedDiffPerSecond = builder.NewOptFloat64Builder(arrow.PrimitiveTypes.Float64)
+		fb.trimmedDiffPerSecond.AppendNull()
 	}
 
 	_, spanNewRecord := tracer.Start(ctx, "NewRecord")
@@ -674,6 +682,7 @@ func (fb *flamegraphBuilder) mergeUnsymbolizedRows(
 		}
 
 		fb.builderCumulative.Add(cr, r.Value.Value(sampleIndex))
+		fb.builderCumulativePerSecond.Add(cr, r.ValuePerSecond.Value(sampleIndex))
 		fb.parent.Set(cr)
 		fb.compareRows = fb.children[cr]
 		return true, nil
@@ -739,8 +748,12 @@ type flamegraphBuilder struct {
 
 	// This keeps track of the total cumulative value so that we can set the first row's cumulative value at the end.
 	cumulative int64
-	// This keeps track of the total diff values so that we can set the irst row's diff value at the end.
+	// This keeps track of the total cumulative per second value so that we can set the first row's cumulative value at the end.
+	cumulativePerSecond float64
+	// This keeps track of the total diff values so that we can set the first row's diff value at the end.
 	diff int64
+	// This keeps track of the total diff per second value so that we can set the first row's diff value at the end.
+	diffPerSecond float64
 	// This keeps track of the max height of the flame graph.
 	maxHeight int32
 	// trimmed keeps track of the values that were trimmed from the flame graph.
@@ -783,7 +796,9 @@ type flamegraphBuilder struct {
 	builderChildren                      *builder.ListBuilder
 	builderChildrenValues                *array.Uint32Builder
 	builderCumulative                    *builder.OptInt64Builder
+	builderCumulativePerSecond           *builder.OptFloat64Builder
 	builderDiff                          *builder.OptInt64Builder
+	builderDiffPerSecond                 *builder.OptFloat64Builder
 
 	// Only at the last step when preparing the new record these are populated.
 	// They are also used to create compacted dictionaries and after that replaced by them.
@@ -803,10 +818,12 @@ type flamegraphBuilder struct {
 
 	labelNameIndex map[string]int
 
-	trimmedLocationLine      array.Builder
-	trimmedFunctionStartLine array.Builder
-	trimmedCumulative        array.Builder
-	trimmedDiff              array.Builder
+	trimmedLocationLine        array.Builder
+	trimmedFunctionStartLine   array.Builder
+	trimmedCumulative          array.Builder
+	trimmedCumulativePerSecond *builder.OptFloat64Builder
+	trimmedDiff                array.Builder
+	trimmedDiffPerSecond       *builder.OptFloat64Builder
 }
 
 type aggregationConfig struct {
@@ -859,10 +876,12 @@ func newFlamegraphBuilder(
 		builderFunctionFilenameIndices:       array.NewInt32Builder(pool),
 		builderFunctionFilenameDictUnifier:   array.NewBinaryDictionaryUnifier(pool),
 
-		builderChildren:       builderChildren,
-		builderChildrenValues: builderChildren.ValueBuilder().(*array.Uint32Builder),
-		builderCumulative:     builder.NewOptInt64Builder(arrow.PrimitiveTypes.Int64),
-		builderDiff:           builder.NewOptInt64Builder(arrow.PrimitiveTypes.Int64),
+		builderChildren:            builderChildren,
+		builderChildrenValues:      builderChildren.ValueBuilder().(*array.Uint32Builder),
+		builderCumulative:          builder.NewOptInt64Builder(arrow.PrimitiveTypes.Int64),
+		builderCumulativePerSecond: builder.NewOptFloat64Builder(arrow.PrimitiveTypes.Float64),
+		builderDiff:                builder.NewOptInt64Builder(arrow.PrimitiveTypes.Int64),
+		builderDiffPerSecond:       builder.NewOptFloat64Builder(arrow.PrimitiveTypes.Float64),
 	}
 
 	for _, f := range aggregateFields {
@@ -902,7 +921,9 @@ func newFlamegraphBuilder(
 
 	// The cumulative values is calculated and at the end set to the correct value.
 	fb.builderCumulative.Append(0)
+	fb.builderCumulativePerSecond.Append(0)
 	fb.builderDiff.Append(0)
+	fb.builderDiffPerSecond.Append(0)
 
 	return fb, nil
 }
@@ -919,7 +940,9 @@ func (fb *flamegraphBuilder) prepareNewRecord() error {
 	// We have manually tracked the total cumulative value.
 	// Now we set/overwrite the cumulative value for the root row (which is always the 0 row in our flame graphs).
 	fb.builderCumulative.Set(0, fb.cumulative)
+	fb.builderCumulativePerSecond.Set(0, fb.cumulativePerSecond)
 	fb.builderDiff.Set(0, fb.diff)
+	fb.builderDiffPerSecond.Set(0, fb.diffPerSecond)
 
 	// We want to unify the dictionaries after having created the flame graph now.
 	// They are going to be trimmed and compacted in the next step.
@@ -1009,7 +1032,7 @@ func (fb *flamegraphBuilder) prepareNewRecord() error {
 // It adds the children to the children column and the labels intersection to the labels column.
 // Finally, it assembles all columns from the builders into an arrow record.
 func (fb *flamegraphBuilder) NewRecord() (arrow.Record, error) {
-	cleanupArrs := make([]arrow.Array, 0, 17+(2*len(fb.builderLabelFields)))
+	cleanupArrs := make([]arrow.Array, 0, 18+(2*len(fb.builderLabelFields)))
 	defer func() {
 		for _, arr := range cleanupArrs {
 			arr.Release()
@@ -1050,10 +1073,12 @@ func (fb *flamegraphBuilder) NewRecord() (arrow.Record, error) {
 		// Values
 		{Name: FlamegraphFieldChildren, Type: arrow.ListOf(arrow.PrimitiveTypes.Uint32)},
 		{Name: FlamegraphFieldCumulative, Type: fb.trimmedCumulative.Type()},
+		{Name: FlamegraphFieldCumulativePerSecond, Type: arrow.PrimitiveTypes.Float64},
 		{Name: FlamegraphFieldDiff, Type: fb.trimmedDiff.Type()},
+		{Name: FlamegraphFieldDiffPerSecond, Type: arrow.PrimitiveTypes.Float64},
 	}
 
-	arrays := make([]arrow.Array, 13+len(fb.labels))
+	arrays := make([]arrow.Array, 15+len(fb.labels))
 	arrays[0] = fb.builderLabelsOnly.NewArray()
 	cleanupArrs = append(cleanupArrs, arrays[0])
 	arrays[1] = fb.builderLocationAddress.NewArray()
@@ -1073,13 +1098,17 @@ func (fb *flamegraphBuilder) NewRecord() (arrow.Record, error) {
 	cleanupArrs = append(cleanupArrs, arrays[10])
 	arrays[11] = fb.trimmedCumulative.NewArray()
 	cleanupArrs = append(cleanupArrs, arrays[11])
-	arrays[12] = fb.trimmedDiff.NewArray()
+	arrays[12] = fb.trimmedCumulativePerSecond.NewArray()
 	cleanupArrs = append(cleanupArrs, arrays[12])
+	arrays[13] = fb.trimmedDiff.NewArray()
+	cleanupArrs = append(cleanupArrs, arrays[13])
+	arrays[14] = fb.trimmedDiffPerSecond.NewArray()
+	cleanupArrs = append(cleanupArrs, arrays[14])
 
 	for i, field := range fb.builderLabelFields {
 		field.Type = fb.labels[i].DataType() // overwrite for variable length uint types
 		fields = append(fields, field)
-		arrays[13+i] = fb.labels[i]
+		arrays[15+i] = fb.labels[i]
 	}
 
 	return array.NewRecord(
@@ -1112,7 +1141,9 @@ func (fb *flamegraphBuilder) Release() {
 
 	fb.builderChildren.Release()
 	fb.builderCumulative.Release()
+	fb.builderCumulativePerSecond.Release()
 	fb.builderDiff.Release()
+	fb.builderDiffPerSecond.Release()
 
 	if fb.trimmedLocationLine != nil {
 		fb.trimmedLocationLine.Release()
@@ -1128,6 +1159,10 @@ func (fb *flamegraphBuilder) Release() {
 
 	if fb.trimmedDiff != nil {
 		fb.trimmedDiff.Release()
+	}
+
+	if fb.trimmedDiffPerSecond != nil {
+		fb.trimmedDiffPerSecond.Release()
 	}
 
 	for i := range fb.builderLabelFields {
@@ -1263,11 +1298,17 @@ func (fb *flamegraphBuilder) appendRow(
 	}
 
 	fb.builderCumulative.Append(r.Value.Value(sampleRow))
+	fb.builderCumulativePerSecond.Append(r.ValuePerSecond.Value(sampleRow))
 
 	if r.Diff.Value(sampleRow) > 0 {
 		fb.builderDiff.Append(r.Diff.Value(sampleRow))
 	} else {
 		fb.builderDiff.AppendNull()
+	}
+	if r.DiffPerSecond.Value(sampleRow) != 0 {
+		fb.builderDiffPerSecond.Append(r.DiffPerSecond.Value(sampleRow))
+	} else {
+		fb.builderDiffPerSecond.AppendNull()
 	}
 
 	return nil
@@ -1326,7 +1367,9 @@ func (fb *flamegraphBuilder) AppendLabelRow(
 
 	// Append both cumulative and diff values and overwrite them below.
 	fb.builderCumulative.Append(0)
+	fb.builderCumulativePerSecond.Append(0)
 	fb.builderDiff.Append(0)
+	fb.builderDiffPerSecond.Append(0)
 	fb.addRowValues(r, row, sampleRow)
 
 	return nil
@@ -1335,7 +1378,9 @@ func (fb *flamegraphBuilder) AppendLabelRow(
 // addRowValues updates the existing row's values and potentially adding existing values on top.
 func (fb *flamegraphBuilder) addRowValues(r *profile.RecordReader, row, sampleRow int) {
 	fb.builderCumulative.Add(row, r.Value.Value(sampleRow))
+	fb.builderCumulativePerSecond.Add(row, r.ValuePerSecond.Value(sampleRow))
 	fb.builderDiff.Add(row, r.Diff.Value(sampleRow))
+	fb.builderDiffPerSecond.Add(row, r.DiffPerSecond.Value(sampleRow))
 }
 
 func (fb *flamegraphBuilder) trim(ctx context.Context, tracer trace.Tracer, threshold float32) error {
@@ -1411,8 +1456,10 @@ func (fb *flamegraphBuilder) trim(ctx context.Context, tracer trace.Tracer, thre
 	trimmedFunctionFilenameIndices := array.NewInt32Builder(fb.pool)
 	trimmedCumulativeType := smallestUnsignedTypeFor(largestCumulativeValue)
 	trimmedCumulative := array.NewBuilder(fb.pool, trimmedCumulativeType)
+	trimmedCumulativePerSecond := builder.NewOptFloat64Builder(arrow.PrimitiveTypes.Float64)
 	trimmedDiffType := smallestSignedTypeFor(smallestDiffValue, largestDiffValue)
 	trimmedDiff := array.NewBuilder(fb.pool, trimmedDiffType)
+	trimmedDiffPerSecond := builder.NewOptFloat64Builder(arrow.PrimitiveTypes.Float64)
 
 	releasers = append(releasers,
 		trimmedMappingFileIndices,
@@ -1443,7 +1490,9 @@ func (fb *flamegraphBuilder) trim(ctx context.Context, tracer trace.Tracer, thre
 	trimmedFunctionSystemNameIndices.Reserve(row)
 	trimmedFunctionFilenameIndices.Reserve(row)
 	trimmedCumulative.Reserve(row)
+	trimmedCumulativePerSecond.Reserve(row)
 	trimmedDiff.Reserve(row)
+	trimmedDiffPerSecond.Reserve(row)
 
 	for _, l := range trimmedLabelsIndices {
 		l.Reserve(row)
@@ -1471,6 +1520,9 @@ func (fb *flamegraphBuilder) trim(ctx context.Context, tracer trace.Tracer, thre
 		for i := range fb.labels {
 			appendDictionaryIndexInt32(fb.labelsIndices[i], trimmedLabelsIndices[i], te.row)
 		}
+
+		copyOptFloat64BuilderValue(fb.builderCumulativePerSecond, trimmedCumulativePerSecond, te.row)
+		copyOptFloat64BuilderValue(fb.builderDiffPerSecond, trimmedDiffPerSecond, te.row)
 
 		// The following two will never be null.
 		cum := fb.builderCumulative.Value(te.row)
@@ -1633,7 +1685,9 @@ func (fb *flamegraphBuilder) trim(ctx context.Context, tracer trace.Tracer, thre
 	fb.trimmedLocationLine = trimmedLocationLine
 	fb.trimmedFunctionStartLine = trimmedFunctionStartLine
 	fb.trimmedCumulative = trimmedCumulative
+	fb.trimmedCumulativePerSecond = trimmedCumulativePerSecond
 	fb.trimmedDiff = trimmedDiff
+	fb.trimmedDiffPerSecond = trimmedDiffPerSecond
 	fb.trimmedChildren = trimmedChildren
 
 	return nil
@@ -1699,6 +1753,14 @@ func copyOptBooleanBuilderValue(old, new *builder.OptBooleanBuilder, row int) {
 }
 
 func copyBoolBuilderValue(old, new *array.BooleanBuilder, row int) {
+	if old.IsNull(row) {
+		new.AppendNull()
+		return
+	}
+	new.Append(old.Value(row))
+}
+
+func copyOptFloat64BuilderValue(old, new *builder.OptFloat64Builder, row int) {
 	if old.IsNull(row) {
 		new.AppendNull()
 		return

--- a/pkg/query/flamegraph_arrow_test.go
+++ b/pkg/query/flamegraph_arrow_test.go
@@ -49,23 +49,24 @@ import (
 )
 
 type flamegraphRow struct {
-	LabelsOnly         bool
-	MappingStart       uint64
-	MappingLimit       uint64
-	MappingOffset      uint64
-	MappingFile        string
-	MappingBuildID     string
-	LocationAddress    uint64
-	Inlined            bool
-	LocationLine       uint8
-	FunctionStartLine  uint8
-	FunctionName       string
-	FunctionSystemName string
-	FunctionFilename   string
-	Labels             map[string]string
-	Children           []uint32
-	Cumulative         uint8
-	Diff               int8
+	LabelsOnly          bool
+	MappingStart        uint64
+	MappingLimit        uint64
+	MappingOffset       uint64
+	MappingFile         string
+	MappingBuildID      string
+	LocationAddress     uint64
+	Inlined             bool
+	LocationLine        uint8
+	FunctionStartLine   uint8
+	FunctionName        string
+	FunctionSystemName  string
+	FunctionFilename    string
+	Labels              map[string]string
+	Children            []uint32
+	Cumulative          uint8
+	CumulativePerSecond uint8
+	Diff                int8
 }
 
 type flamegraphColumns struct {
@@ -82,6 +83,7 @@ type flamegraphColumns struct {
 	labels              []map[string]string
 	children            [][]uint32
 	cumulative          []uint8
+	cumulativePerSecond []uint8
 	diff                []int8
 }
 
@@ -101,6 +103,7 @@ func rowsToColumn(rows []flamegraphRow) flamegraphColumns {
 		columns.labels = append(columns.labels, row.Labels)
 		columns.children = append(columns.children, row.Children)
 		columns.cumulative = append(columns.cumulative, row.Cumulative)
+		columns.cumulativePerSecond = append(columns.cumulativePerSecond, row.CumulativePerSecond)
 		columns.diff = append(columns.diff, row.Diff)
 	}
 	return columns
@@ -434,7 +437,7 @@ func TestGenerateFlamegraphArrow(t *testing.T) {
 			require.Equal(t, tc.cumulative, cumulative)
 			require.Equal(t, tc.height, height)
 			require.Equal(t, tc.trimmed, trimmed)
-			require.Equal(t, int64(14), fa.NumCols())
+			require.Equal(t, int64(16), fa.NumCols())
 
 			// Convert the numRows to columns for easier access when testing below.
 			expectedColumns := rowsToColumn(tc.rows)
@@ -591,7 +594,7 @@ func TestGenerateFlamegraphArrowEmpty(t *testing.T) {
 	require.Equal(t, int64(0), total)
 	require.Equal(t, int32(1), height)
 	require.Equal(t, int64(0), trimmed)
-	require.Equal(t, int64(13), record.NumCols())
+	require.Equal(t, int64(15), record.NumCols())
 	require.Equal(t, int64(1), record.NumRows())
 }
 
@@ -666,7 +669,7 @@ func TestGenerateFlamegraphArrowWithInlined(t *testing.T) {
 	require.Equal(t, int32(5), height)
 	require.Equal(t, int64(0), trimmed)
 
-	require.Equal(t, int64(13), record.NumCols())
+	require.Equal(t, int64(15), record.NumCols())
 	require.Equal(t, int64(5), record.NumRows())
 
 	rows := []flamegraphRow{
@@ -787,7 +790,7 @@ func TestGenerateFlamegraphArrowUnsymbolized(t *testing.T) {
 			require.Equal(t, tc.height, height)
 			require.Equal(t, tc.trimmed, trimmed)
 			require.Equal(t, int64(len(tc.rows)), fa.NumRows())
-			require.Equal(t, int64(13), fa.NumCols())
+			require.Equal(t, int64(15), fa.NumCols())
 
 			// Convert the numRows to columns for easier access when testing below.
 			expectedColumns := rowsToColumn(tc.rows)
@@ -913,7 +916,7 @@ func TestGenerateFlamegraphArrowTrimming(t *testing.T) {
 	require.Equal(t, int32(5), height)
 	require.Equal(t, int64(4), trimmed)
 	require.Equal(t, int64(3), fa.NumRows())
-	require.Equal(t, int64(13), fa.NumCols())
+	require.Equal(t, int64(15), fa.NumCols())
 
 	// TODO: MappingBuildID and FunctionSystemNames shouldn't be "" but null?
 	rows := []flamegraphRow{

--- a/ui/packages/shared/profile/src/GraphTooltipArrow/Content.tsx
+++ b/ui/packages/shared/profile/src/GraphTooltipArrow/Content.tsx
@@ -61,7 +61,17 @@ const GraphTooltipArrowContent = ({
     return <></>;
   }
 
-  const {name, locationAddress, cumulativeText, diffText, diff, row: rowNumber} = graphTooltipData;
+  const {
+    name,
+    locationAddress,
+    cumulativeText,
+    cumulativePerSecondText,
+    diffText,
+    diff,
+    row: rowNumber,
+  } = graphTooltipData;
+
+  const delta = unit === 'nanoseconds';
 
   return (
     <div className={`flex text-sm ${isFixed ? 'w-full' : ''}`}>
@@ -84,6 +94,16 @@ const GraphTooltipArrowContent = ({
               </div>
               <table className="my-2 w-full table-fixed pr-0 text-gray-700 dark:text-gray-300">
                 <tbody>
+                  {delta ? (
+                    <tr>
+                      <td className="w-1/4">Per Second</td>
+                      <td className="w-3/4">
+                        <div>{cumulativePerSecondText}</div>
+                      </td>
+                    </tr>
+                  ) : (
+                    <></>
+                  )}
                   <tr>
                     <td className="w-1/4">Cumulative</td>
 

--- a/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/IcicleGraphNodes.tsx
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/IcicleGraphNodes.tsx
@@ -24,7 +24,9 @@ import 'react-contexify/dist/ReactContexify.css';
 import {
   FIELD_CHILDREN,
   FIELD_CUMULATIVE,
+  FIELD_CUMULATIVE_PER_SECOND,
   FIELD_DIFF,
+  FIELD_DIFF_PER_SECOND,
   FIELD_FUNCTION_NAME,
   FIELD_MAPPING_FILE,
 } from './index';
@@ -53,6 +55,7 @@ interface IcicleGraphNodesProps {
   sortBy: string;
   darkMode: boolean;
   compareMode: boolean;
+  delta: boolean;
   isContextMenuOpen: boolean;
   hoveringName: string | null;
   setHoveringName: (name: string | null) => void;
@@ -80,6 +83,7 @@ export const IcicleGraphNodes = React.memo(function IcicleGraphNodesNoMemo({
   searchString,
   darkMode,
   compareMode,
+  delta,
   isContextMenuOpen,
   hoveringName,
   setHoveringName,
@@ -127,6 +131,7 @@ export const IcicleGraphNodes = React.memo(function IcicleGraphNodesNoMemo({
         searchString={searchString}
         darkMode={darkMode}
         compareMode={compareMode}
+        delta={delta}
         isContextMenuOpen={isContextMenuOpen}
         hoveringName={hoveringName}
         setHoveringName={setHoveringName}
@@ -165,6 +170,7 @@ interface IcicleNodeProps {
   sortBy: string;
   darkMode: boolean;
   compareMode: boolean;
+  delta: boolean;
   isContextMenuOpen: boolean;
   hoveringName: string | null;
   setHoveringName: (name: string | null) => void;
@@ -204,6 +210,7 @@ export const IcicleNode = React.memo(function IcicleNodeNoMemo({
   sortBy,
   darkMode,
   compareMode,
+  delta,
   isContextMenuOpen,
   hoveringName,
   setHoveringName,
@@ -215,12 +222,18 @@ export const IcicleNode = React.memo(function IcicleNodeNoMemo({
   const mappingColumn = table.getChild(FIELD_MAPPING_FILE);
   const functionNameColumn = table.getChild(FIELD_FUNCTION_NAME);
   const cumulativeColumn = table.getChild(FIELD_CUMULATIVE);
+  const cumulativePerSecondColumn = table.getChild(FIELD_CUMULATIVE_PER_SECOND);
   const diffColumn = table.getChild(FIELD_DIFF);
+  const diffPerSecondColumn = table.getChild(FIELD_DIFF_PER_SECOND);
   // get the actual values from the columns
   const mappingFile: string | null = arrowToString(mappingColumn?.get(row));
   const functionName: string | null = arrowToString(functionNameColumn?.get(row));
   const cumulative = cumulativeColumn?.get(row) !== null ? BigInt(cumulativeColumn?.get(row)) : 0n;
+  const cumulativePerSecond: number | null =
+    cumulativePerSecondColumn?.get(row) != null ? cumulativePerSecondColumn.get(row) : 0;
   const diff: bigint | null = diffColumn?.get(row) !== null ? BigInt(diffColumn?.get(row)) : null;
+  const diffPerSecond: number | null =
+    diffPerSecondColumn?.get(row) != null ? diffPerSecondColumn.get(row) : null;
   const childRows: number[] = Array.from(table.getChild(FIELD_CHILDREN)?.get(row) ?? []);
 
   const highlightedNodes = useMemo(() => {
@@ -259,6 +272,15 @@ export const IcicleNode = React.memo(function IcicleNodeNoMemo({
       });
       break;
     case FIELD_CUMULATIVE:
+      if (delta) {
+        childRows.sort((a, b) => {
+          const aCumulativePerSecond = cumulativePerSecondColumn?.get(a);
+          const bCumulativePerSecond = cumulativePerSecondColumn?.get(b);
+          return bCumulativePerSecond - aCumulativePerSecond;
+        });
+        break;
+      }
+
       childRows.sort((a, b) => {
         const aCumulative: bigint = cumulativeColumn?.get(a);
         const bCumulative: bigint = cumulativeColumn?.get(b);
@@ -267,15 +289,59 @@ export const IcicleNode = React.memo(function IcicleNodeNoMemo({
       break;
     case FIELD_DIFF:
       childRows.sort((a, b) => {
-        const aDiff: bigint | null = diffColumn?.get(a);
-        const bDiff: bigint | null = diffColumn?.get(b);
-        if (aDiff !== null && bDiff !== null) {
-          return Number(bDiff - aDiff);
+        if (delta) {
+          let aRatio: number | null = null;
+          let bRatio: number | null = null;
+
+          const aDiff: number | null = diffPerSecondColumn?.get(a);
+          if (aDiff !== null) {
+            const cumulative: number = cumulativePerSecondColumn?.get(a);
+            const prev = cumulative - aDiff;
+            aRatio = aDiff / prev;
+          }
+
+          const bDiff: number | null = diffPerSecondColumn?.get(b);
+          if (bDiff !== null) {
+            const cumulative: number = cumulativePerSecondColumn?.get(b);
+            const prev = cumulative - bDiff;
+            bRatio = bDiff / prev;
+          }
+
+          if (aRatio !== null && bRatio !== null) {
+            return bRatio - aRatio;
+          }
+          if (aRatio === null && bRatio !== null) {
+            return -1;
+          }
+          if (aRatio !== null && bRatio === null) {
+            return 1;
+          }
+          // both are null
+          return 0;
         }
-        if (aDiff === null && bDiff !== null) {
+
+        let aRatio: number | null = null;
+        const aDiff: bigint | null = diffColumn?.get(a);
+        if (aDiff !== null) {
+          const cumulative: bigint = cumulativeColumn?.get(a) ?? 0n;
+          const prev: bigint = cumulative - aDiff;
+          aRatio = Number(aDiff) / Number(prev);
+        }
+        let bRatio: number | null = null;
+        const bDiff: bigint | null = diffColumn?.get(b);
+        if (bDiff !== null) {
+          const cumulative: bigint = cumulativeColumn?.get(b) ?? 0n;
+          const prev: bigint = cumulative - bDiff;
+          bRatio = Number(bDiff) / Number(prev);
+        }
+
+        if (aRatio !== null && bRatio !== null) {
+          return bRatio - aRatio;
+        }
+        if (aRatio === null && bRatio !== null) {
           return -1;
         }
-        if (aDiff !== null && bDiff === null) {
+        if (aRatio !== null && bRatio === null) {
           return 1;
         }
         // both are null
@@ -289,7 +355,9 @@ export const IcicleNode = React.memo(function IcicleNodeNoMemo({
     isDarkMode: darkMode,
     compareMode,
     cumulative,
+    cumulativePerSecond,
     diff,
+    diffPerSecond,
     mappingColors,
     mappingFile,
     functionName,
@@ -393,6 +461,7 @@ export const IcicleNode = React.memo(function IcicleNodeNoMemo({
           searchString={searchString}
           sortBy={sortBy}
           darkMode={darkMode}
+          delta={delta}
           compareMode={compareMode}
           isContextMenuOpen={isContextMenuOpen}
           hoveringName={hoveringName}

--- a/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/index.tsx
@@ -49,7 +49,9 @@ export const FIELD_FUNCTION_START_LINE = 'function_startline';
 export const FIELD_CHILDREN = 'children';
 export const FIELD_LABELS = 'labels';
 export const FIELD_CUMULATIVE = 'cumulative';
+export const FIELD_CUMULATIVE_PER_SECOND = 'cumulative_per_second';
 export const FIELD_DIFF = 'diff';
+export const FIELD_DIFF_PER_SECOND = 'diff_per_second';
 
 interface IcicleGraphArrowProps {
   arrow: FlamegraphArrow;
@@ -229,6 +231,7 @@ export const IcicleGraphArrow = memo(function IcicleGraphArrow({
               sortBy={sortBy}
               darkMode={isDarkMode}
               compareMode={compareMode}
+              delta={sampleUnit === 'nanoseconds'}
               isContextMenuOpen={isContextMenuOpen}
               hoveringName={hoveringName}
               setHoveringName={setHoveringName}
@@ -246,6 +249,7 @@ export const IcicleGraphArrow = memo(function IcicleGraphArrow({
     currentSearchString,
     height,
     isDarkMode,
+    sampleUnit,
     mappingColors,
     setCurPath,
     sortBy,

--- a/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/useNodeColor.ts
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/useNodeColor.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import {EVERYTHING_ELSE} from '@parca/store';
-import {diffColor, getLastItem} from '@parca/utilities';
+import {diffColor, diffColorPerSecond, getLastItem} from '@parca/utilities';
 
 interface mappingColors {
   [key: string]: string;
@@ -22,7 +22,9 @@ interface Props {
   isDarkMode: boolean;
   compareMode: boolean;
   cumulative: bigint;
+  cumulativePerSecond: number | null;
   diff: bigint | null;
+  diffPerSecond: number | null;
   mappingColors: mappingColors;
   functionName: string | null;
   mappingFile: string | null;
@@ -32,12 +34,18 @@ const useNodeColor = ({
   isDarkMode,
   compareMode,
   cumulative,
+  cumulativePerSecond,
   diff,
+  diffPerSecond,
   mappingColors,
   functionName,
   mappingFile,
 }: Props): string => {
   if (compareMode) {
+    if (cumulativePerSecond !== null && diffPerSecond !== null) {
+      return diffColorPerSecond(diffPerSecond, cumulativePerSecond, isDarkMode);
+    }
+
     return diffColor(diff ?? 0n, cumulative, isDarkMode);
   }
 

--- a/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/utils.ts
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/utils.ts
@@ -91,6 +91,17 @@ export const getTextForCumulative = (
     (${(100 * divide(hoveringNodeCumulative, totalUnfiltered)).toFixed(2)}%${filtered})`;
 };
 
+export const getTextForCumulativePerSecond = (
+  hoveringNodeCumulative: number,
+  unit: string
+): string => {
+  return `${valueFormatter(
+    hoveringNodeCumulative,
+    unit === 'nanoseconds' ? 'CPU Cores' : unit,
+    5
+  )}`;
+};
+
 export const arrowToString = (buffer: any): string | null => {
   if (buffer == null || typeof buffer === 'string') {
     return buffer;

--- a/ui/packages/shared/utilities/src/index.ts
+++ b/ui/packages/shared/utilities/src/index.ts
@@ -323,13 +323,33 @@ export const diffColor = (diff: bigint, cumulative: bigint, isDarkMode: boolean)
   const diffRatio = prevValue > 0 ? (diff !== 0n ? divide(diff, prevValue) : 0) : 1.0;
   const hasDiff = Math.abs(diffRatio) > DIFF_RATIO_THRESHOLD;
 
+  return diffColorRatio(hasDiff, diffRatio, isDarkMode);
+};
+
+export const diffColorPerSecond = (
+  diff: number,
+  cumulative: number,
+  isDarkMode: boolean
+): string => {
+  const prevValue = cumulative - diff;
+  const diffRatio = prevValue > 0 ? (diff !== 0 ? diff / prevValue : 0) : 1.0;
+  const hasDiff = Math.abs(diffRatio) > DIFF_RATIO_THRESHOLD;
+
+  return diffColorRatio(hasDiff, diffRatio, isDarkMode);
+};
+
+const diffColorRatio = (hasDiff: boolean, diffRatio: number, isDarkMode: boolean): string => {
   const diffTransparency = hasDiff ? Math.min((Math.abs(diffRatio) / 2 + 0.5) * 0.8, 0.8) : 0;
 
   const newSpanColor = getNewSpanColor(isDarkMode);
   const increasedSpanColor = getIncreasedSpanColor(diffTransparency, isDarkMode);
   const reducedSpanColor = getReducedSpanColor(diffTransparency, isDarkMode);
 
-  const color: string = !hasDiff ? newSpanColor : diff > 0n ? increasedSpanColor : reducedSpanColor;
+  const color: string = !hasDiff
+    ? newSpanColor
+    : diffRatio > 0
+    ? increasedSpanColor
+    : reducedSpanColor;
 
   return color;
 };


### PR DESCRIPTION
For delta profiles (cpu with nanoseconds) we query the value per second, which basically is the `sum(value) / sum(duration)` per stack trace.

We already show this value in the metrics graphs. Now, the icicle graph is going to show it too. More importantly, we're going to use this for diffs.
