### PR TITLE
ui: Bug fix where the metrics graph's context menu incorrectly adds labels to the query browser

### DIFF
--- a/ui/packages/shared/profile/src/MetricsGraph/index.tsx
+++ b/ui/packages/shared/profile/src/MetricsGraph/index.tsx
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import React, {Fragment, useCallback, useMemo, useRef, useState} from 'react';
+import React, {Fragment, useCallback, useId, useMemo, useRef, useState} from 'react';
 
 import * as d3 from 'd3';
 import {pointer} from 'd3-selection';
@@ -140,6 +140,7 @@ export const RawMetricsGraph = ({
   const [pos, setPos] = useState([0, 0]);
   const [isContextMenuOpen, setIsContextMenuOpen] = useState<boolean>(false);
   const metricPointRef = useRef(null);
+  const idForContextMenu = useId();
 
   // the time of the selected point is the start of the merge window
   const time: number = parseFloat(profile?.HistoryParams().merge_from);
@@ -372,7 +373,7 @@ export const RawMetricsGraph = ({
 
   const selected = findSelectedProfile();
 
-  const MENU_ID = 'metrics-context-menu';
+  const MENU_ID = `metrics-context-menu-${idForContextMenu}`;
 
   const {show} = useContextMenu({
     id: MENU_ID,


### PR DESCRIPTION
This fixes a bug where when comparing profiles, and you focus on the profile on the LHS, and then use the right-click context menu to add a label to the query browser (individual label or even focusing on an entire series), the label doesn't get added to the LHS, instead the RHS.

The root cause for the bug was because we used the same ID for the right click context menu itself (even when comparing profiles), which meant there was no way to differentiate from which compare window we were actually adding the labels. I fixed by appending a random ID (generated using React's [useId](https://react.dev/reference/react/useId)) to the string `metrics-context-menu`.