### PR TITLE
pkg/query: Explicitly show Flat and FlatPerSecond values on icicle graph

### DIFF
--- a/pkg/query/columnquery_test.go
+++ b/pkg/query/columnquery_test.go
@@ -1189,6 +1189,8 @@ func PprofToSymbolizedProfile(meta profile.Meta, prof *pprofprofile.Profile, ind
 		labelNames = append(labelNames, l)
 	}
 
+	durationSeconds := float64(meta.Duration) / float64(time.Second.Nanoseconds())
+
 	w := profile.NewWriter(memory.DefaultAllocator, labelNames)
 	defer w.RecordBuilder.Release()
 	for i := range prof.Sample {
@@ -1197,7 +1199,12 @@ func PprofToSymbolizedProfile(meta profile.Meta, prof *pprofprofile.Profile, ind
 		}
 
 		w.Value.Append(prof.Sample[i].Value[index])
-		w.ValuePerSecond.Append(0)
+		if meta.Duration > 0 {
+			w.ValuePerSecond.Append(float64(prof.Sample[i].Value[index]) / durationSeconds)
+		} else {
+			w.ValuePerSecond.AppendNull()
+		}
+
 		w.Diff.Append(0)
 		w.DiffPerSecond.Append(0)
 

--- a/pkg/query/flamegraph_arrow_test.go
+++ b/pkg/query/flamegraph_arrow_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/apache/arrow/go/v16/arrow/memory"
 	pprofprofile "github.com/google/pprof/profile"
 	"github.com/prometheus/prometheus/model/labels"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/trace/noop"
 
@@ -550,14 +549,8 @@ func (c *flamegraphComparer) compare(expected flamegraphColumns) {
 	require.Equal(c.t, expected.children, sortedChildren)
 
 	// floats...
-	cumulativePerSecondActual := reorder(c.actual.cumulativePerSecond, order)
-	if !assert.InDeltaSlice(c.t, expected.cumulativePerSecond, cumulativePerSecondActual, 0.0001) {
-		c.t.Logf("expected %v but got %v", expected.cumulativePerSecond, cumulativePerSecondActual)
-	}
-	flatPerSecondActual := reorder(c.actual.flatPerSecond, order)
-	if !assert.InDeltaSlice(c.t, expected.flatPerSecond, flatPerSecondActual, 0.0001) {
-		c.t.Logf("expected %v but got %v", expected.flatPerSecond, flatPerSecondActual)
-	}
+	require.InDeltaSlice(c.t, expected.cumulativePerSecond, reorder(c.actual.cumulativePerSecond, order), 0.0001)
+	require.InDeltaSlice(c.t, expected.flatPerSecond, reorder(c.actual.flatPerSecond, order), 0.0001)
 }
 
 func reorder[T any](slice []T, order []int) []T {

--- a/pkg/query/flamegraph_arrow_test.go
+++ b/pkg/query/flamegraph_arrow_test.go
@@ -544,8 +544,8 @@ func (c *flamegraphComparer) compare(expected flamegraphColumns) {
 	require.Equal(c.t, expected.functionSystemNames, reorder(c.actual.functionSystemNames, order))
 	require.Equal(c.t, expected.functionFileNames, reorder(c.actual.functionFileNames, order))
 	require.Equal(c.t, expected.labels, reorder(c.actual.labels, order))
-	require.Equal(c.t, expected.cumulative, reorder(c.actual.cumulative, order), order)
-	require.Equal(c.t, expected.flat, reorder(c.actual.flat, order), order)
+	require.Equal(c.t, expected.cumulative, reorder(c.actual.cumulative, order))
+	require.Equal(c.t, expected.flat, reorder(c.actual.flat, order))
 	require.Equal(c.t, expected.diff, reorder(c.actual.diff, order))
 	require.Equal(c.t, expected.children, sortedChildren)
 
@@ -663,11 +663,11 @@ func TestGenerateFlamegraphArrowWithInlined(t *testing.T) {
 	require.Equal(t, int64(5), record.NumRows())
 
 	rows := []flamegraphRow{
-		{MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0, LocationLine: 0, FunctionStartLine: 0, FunctionName: "(null)", FunctionSystemName: "(null)", FunctionFilename: "(null)", Cumulative: 1, Flat: 0, Labels: nil, Children: []uint32{1}},                                                                                        // 0
-		{MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0xa1, LocationLine: 173, FunctionStartLine: 0, FunctionName: "net.(*netFD).accept", FunctionSystemName: "net.(*netFD).accept", FunctionFilename: "net/fd_unix.go", Cumulative: 1, Flat: 0, Labels: nil, Children: []uint32{2}},                                                 // 1
-		{MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0xa2, LocationLine: 200, FunctionStartLine: 0, FunctionName: "internal/poll.(*pollDesc).waitRead", FunctionSystemName: "internal/poll.(*pollDesc).waitRead", FunctionFilename: "internal/poll/fd_poll_runtime.go", Cumulative: 1, Flat: 0, Labels: nil, Children: []uint32{3}}, // 2
-		{MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0xa2, LocationLine: 89, FunctionStartLine: 0, FunctionName: "internal/poll.(*FD).Accept", FunctionSystemName: "internal/poll.(*FD).Accept", FunctionFilename: "internal/poll/fd_unix.go", Cumulative: 1, Flat: 0, Labels: nil, Children: []uint32{4}, Inlined: true},           // 3
-		{MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0xa3, LocationLine: 84, FunctionStartLine: 0, FunctionName: "internal/poll.(*pollDesc).wait", FunctionSystemName: "internal/poll.(*pollDesc).wait", FunctionFilename: "internal/poll/fd_poll_runtime.go", Cumulative: 1, Flat: 1, Labels: nil, Children: nil},                  // 4
+		{MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0, LocationLine: 0, FunctionStartLine: 0, FunctionName: "(null)", FunctionSystemName: "(null)", FunctionFilename: "(null)", Cumulative: 1, CumulativePerSecond: 0.1, Flat: 0, FlatPerSecond: 0, Labels: nil, Children: []uint32{1}},                                                                                        // 0
+		{MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0xa1, LocationLine: 173, FunctionStartLine: 0, FunctionName: "net.(*netFD).accept", FunctionSystemName: "net.(*netFD).accept", FunctionFilename: "net/fd_unix.go", Cumulative: 1, CumulativePerSecond: 0.1, Flat: 0, FlatPerSecond: 0, Labels: nil, Children: []uint32{2}},                                                 // 1
+		{MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0xa2, LocationLine: 200, FunctionStartLine: 0, FunctionName: "internal/poll.(*pollDesc).waitRead", FunctionSystemName: "internal/poll.(*pollDesc).waitRead", FunctionFilename: "internal/poll/fd_poll_runtime.go", Cumulative: 1, CumulativePerSecond: 0.1, Flat: 0, FlatPerSecond: 0, Labels: nil, Children: []uint32{3}}, // 2
+		{MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0xa2, LocationLine: 89, FunctionStartLine: 0, FunctionName: "internal/poll.(*FD).Accept", FunctionSystemName: "internal/poll.(*FD).Accept", FunctionFilename: "internal/poll/fd_unix.go", Cumulative: 1, CumulativePerSecond: 0.1, Flat: 0, FlatPerSecond: 0, Labels: nil, Children: []uint32{4}, Inlined: true},           // 3
+		{MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0xa3, LocationLine: 84, FunctionStartLine: 0, FunctionName: "internal/poll.(*pollDesc).wait", FunctionSystemName: "internal/poll.(*pollDesc).wait", FunctionFilename: "internal/poll/fd_poll_runtime.go", Cumulative: 1, CumulativePerSecond: 0.1, Flat: 1, FlatPerSecond: 0.1, Labels: nil, Children: nil},                // 4
 	}
 	expectedColumns := rowsToColumn(rows)
 
@@ -742,12 +742,12 @@ func TestGenerateFlamegraphArrowUnsymbolized(t *testing.T) {
 			height:     5,
 			trimmed:    0,
 			rows: []flamegraphRow{
-				{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: "(null)", MappingBuildID: "(null)", LocationAddress: 0, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 6, Flat: 0, Children: []uint32{1}},    // 0
-				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 6, Flat: 0, Children: []uint32{2}},    // 1
-				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 6, Flat: 2, Children: []uint32{3}},    // 2
-				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 4, Flat: 0, Children: []uint32{4, 5}}, // 3
-				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa4, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 3, Flat: 3, Children: nil},            // 4
-				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa5, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 1, Flat: 1, Children: nil},            // 5
+				{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: "(null)", MappingBuildID: "(null)", LocationAddress: 0, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 6, CumulativePerSecond: 0.6, Flat: 0, FlatPerSecond: 0, Children: []uint32{1}},    // 0
+				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 6, CumulativePerSecond: 0.6, Flat: 0, FlatPerSecond: 0, Children: []uint32{2}},    // 1
+				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 6, CumulativePerSecond: 0.6, Flat: 2, FlatPerSecond: 0.2, Children: []uint32{3}},  // 2
+				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 4, CumulativePerSecond: 0.4, Flat: 0, FlatPerSecond: 0, Children: []uint32{4, 5}}, // 3
+				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa4, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 3, CumulativePerSecond: 0.3, Flat: 3, FlatPerSecond: 0.3, Children: nil},          // 4
+				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa5, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 1, CumulativePerSecond: 0.1, Flat: 1, FlatPerSecond: 0.1, Children: nil},          // 5
 			},
 		},
 	} {
@@ -851,9 +851,9 @@ func TestGenerateFlamegraphArrowTrimming(t *testing.T) {
 
 	// TODO: MappingBuildID and FunctionSystemNames shouldn't be "" but null?
 	rows := []flamegraphRow{
-		{MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 14, Flat: 0, Children: []uint32{1}}, // 0
-		{MappingFile: "a", MappingBuildID: "", FunctionName: "1", FunctionSystemName: "", FunctionFilename: "", Cumulative: 14, Flat: 0, Children: []uint32{2}},                                                                               // 1
-		{MappingFile: "a", MappingBuildID: "", FunctionName: "2", FunctionSystemName: "", FunctionFilename: "", Cumulative: 14, Flat: 10, Children: nil},                                                                                      // 2
+		{MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 14, CumulativePerSecond: 1.4, Flat: 0, FlatPerSecond: 0, Children: []uint32{1}}, // 0
+		{MappingFile: "a", MappingBuildID: "", FunctionName: "1", FunctionSystemName: "", FunctionFilename: "", Cumulative: 14, CumulativePerSecond: 1.4, Flat: 0, FlatPerSecond: 0, Children: []uint32{2}},                                                                               // 1
+		{MappingFile: "a", MappingBuildID: "", FunctionName: "2", FunctionSystemName: "", FunctionFilename: "", Cumulative: 14, CumulativePerSecond: 1.4, Flat: 10, FlatPerSecond: 1, Children: nil},                                                                                      // 2
 	}
 	expectedColumns := rowsToColumn(rows)
 

--- a/pkg/query/flamegraph_arrow_test.go
+++ b/pkg/query/flamegraph_arrow_test.go
@@ -24,6 +24,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/apache/arrow/go/v16/arrow"
 	"github.com/apache/arrow/go/v16/arrow/array"
@@ -31,6 +32,7 @@ import (
 	"github.com/apache/arrow/go/v16/arrow/memory"
 	pprofprofile "github.com/google/pprof/profile"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/trace/noop"
 
@@ -367,12 +369,12 @@ func TestGenerateFlamegraphArrow(t *testing.T) {
 		height:     5,
 		trimmed:    0,
 		rows: []flamegraphRow{
-			{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0, LocationLine: 0, FunctionStartLine: 0, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 11, Flat: 0, Labels: nil, Children: []uint32{1}}, // 0
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 11, Flat: 0, Labels: nil, Children: []uint32{2}},                                                                  // 1
-			{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0x0, LocationLine: 0, FunctionStartLine: 0, FunctionName: "2", FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 11, Flat: 3, Labels: nil, Children: []uint32{3}},              // 2
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationLine: 3, FunctionStartLine: 3, FunctionName: "3", FunctionSystemName: "3", FunctionFilename: "3", Cumulative: 8, Flat: 0, Labels: nil, Children: []uint32{4, 5}},                                                                // 3
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa4, LocationLine: 4, FunctionStartLine: 4, FunctionName: "4", FunctionSystemName: "4", FunctionFilename: "4", Cumulative: 3, Flat: 3, Labels: nil, Children: nil},                                                                           // 4
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa5, LocationLine: 5, FunctionStartLine: 5, FunctionName: "5", FunctionSystemName: "5", FunctionFilename: "5", Cumulative: 5, Flat: 5, Labels: nil, Children: nil},                                                                           // 5
+			{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0, LocationLine: 0, FunctionStartLine: 0, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 11, CumulativePerSecond: 1.1, Flat: 0, FlatPerSecond: 0, Labels: nil, Children: []uint32{1}}, // 0
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 11, CumulativePerSecond: 1.1, Flat: 0, FlatPerSecond: 0, Labels: nil, Children: []uint32{2}},                                                                  // 1
+			{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0x0, LocationLine: 0, FunctionStartLine: 0, FunctionName: "2", FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 11, CumulativePerSecond: 1.1, Flat: 3, FlatPerSecond: 0.3, Labels: nil, Children: []uint32{3}},            // 2
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationLine: 3, FunctionStartLine: 3, FunctionName: "3", FunctionSystemName: "3", FunctionFilename: "3", Cumulative: 8, CumulativePerSecond: 0.8, Flat: 0, FlatPerSecond: 0, Labels: nil, Children: []uint32{4, 5}},                                                                // 3
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa4, LocationLine: 4, FunctionStartLine: 4, FunctionName: "4", FunctionSystemName: "4", FunctionFilename: "4", Cumulative: 3, CumulativePerSecond: 0.3, Flat: 3, FlatPerSecond: 0.3, Labels: nil, Children: nil},                                                                         // 4
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa5, LocationLine: 5, FunctionStartLine: 5, FunctionName: "5", FunctionSystemName: "5", FunctionFilename: "5", Cumulative: 5, CumulativePerSecond: 0.5, Flat: 5, FlatPerSecond: 0.5, Labels: nil, Children: nil},                                                                         // 5
 		},
 	}, {
 		name:      "aggregate-pprof-labels",
@@ -383,24 +385,24 @@ func TestGenerateFlamegraphArrow(t *testing.T) {
 		trimmed:    0,
 		rows: []flamegraphRow{
 			// root
-			{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0, LocationLine: 0, FunctionStartLine: 0, FunctionName: `(null)`, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 11, Flat: 0, Labels: nil, Children: []uint32{1, 6, 11}}, // 0
+			{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0, LocationLine: 0, FunctionStartLine: 0, FunctionName: `(null)`, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 11, CumulativePerSecond: 1.1, Flat: 0, FlatPerSecond: 0, Labels: nil, Children: []uint32{1, 6, 11}}, // 0
 			// stack 1
-			{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0, LocationLine: 0, FunctionStartLine: 0, FunctionName: `(null)`, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 3, Flat: 0, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{2}, LabelsOnly: true}, // 1
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 3, Flat: 0, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{3}},                                                                          // 2
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationLine: 2, FunctionStartLine: 2, FunctionName: "2", FunctionSystemName: "2", FunctionFilename: "2", Cumulative: 3, Flat: 2, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{4}},                                                                          // 3
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationLine: 3, FunctionStartLine: 3, FunctionName: "3", FunctionSystemName: "3", FunctionFilename: "3", Cumulative: 1, Flat: 0, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{5}},                                                                          // 4
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa5, LocationLine: 5, FunctionStartLine: 5, FunctionName: "5", FunctionSystemName: "5", FunctionFilename: "5", Cumulative: 1, Flat: 1, Labels: map[string]string{"goroutine": "1"}, Children: nil},                                                                                  // 5
+			{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0, LocationLine: 0, FunctionStartLine: 0, FunctionName: `(null)`, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 3, CumulativePerSecond: 0.3, Flat: 0, FlatPerSecond: 0, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{2}, LabelsOnly: true}, // 1
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 3, CumulativePerSecond: 0.3, Flat: 0, FlatPerSecond: 0, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{3}},                                                                          // 2
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationLine: 2, FunctionStartLine: 2, FunctionName: "2", FunctionSystemName: "2", FunctionFilename: "2", Cumulative: 3, CumulativePerSecond: 0.3, Flat: 2, FlatPerSecond: 0.2, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{4}},                                                                        // 3
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationLine: 3, FunctionStartLine: 3, FunctionName: "3", FunctionSystemName: "3", FunctionFilename: "3", Cumulative: 1, CumulativePerSecond: 0.1, Flat: 0, FlatPerSecond: 0, Labels: map[string]string{"goroutine": "1"}, Children: []uint32{5}},                                                                          // 4
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa5, LocationLine: 5, FunctionStartLine: 5, FunctionName: "5", FunctionSystemName: "5", FunctionFilename: "5", Cumulative: 1, CumulativePerSecond: 0.1, Flat: 1, FlatPerSecond: 0.1, Labels: map[string]string{"goroutine": "1"}, Children: nil},                                                                                // 5
 			// stack 2
