### PR TITLE
pkg/config: support seconds in pprof configuration

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -205,21 +205,6 @@ func (c *ScrapeConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		unmarshalled.ProfilingConfig = defaults.ProfilingConfig
 	} else if unmarshalled.ProfilingConfig.PprofConfig == nil {
 		unmarshalled.ProfilingConfig.PprofConfig = defaults.ProfilingConfig.PprofConfig
-	} else {
-		// Merge unmarshalled config with defaults
-		for pt, pc := range defaults.ProfilingConfig.PprofConfig {
-			// nothing set yet so simply use the default
-			if unmarshalled.ProfilingConfig.PprofConfig[pt] == nil {
-				unmarshalled.ProfilingConfig.PprofConfig[pt] = pc
-				continue
-			}
-			if unmarshalled.ProfilingConfig.PprofConfig[pt].Enabled == nil {
-				unmarshalled.ProfilingConfig.PprofConfig[pt].Enabled = trueValue()
-			}
-			if unmarshalled.ProfilingConfig.PprofConfig[pt].Path == "" {
-				unmarshalled.ProfilingConfig.PprofConfig[pt].Path = pc.Path
-			}
-		}
 	}
 
 	// If path prefix is specified, add to PprofConfig path
@@ -295,6 +280,7 @@ type PprofProfilingConfig struct {
 	Path           string       `yaml:"path,omitempty"`
 	Delta          bool         `yaml:"delta,omitempty"`
 	KeepSampleType []SampleType `yaml:"keep_sample_type,omitempty"`
+	Seconds        int          `yaml:"seconds,omitempty"`
 }
 
 type SampleType struct {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -68,6 +68,14 @@ scrape_configs:
   - job_name: 'path-prefix-with-defaults'
     profiling_config:
       path_prefix: /test/prefix
+  - job_name: 'path-prefix-and-seconds'
+    profiling_config:
+      path_prefix: /test/prefix
+      pprof_config:
+        fgprof:
+          enabled: true
+          path: /debug/fgprof
+          seconds: 3
 `
 
 	expected := &Config{
@@ -82,23 +90,6 @@ scrape_configs:
 						"memory": &PprofProfilingConfig{
 							Enabled: trueValue(),
 							Path:    "/parca/debug/pprof/allocs",
-						},
-						"block": &PprofProfilingConfig{
-							Enabled: trueValue(),
-							Path:    "/debug/pprof/block",
-						},
-						"goroutine": &PprofProfilingConfig{
-							Enabled: trueValue(),
-							Path:    "/debug/pprof/goroutine",
-						},
-						"mutex": &PprofProfilingConfig{
-							Enabled: trueValue(),
-							Path:    "/debug/pprof/mutex",
-						},
-						"process_cpu": &PprofProfilingConfig{
-							Enabled: trueValue(),
-							Delta:   true,
-							Path:    "/debug/pprof/profile",
 						},
 						"fgprof": &PprofProfilingConfig{
 							Enabled: trueValue(),
@@ -130,23 +121,6 @@ scrape_configs:
 						"memory": &PprofProfilingConfig{
 							Enabled: trueValue(),
 							Path:    "/test/prefix/parca/debug/pprof/allocs",
-						},
-						"block": &PprofProfilingConfig{
-							Enabled: trueValue(),
-							Path:    "/test/prefix/debug/pprof/block",
-						},
-						"goroutine": &PprofProfilingConfig{
-							Enabled: trueValue(),
-							Path:    "/test/prefix/debug/pprof/goroutine",
-						},
-						"mutex": &PprofProfilingConfig{
-							Enabled: trueValue(),
-							Path:    "/test/prefix/debug/pprof/mutex",
-						},
-						"process_cpu": &PprofProfilingConfig{
-							Enabled: trueValue(),
-							Delta:   true,
-							Path:    "/test/prefix/debug/pprof/profile",
 						},
 						"fgprof": &PprofProfilingConfig{
 							Enabled: trueValue(),
@@ -187,11 +161,27 @@ scrape_configs:
 					},
 				},
 			},
+			{
+				JobName:        "path-prefix-and-seconds",
+				ScrapeInterval: model.Duration(10 * time.Second),
+				ScrapeTimeout:  model.Duration(13 * time.Second),
+				Scheme:         "http",
+				ProfilingConfig: &ProfilingConfig{
+					PprofPrefix: "/test/prefix",
+					PprofConfig: PprofConfig{
+						"fgprof": &PprofProfilingConfig{
+							Enabled: trueValue(),
+							Path:    "/test/prefix/debug/fgprof",
+							Seconds: 3,
+						},
+					},
+				},
+			},
 		},
 	}
 	c, err := Load(complexYAML)
 	require.NoError(t, err)
-	require.Len(t, c.ScrapeConfigs, 4)
+	require.Len(t, c.ScrapeConfigs, 5)
 	require.Equal(t, expected, c)
 }
 

--- a/pkg/scrape/target.go
+++ b/pkg/scrape/target.go
@@ -388,7 +388,11 @@ func targetsFromGroup(tg *targetgroup.Group, cfg *config.ScrapeConfig, targets [
 				}
 
 				if pcfg, found := cfg.ProfilingConfig.PprofConfig[profType]; found && pcfg.Delta {
-					params.Add("seconds", strconv.Itoa(int(time.Duration(cfg.ScrapeInterval)/time.Second)))
+					seconds := int(time.Duration(cfg.ScrapeInterval) / time.Second)
+					if pcfg.Seconds > 0 {
+						seconds = pcfg.Seconds
+					}
+					params.Add("seconds", strconv.Itoa(seconds))
 				}
 
 				targets = append(targets, NewTarget(lset, origLabels, params, keepSets[i]))

--- a/pkg/scrape/target.go
+++ b/pkg/scrape/target.go
@@ -388,6 +388,7 @@ func targetsFromGroup(tg *targetgroup.Group, cfg *config.ScrapeConfig, targets [
 				}
 
 				if pcfg, found := cfg.ProfilingConfig.PprofConfig[profType]; found && pcfg.Delta {
+					// If Seconds is NOT set on the pprof configuration explicitly, we default to ScrapeInterval.
 					seconds := int(time.Duration(cfg.ScrapeInterval) / time.Second)
 					if pcfg.Seconds > 0 {
 						seconds = pcfg.Seconds

--- a/pkg/scrape/target_test.go
+++ b/pkg/scrape/target_test.go
@@ -1,0 +1,149 @@
+package scrape
+
+import (
+	"github.com/parca-dev/parca/pkg/config"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/discovery/targetgroup"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+	"sort"
+	"testing"
+	"time"
+)
+
+func TestTargetsFromGroup(t *testing.T) {
+	testCases := []struct {
+		name     string
+		tg       *targetgroup.Group
+		cfg      config.ScrapeConfig
+		targets  Targets
+		lb       *labels.Builder
+		expected Targets
+		err      error
+	}{
+		{
+			name: "default-scrape-config",
+			tg: &targetgroup.Group{
+				Targets: []model.LabelSet{
+					{"__address__": "localhost:9090"},
+				},
+				Labels: model.LabelSet{},
+			},
+			cfg: config.DefaultScrapeConfig(),
+			lb:  labels.NewBuilder(labels.EmptyLabels()),
+			expected: Targets{
+				{
+					labels: labels.FromStrings(
+						model.AddressLabel, "localhost:9090",
+						model.SchemeLabel, "http",
+						ProfilePath, "/debug/pprof/allocs",
+					),
+				},
+				{
+					labels: labels.FromStrings(
+						model.AddressLabel, "localhost:9090",
+						model.SchemeLabel, "http",
+						ProfilePath, "/debug/pprof/mutex",
+					),
+				},
+				{
+					labels: labels.FromStrings(
+						model.AddressLabel, "localhost:9090",
+						model.SchemeLabel, "http",
+						ProfilePath, "/debug/pprof/block",
+					),
+				},
+				{
+					labels: labels.FromStrings(
+						model.AddressLabel, "localhost:9090",
+						model.SchemeLabel, "http",
+						ProfilePath, "/debug/pprof/goroutine",
+					),
+				},
+				{
+					labels: labels.FromStrings(
+						model.AddressLabel, "localhost:9090",
+						model.SchemeLabel, "http",
+						ProfilePath, "/debug/pprof/profile",
+						model.ParamLabelPrefix+"seconds", "10",
+					),
+				},
+			},
+			err: nil,
+		},
+		{
+			name: "custom-scrape-config-with-pprof-seconds",
+			tg: &targetgroup.Group{
+				Targets: []model.LabelSet{
+					{"__address__": "localhost:9090"},
+				},
+				Labels: model.LabelSet{},
+			},
+			cfg: config.ScrapeConfig{
+				ScrapeInterval: model.Duration(time.Minute * 10),
+				Scheme:         "http",
+				ProfilingConfig: &config.ProfilingConfig{
+					PprofConfig: config.PprofConfig{
+						"pprofMemory": &config.PprofProfilingConfig{
+							Enabled: trueValue(),
+							Delta:   true,
+							Path:    "/debug/pprof/allocs",
+							Seconds: 10,
+						},
+						"pprofProcessCPU": &config.PprofProfilingConfig{
+							Enabled: trueValue(),
+							Delta:   true,
+							Path:    "/debug/pprof/profile",
+							Seconds: 30,
+						},
+					},
+				},
+			},
+			lb: labels.NewBuilder(labels.EmptyLabels()),
+			expected: Targets{
+				{
+					labels: labels.FromStrings(
+						model.AddressLabel, "localhost:9090",
+						model.SchemeLabel, "http",
+						ProfilePath, "/debug/pprof/allocs",
+						model.ParamLabelPrefix+"seconds", "10",
+					),
+				},
+				{
+					labels: labels.FromStrings(
+						model.AddressLabel, "localhost:9090",
+						model.SchemeLabel, "http",
+						ProfilePath, "/debug/pprof/profile",
+						model.ParamLabelPrefix+"seconds", "30",
+					),
+				},
+			},
+			err: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			a, err := targetsFromGroup(tc.tg, &tc.cfg, tc.targets, tc.lb)
+			actual := Targets(a) // convert to slice type for convenience
+			if tc.err != nil && (err == nil || err.Error() != tc.err.Error()) {
+				t.Fatalf("unexpected error: %v", err)
+				return
+			}
+			if tc.err != nil && err != nil && err.Error() == tc.err.Error() {
+				return
+			}
+			require.Equal(t, len(tc.expected), len(actual), "unexpected number of targets")
+			sort.Sort(tc.expected)
+			sort.Sort(actual)
+			for i := range actual {
+				require.Equal(t, tc.expected[i].URL(), actual[i].URL())
+			}
+		})
+	}
+}
+
+func trueValue() *bool {
+	a := true
+	return &a
+}

--- a/pkg/scrape/target_test.go
+++ b/pkg/scrape/target_test.go
@@ -18,11 +18,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/parca-dev/parca/pkg/config"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
+
+	"github.com/parca-dev/parca/pkg/config"
 )
 
 func TestTargetsFromGroup(t *testing.T) {

--- a/pkg/scrape/target_test.go
+++ b/pkg/scrape/target_test.go
@@ -1,3 +1,16 @@
+// Copyright 2024 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package scrape
 
 import (

--- a/pkg/scrape/target_test.go
+++ b/pkg/scrape/target_test.go
@@ -14,14 +14,15 @@
 package scrape
 
 import (
+	"sort"
+	"testing"
+	"time"
+
 	"github.com/parca-dev/parca/pkg/config"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
-	"sort"
-	"testing"
-	"time"
 )
 
 func TestTargetsFromGroup(t *testing.T) {


### PR DESCRIPTION
this updates the definition of `PprofProfilingConfig` such that a new integer field `Seconds` is added which can be set for profiles, in an attempt to resolve https://github.com/parca-dev/parca/issues/2818.

additionally, it changes the behavior where setting any profiling configurations will end up overriding the default so merge will now become a replace.

seconds is accepted as a query parameter and with this change, when provided, it will be used as scraping duration rather than the scraping interval value. this allows having scraping where process being profiled isn't under constant profiling. this only applies to configurations that have delta enabled.

https://pkg.go.dev/net/http/pprof