-			{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0, LocationLine: 0, FunctionStartLine: 0, FunctionName: `(null)`, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 4, Flat: 0, Labels: map[string]string{"goroutine": "2"}, Children: []uint32{7}, LabelsOnly: true}, // 6
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 4, Flat: 0, Labels: map[string]string{"goroutine": "2"}, Children: []uint32{8}},                                                                          // 7
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationLine: 2, FunctionStartLine: 2, FunctionName: "2", FunctionSystemName: "2", FunctionFilename: "2", Cumulative: 4, Flat: 0, Labels: map[string]string{"goroutine": "2"}, Children: []uint32{9}},                                                                          // 8
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationLine: 3, FunctionStartLine: 3, FunctionName: "3", FunctionSystemName: "3", FunctionFilename: "3", Cumulative: 4, Flat: 0, Labels: map[string]string{"goroutine": "2"}, Children: []uint32{10}},                                                                         // 9
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa5, LocationLine: 5, FunctionStartLine: 5, FunctionName: "5", FunctionSystemName: "5", FunctionFilename: "5", Cumulative: 4, Flat: 4, Labels: map[string]string{"goroutine": "2"}, Children: nil},                                                                                  // 10
+			{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0, LocationLine: 0, FunctionStartLine: 0, FunctionName: `(null)`, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 4, CumulativePerSecond: 0.4, Flat: 0, FlatPerSecond: 0, Labels: map[string]string{"goroutine": "2"}, Children: []uint32{7}, LabelsOnly: true}, // 6
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 4, CumulativePerSecond: 0.4, Flat: 0, FlatPerSecond: 0, Labels: map[string]string{"goroutine": "2"}, Children: []uint32{8}},                                                                          // 7
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationLine: 2, FunctionStartLine: 2, FunctionName: "2", FunctionSystemName: "2", FunctionFilename: "2", Cumulative: 4, CumulativePerSecond: 0.4, Flat: 0, FlatPerSecond: 0, Labels: map[string]string{"goroutine": "2"}, Children: []uint32{9}},                                                                          // 8
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationLine: 3, FunctionStartLine: 3, FunctionName: "3", FunctionSystemName: "3", FunctionFilename: "3", Cumulative: 4, CumulativePerSecond: 0.4, Flat: 0, FlatPerSecond: 0, Labels: map[string]string{"goroutine": "2"}, Children: []uint32{10}},                                                                         // 9
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa5, LocationLine: 5, FunctionStartLine: 5, FunctionName: "5", FunctionSystemName: "5", FunctionFilename: "5", Cumulative: 4, CumulativePerSecond: 0.4, Flat: 4, FlatPerSecond: 0.4, Labels: map[string]string{"goroutine": "2"}, Children: nil},                                                                                // 10
 			// stack 3
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 4, Flat: 0, Labels: nil, Children: []uint32{12}},                                                        // 11
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0, LocationLine: 0, FunctionStartLine: 0, FunctionName: "2", FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 4, Flat: 1, Labels: nil, Children: []uint32{13}}, // 12
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationLine: 3, FunctionStartLine: 3, FunctionName: "3", FunctionSystemName: "3", FunctionFilename: "3", Cumulative: 3, Flat: 0, Labels: nil, Children: []uint32{14}},                                                        // 13
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa4, LocationLine: 4, FunctionStartLine: 4, FunctionName: "4", FunctionSystemName: "4", FunctionFilename: "4", Cumulative: 3, Flat: 3, Labels: nil, Children: nil},                                                                 // 14
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 4, CumulativePerSecond: 0.4, Flat: 0, FlatPerSecond: 0, Labels: nil, Children: []uint32{12}},                                                          // 11
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0, LocationLine: 0, FunctionStartLine: 0, FunctionName: "2", FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 4, CumulativePerSecond: 0.4, Flat: 1, FlatPerSecond: 0.1, Labels: nil, Children: []uint32{13}}, // 12
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationLine: 3, FunctionStartLine: 3, FunctionName: "3", FunctionSystemName: "3", FunctionFilename: "3", Cumulative: 3, CumulativePerSecond: 0.3, Flat: 0, FlatPerSecond: 0, Labels: nil, Children: []uint32{14}},                                                          // 13
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa4, LocationLine: 4, FunctionStartLine: 4, FunctionName: "4", FunctionSystemName: "4", FunctionFilename: "4", Cumulative: 3, CumulativePerSecond: 0.3, Flat: 3, FlatPerSecond: 0.3, Labels: nil, Children: nil},                                                                 // 14
 		},
 	}, {
 		name:      "aggregate-mapping-file",
@@ -411,17 +413,17 @@ func TestGenerateFlamegraphArrow(t *testing.T) {
 		trimmed:    0,
 		rows: []flamegraphRow{
 			// This aggregates all the rows with the same mapping file, meaning that we only keep one flamegraphRow per stack depth in this example.
-			{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0, LocationLine: 0, FunctionStartLine: 0, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 11, Flat: 0, Labels: nil, Children: []uint32{1}}, // 0
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 11, Flat: 0, Labels: nil, Children: []uint32{2, 6}},                                                               // 1
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationLine: 2, FunctionStartLine: 2, FunctionName: "2", FunctionSystemName: "2", FunctionFilename: "2", Cumulative: 10, Flat: 2, Labels: nil, Children: []uint32{3}},                                                                  // 2
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationLine: 3, FunctionStartLine: 3, FunctionName: "3", FunctionSystemName: "3", FunctionFilename: "3", Cumulative: 8, Flat: 0, Labels: nil, Children: []uint32{4, 5}},                                                                // 3
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa4, LocationLine: 4, FunctionStartLine: 4, FunctionName: "4", FunctionSystemName: "4", FunctionFilename: "4", Cumulative: 3, Flat: 3, Labels: nil, Children: nil},                                                                           // 4
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa5, LocationLine: 5, FunctionStartLine: 5, FunctionName: "5", FunctionSystemName: "5", FunctionFilename: "5", Cumulative: 5, Flat: 5, Labels: nil, Children: nil},                                                                           // 5
-			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "b", MappingBuildID: "bID", LocationAddress: 0xa6, LocationLine: 6, FunctionStartLine: 6, FunctionName: "2", FunctionSystemName: "6", FunctionFilename: "6", Cumulative: 1, Flat: 1, Labels: nil, Children: nil},                                                                           // 5
+			{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0, LocationLine: 0, FunctionStartLine: 0, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 11, CumulativePerSecond: 1.1, Flat: 0, FlatPerSecond: 0, Labels: nil, Children: []uint32{1}}, // 0
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, LocationLine: 1, FunctionStartLine: 1, FunctionName: "1", FunctionSystemName: "1", FunctionFilename: "1", Cumulative: 11, CumulativePerSecond: 1.1, Flat: 0, FlatPerSecond: 0, Labels: nil, Children: []uint32{2, 6}},                                                               // 1
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, LocationLine: 2, FunctionStartLine: 2, FunctionName: "2", FunctionSystemName: "2", FunctionFilename: "2", Cumulative: 10, CumulativePerSecond: 1.0, Flat: 2, FlatPerSecond: 0.2, Labels: nil, Children: []uint32{3}},                                                                // 2
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, LocationLine: 3, FunctionStartLine: 3, FunctionName: "3", FunctionSystemName: "3", FunctionFilename: "3", Cumulative: 8, CumulativePerSecond: 0.8, Flat: 0, FlatPerSecond: 0, Labels: nil, Children: []uint32{4, 5}},                                                                // 3
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa4, LocationLine: 4, FunctionStartLine: 4, FunctionName: "4", FunctionSystemName: "4", FunctionFilename: "4", Cumulative: 3, CumulativePerSecond: 0.3, Flat: 3, FlatPerSecond: 0.3, Labels: nil, Children: nil},                                                                         // 4
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa5, LocationLine: 5, FunctionStartLine: 5, FunctionName: "5", FunctionSystemName: "5", FunctionFilename: "5", Cumulative: 5, CumulativePerSecond: 0.5, Flat: 5, FlatPerSecond: 0.5, Labels: nil, Children: nil},                                                                         // 5
+			{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "b", MappingBuildID: "bID", LocationAddress: 0xa6, LocationLine: 6, FunctionStartLine: 6, FunctionName: "2", FunctionSystemName: "6", FunctionFilename: "6", Cumulative: 1, CumulativePerSecond: 0.1, Flat: 1, FlatPerSecond: 0.1, Labels: nil, Children: nil},                                                                         // 5
 		},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			sp, err := PprofToSymbolizedProfile(profile.Meta{}, p, 0)
+			sp, err := PprofToSymbolizedProfile(profile.Meta{Duration: (10 * time.Second).Nanoseconds()}, p, 0)
 			require.NoError(t, err)
 
 			sp.Samples = []arrow.Record{
@@ -543,11 +545,19 @@ func (c *flamegraphComparer) compare(expected flamegraphColumns) {
 	require.Equal(c.t, expected.functionFileNames, reorder(c.actual.functionFileNames, order))
 	require.Equal(c.t, expected.labels, reorder(c.actual.labels, order))
 	require.Equal(c.t, expected.cumulative, reorder(c.actual.cumulative, order), order)
-	require.Equal(c.t, expected.cumulativePerSecond, reorder(c.actual.cumulativePerSecond, order), order)
 	require.Equal(c.t, expected.flat, reorder(c.actual.flat, order), order)
-	require.Equal(c.t, expected.flatPerSecond, reorder(c.actual.flatPerSecond, order), order)
 	require.Equal(c.t, expected.diff, reorder(c.actual.diff, order))
 	require.Equal(c.t, expected.children, sortedChildren)
+
+	// floats...
+	cumulativePerSecondActual := reorder(c.actual.cumulativePerSecond, order)
+	if !assert.InDeltaSlice(c.t, expected.cumulativePerSecond, cumulativePerSecondActual, 0.0001) {
+		c.t.Logf("expected %v but got %v", expected.cumulativePerSecond, cumulativePerSecondActual)
+	}
+	flatPerSecondActual := reorder(c.actual.flatPerSecond, order)
+	if !assert.InDeltaSlice(c.t, expected.flatPerSecond, flatPerSecondActual, 0.0001) {
+		c.t.Logf("expected %v but got %v", expected.flatPerSecond, flatPerSecondActual)
+	}
 }
 
 func reorder[T any](slice []T, order []int) []T {
@@ -599,7 +609,7 @@ func TestGenerateFlamegraphArrowEmpty(t *testing.T) {
 	require.Equal(t, int64(0), total)
 	require.Equal(t, int32(1), height)
 	require.Equal(t, int64(0), trimmed)
-	require.Equal(t, int64(15), record.NumCols())
+	require.Equal(t, int64(17), record.NumCols())
 	require.Equal(t, int64(1), record.NumRows())
 }
 
@@ -632,7 +642,7 @@ func TestGenerateFlamegraphArrowWithInlined(t *testing.T) {
 		},
 	}
 
-	p, err := PprofToSymbolizedProfile(profile.Meta{}, &pprofprofile.Profile{
+	p, err := PprofToSymbolizedProfile(profile.Meta{Duration: (10 * time.Second).Nanoseconds()}, &pprofprofile.Profile{
 		SampleType: []*pprofprofile.ValueType{{Type: "alloc_space", Unit: "bytes"}},
 		PeriodType: &pprofprofile.ValueType{Type: "space", Unit: "bytes"},
 		Sample:     samples,
@@ -649,15 +659,15 @@ func TestGenerateFlamegraphArrowWithInlined(t *testing.T) {
 	require.Equal(t, int32(5), height)
 	require.Equal(t, int64(0), trimmed)
 
-	require.Equal(t, int64(15), record.NumCols())
+	require.Equal(t, int64(17), record.NumCols())
 	require.Equal(t, int64(5), record.NumRows())
 
 	rows := []flamegraphRow{
-		{MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0, LocationLine: 0, FunctionStartLine: 0, FunctionName: "(null)", FunctionSystemName: "(null)", FunctionFilename: "(null)", Cumulative: 1, Labels: nil, Children: []uint32{1}},                                                                                        // 0
-		{MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0xa1, LocationLine: 173, FunctionStartLine: 0, FunctionName: "net.(*netFD).accept", FunctionSystemName: "net.(*netFD).accept", FunctionFilename: "net/fd_unix.go", Cumulative: 1, Labels: nil, Children: []uint32{2}},                                                 // 1
-		{MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0xa2, LocationLine: 200, FunctionStartLine: 0, FunctionName: "internal/poll.(*pollDesc).waitRead", FunctionSystemName: "internal/poll.(*pollDesc).waitRead", FunctionFilename: "internal/poll/fd_poll_runtime.go", Cumulative: 1, Labels: nil, Children: []uint32{3}}, // 2
-		{MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0xa2, LocationLine: 89, FunctionStartLine: 0, FunctionName: "internal/poll.(*FD).Accept", FunctionSystemName: "internal/poll.(*FD).Accept", FunctionFilename: "internal/poll/fd_unix.go", Cumulative: 1, Labels: nil, Children: []uint32{4}, Inlined: true},           // 3
-		{MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0xa3, LocationLine: 84, FunctionStartLine: 0, FunctionName: "internal/poll.(*pollDesc).wait", FunctionSystemName: "internal/poll.(*pollDesc).wait", FunctionFilename: "internal/poll/fd_poll_runtime.go", Cumulative: 1, Labels: nil, Children: nil},                  // 4
+		{MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0, LocationLine: 0, FunctionStartLine: 0, FunctionName: "(null)", FunctionSystemName: "(null)", FunctionFilename: "(null)", Cumulative: 1, Flat: 0, Labels: nil, Children: []uint32{1}},                                                                                        // 0
+		{MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0xa1, LocationLine: 173, FunctionStartLine: 0, FunctionName: "net.(*netFD).accept", FunctionSystemName: "net.(*netFD).accept", FunctionFilename: "net/fd_unix.go", Cumulative: 1, Flat: 0, Labels: nil, Children: []uint32{2}},                                                 // 1
+		{MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0xa2, LocationLine: 200, FunctionStartLine: 0, FunctionName: "internal/poll.(*pollDesc).waitRead", FunctionSystemName: "internal/poll.(*pollDesc).waitRead", FunctionFilename: "internal/poll/fd_poll_runtime.go", Cumulative: 1, Flat: 0, Labels: nil, Children: []uint32{3}}, // 2
+		{MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0xa2, LocationLine: 89, FunctionStartLine: 0, FunctionName: "internal/poll.(*FD).Accept", FunctionSystemName: "internal/poll.(*FD).Accept", FunctionFilename: "internal/poll/fd_unix.go", Cumulative: 1, Flat: 0, Labels: nil, Children: []uint32{4}, Inlined: true},           // 3
+		{MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, LocationAddress: 0xa3, LocationLine: 84, FunctionStartLine: 0, FunctionName: "internal/poll.(*pollDesc).wait", FunctionSystemName: "internal/poll.(*pollDesc).wait", FunctionFilename: "internal/poll/fd_poll_runtime.go", Cumulative: 1, Flat: 1, Labels: nil, Children: nil},                  // 4
 	}
 	expectedColumns := rowsToColumn(rows)
 
@@ -697,7 +707,7 @@ func TestGenerateFlamegraphArrowUnsymbolized(t *testing.T) {
 		Address: 0xa5,
 	}}
 
-	p, err := PprofToSymbolizedProfile(profile.Meta{}, &pprofprofile.Profile{
+	p, err := PprofToSymbolizedProfile(profile.Meta{Duration: (10 * time.Second).Nanoseconds()}, &pprofprofile.Profile{
 		Mapping:  mappings,
 		Location: locations,
 		Sample: []*pprofprofile.Sample{{
@@ -732,12 +742,12 @@ func TestGenerateFlamegraphArrowUnsymbolized(t *testing.T) {
 			height:     5,
 			trimmed:    0,
 			rows: []flamegraphRow{
-				{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: "(null)", MappingBuildID: "(null)", LocationAddress: 0, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 6, Children: []uint32{1}},    // 0
-				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 6, Children: []uint32{2}},    // 1
-				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 6, Children: []uint32{3}},    // 2
-				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 4, Children: []uint32{4, 5}}, // 3
-				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa4, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 3, Children: nil},            // 4
-				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa5, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 1, Children: nil},            // 5
+				{MappingStart: 0, MappingLimit: 0, MappingOffset: 0, MappingFile: "(null)", MappingBuildID: "(null)", LocationAddress: 0, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 6, Flat: 0, Children: []uint32{1}},    // 0
+				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa1, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 6, Flat: 0, Children: []uint32{2}},    // 1
+				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa2, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 6, Flat: 2, Children: []uint32{3}},    // 2
+				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa3, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 4, Flat: 0, Children: []uint32{4, 5}}, // 3
+				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa4, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 3, Flat: 3, Children: nil},            // 4
+				{MappingStart: 1, MappingLimit: 1, MappingOffset: 0x1234, MappingFile: "a", MappingBuildID: "aID", LocationAddress: 0xa5, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 1, Flat: 1, Children: nil},            // 5
 			},
 		},
 	} {
@@ -750,7 +760,7 @@ func TestGenerateFlamegraphArrowUnsymbolized(t *testing.T) {
 			require.Equal(t, tc.height, height)
 			require.Equal(t, tc.trimmed, trimmed)
 			require.Equal(t, int64(len(tc.rows)), fa.NumRows())
-			require.Equal(t, int64(15), fa.NumCols())
+			require.Equal(t, int64(17), fa.NumCols())
 
 			// Convert the numRows to columns for easier access when testing below.
 			expectedColumns := rowsToColumn(tc.rows)
@@ -812,7 +822,7 @@ func TestGenerateFlamegraphArrowTrimming(t *testing.T) {
 	}}
 
 	p, err := PprofToSymbolizedProfile(
-		profile.Meta{},
+		profile.Meta{Duration: (10 * time.Second).Nanoseconds()},
 		&pprofprofile.Profile{
 			Sample: []*pprofprofile.Sample{{
 				Location: []*pprofprofile.Location{locations[1], locations[0]},
@@ -837,13 +847,13 @@ func TestGenerateFlamegraphArrowTrimming(t *testing.T) {
 	require.Equal(t, int32(5), height)
 	require.Equal(t, int64(4), trimmed)
 	require.Equal(t, int64(3), fa.NumRows())
-	require.Equal(t, int64(15), fa.NumCols())
+	require.Equal(t, int64(17), fa.NumCols())
 
 	// TODO: MappingBuildID and FunctionSystemNames shouldn't be "" but null?
 	rows := []flamegraphRow{
-		{MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 14, Children: []uint32{1}}, // 0
-		{MappingFile: "a", MappingBuildID: "", FunctionName: "1", FunctionSystemName: "", FunctionFilename: "", Cumulative: 14, Children: []uint32{2}},                                                                               // 1
-		{MappingFile: "a", MappingBuildID: "", FunctionName: "2", FunctionSystemName: "", FunctionFilename: "", Cumulative: 14, Children: nil},                                                                                       // 2
+		{MappingFile: array.NullValueStr, MappingBuildID: array.NullValueStr, FunctionName: array.NullValueStr, FunctionSystemName: array.NullValueStr, FunctionFilename: array.NullValueStr, Cumulative: 14, Flat: 0, Children: []uint32{1}}, // 0
+		{MappingFile: "a", MappingBuildID: "", FunctionName: "1", FunctionSystemName: "", FunctionFilename: "", Cumulative: 14, Flat: 0, Children: []uint32{2}},                                                                               // 1
+		{MappingFile: "a", MappingBuildID: "", FunctionName: "2", FunctionSystemName: "", FunctionFilename: "", Cumulative: 14, Flat: 10, Children: nil},                                                                                      // 2
 	}
 	expectedColumns := rowsToColumn(rows)
 

--- a/ui/packages/shared/profile/src/GraphTooltipArrow/Content.tsx
+++ b/ui/packages/shared/profile/src/GraphTooltipArrow/Content.tsx
@@ -88,8 +88,8 @@ const GraphTooltipArrowContent = ({
                     {name !== ''
                       ? name
                       : locationAddress !== 0n
-                        ? hexifyAddress(locationAddress)
-                        : 'unknown'}
+                      ? hexifyAddress(locationAddress)
+                      : 'unknown'}
                   </p>
                 )}
               </div>

--- a/ui/packages/shared/profile/src/GraphTooltipArrow/Content.tsx
+++ b/ui/packages/shared/profile/src/GraphTooltipArrow/Content.tsx
@@ -67,6 +67,8 @@ const GraphTooltipArrowContent = ({
     locationAddress,
     cumulativeText,
     cumulativePerSecondText,
+    flatText,
+    flatPerSecondText,
     diffText,
     diff,
     row: rowNumber,
@@ -86,16 +88,22 @@ const GraphTooltipArrowContent = ({
                     {name !== ''
                       ? name
                       : locationAddress !== 0n
-                      ? hexifyAddress(locationAddress)
-                      : 'unknown'}
+                        ? hexifyAddress(locationAddress)
+                        : 'unknown'}
                   </p>
                 )}
               </div>
               <table className="my-2 w-full table-fixed pr-0 text-gray-700 dark:text-gray-300">
                 <tbody>
+                  <tr>
+                    <td className="w-1/4">Cumulative</td>
+                    <td className="w-3/4">
+                      <div>{cumulativeText}</div>
+                    </td>
+                  </tr>
                   {profileType?.delta ?? false ? (
                     <tr>
-                      <td className="w-1/4">Per Second</td>
+                      <td className="w-1/4"></td>
                       <td className="w-3/4">
                         <div>{cumulativePerSecondText}</div>
                       </td>
@@ -104,16 +112,25 @@ const GraphTooltipArrowContent = ({
                     <></>
                   )}
                   <tr>
-                    <td className="w-1/4">Cumulative</td>
-
-                    <td className="w-3/4">
-                      <div>{cumulativeText}</div>
+                    <td className="w-1/4 pt-2">Flat</td>
+                    <td className="w-3/4 pt-2">
+                      <div>{flatText}</div>
                     </td>
                   </tr>
+                  {profileType?.delta ?? false ? (
+                    <tr>
+                      <td className="w-1/4"></td>
+                      <td className="w-3/4">
+                        <div>{flatPerSecondText}</div>
+                      </td>
+                    </tr>
+                  ) : (
+                    <></>
+                  )}
                   {diff !== 0n && (
                     <tr>
-                      <td className="w-1/4">Diff</td>
-                      <td className="w-3/4">
+                      <td className="w-1/4 pt-2">Diff</td>
+                      <td className="w-3/4 pt-2">
                         <div>{diffText}</div>
                       </td>
                     </tr>
@@ -169,8 +186,8 @@ const TooltipMetaInfo = ({
   return (
     <>
       <tr>
-        <td className="w-1/4">File</td>
-        <td className="w-3/4 break-all">
+        <td className="w-1/4 pt-2">File</td>
+        <td className="w-3/4 pt-2 break-all">
           {functionFilename === '' ? (
             <NoData />
           ) : (

--- a/ui/packages/shared/profile/src/GraphTooltipArrow/useGraphTooltip/index.ts
+++ b/ui/packages/shared/profile/src/GraphTooltipArrow/useGraphTooltip/index.ts
@@ -21,6 +21,8 @@ import {
   FIELD_CUMULATIVE_PER_SECOND,
   FIELD_DIFF,
   FIELD_DIFF_PER_SECOND,
+  FIELD_FLAT,
+  FIELD_FLAT_PER_SECOND,
   FIELD_LOCATION_ADDRESS,
 } from '../../ProfileIcicleGraph/IcicleGraphArrow';
 import {
@@ -43,6 +45,8 @@ interface GraphTooltipData {
   locationAddress: bigint;
   cumulativeText: string;
   cumulativePerSecondText: string;
+  flatText: string;
+  flatPerSecondText: string;
   diffText: string;
   diff: bigint;
   row: number;
@@ -69,6 +73,14 @@ export const useGraphTooltip = ({
   const cumulativePerSecond: number =
     table.getChild(FIELD_CUMULATIVE_PER_SECOND)?.get(row) !== null
       ? table.getChild(FIELD_CUMULATIVE_PER_SECOND)?.get(row)
+      : 0;
+  const flat: bigint =
+    table.getChild(FIELD_FLAT)?.get(row) !== null
+      ? BigInt(table.getChild(FIELD_FLAT)?.get(row))
+      : 0n;
+  const flatPerSecond: number =
+    table.getChild(FIELD_FLAT_PER_SECOND)?.get(row) !== null
+      ? table.getChild(FIELD_FLAT_PER_SECOND)?.get(row)
       : 0;
   const diff: bigint =
     table.getChild(FIELD_DIFF)?.get(row) !== null
@@ -109,6 +121,11 @@ export const useGraphTooltip = ({
     ),
     cumulativePerSecondText: getTextForCumulativePerSecond(
       cumulativePerSecond,
+      profileType?.periodUnit ?? 'CPU Cores'
+    ),
+    flatText: getTextForCumulative(flat, totalUnfiltered, total, profileType.periodUnit ?? ''),
+    flatPerSecondText: getTextForCumulativePerSecond(
+      flatPerSecond,
       profileType?.periodUnit ?? 'CPU Cores'
     ),
     diffText,

--- a/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/index.tsx
@@ -52,6 +52,8 @@ export const FIELD_CHILDREN = 'children';
 export const FIELD_LABELS = 'labels';
 export const FIELD_CUMULATIVE = 'cumulative';
 export const FIELD_CUMULATIVE_PER_SECOND = 'cumulative_per_second';
+export const FIELD_FLAT = 'flat';
+export const FIELD_FLAT_PER_SECOND = 'flat_per_second';
 export const FIELD_DIFF = 'diff';
 export const FIELD_DIFF_PER_SECOND = 'diff_per_second';
 

--- a/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/utils.ts
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/utils.ts
@@ -94,7 +94,7 @@ export const getTextForCumulativePerSecond = (
     hoveringNodeCumulative,
     unit === 'nanoseconds' ? 'CPU Cores' : unit,
     5
-  )}`;
+  )}/s`;
 };
 
 export const arrowToString = (buffer: any): string | null => {


### PR DESCRIPTION
It has become clear that it's not always easy for users to understand what exactly consumes resources, aka the flat value, compared to the cumulative value of a function and all of its children. 

This PR surfaces the flat value and flat value in cores/s for delta profiles in the UI for icicle graphs. 

![image](https://github.com/parca-dev/parca/assets/872251/c5421802-2b8e-4a7d-af6a-540c5792cfe7)

With this change, it will be clearer that, for this example, the `scanobject` function used a total of 2.64s, including its children. The function itself, without its children, only used 700ms though (which can be seen on the right-hand side of the icicle graph where nothing is below the function itself).