### PR TITLE
Remove the labels metadata call

### DIFF
--- a/pkg/query/columnquery.go
+++ b/pkg/query/columnquery.go
@@ -946,10 +946,7 @@ func getMappingFilesAndLabels(
 		return nil, nil, err
 	}
 
-	labels, err := q.GetProfileMetadataLabels(ctx, startTime, endTime)
-	if err != nil {
-		return nil, nil, err
-	}
+	labels := []string{}
 
 	return mappingFiles, labels, nil
 }

--- a/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/ColorStackLegend.tsx
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/ColorStackLegend.tsx
@@ -19,9 +19,10 @@ import cx from 'classnames';
 import {useURLState} from '@parca/components';
 import {USER_PREFERENCES, useCurrentColorProfile, useUserPreference} from '@parca/hooks';
 import {EVERYTHING_ELSE, selectDarkMode, useAppSelector} from '@parca/store';
-import {getLastItem, type NavigateFunction} from '@parca/utilities';
+import {type NavigateFunction} from '@parca/utilities';
 
 import {getMappingColors} from '.';
+import useMappingList from './useMappingList';
 
 interface Props {
   mappings?: string[];
@@ -46,25 +47,7 @@ const ColorStackLegend = ({
     navigateTo,
   });
 
-  const mappingsList = useMemo(() => {
-    if (mappings === undefined) {
-      return [];
-    }
-    const list =
-      mappings
-        ?.map(mapping => {
-          return getLastItem(mapping) as string;
-        })
-        .flat() ?? [];
-
-    // We add a EVERYTHING ELSE mapping to the list.
-    list.push('');
-
-    // We sort the mappings alphabetically to make sure that the order is always the same.
-    list.sort((a, b) => a.localeCompare(b));
-
-    return list;
-  }, [mappings]);
+  const mappingsList = useMappingList(mappings);
 
   const mappingColors = useMemo(() => {
     const colors = getMappingColors(mappingsList, isDarkMode, currentColorProfile);

--- a/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/ColorStackLegend.tsx
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/ColorStackLegend.tsx
@@ -25,7 +25,7 @@ import {getMappingColors} from '.';
 
 interface Props {
   mappings?: string[];
-  mappingsLoading?: boolean;
+  loading?: boolean;
   navigateTo?: NavigateFunction;
   compareMode?: boolean;
 }
@@ -34,7 +34,7 @@ const ColorStackLegend = ({
   mappings,
   navigateTo,
   compareMode = false,
-  mappingsLoading,
+  loading,
 }: Props): React.JSX.Element => {
   const isDarkMode = useAppSelector(selectDarkMode);
   const currentColorProfile = useCurrentColorProfile();
@@ -83,7 +83,7 @@ const ColorStackLegend = ({
     });
   }, [mappingColors]);
 
-  if (mappingColors === undefined && mappingsLoading === false) {
+  if (stackColorArray.length === 0 && loading === false) {
     return <></>;
   }
 

--- a/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/index.tsx
@@ -72,6 +72,7 @@ interface IcicleGraphArrowProps {
   sortBy: string;
   flamegraphLoading: boolean;
   isHalfScreen: boolean;
+  mappingsListFromMetadata: string[];
 }
 
 export const getMappingColors = (
@@ -99,6 +100,7 @@ export const IcicleGraphArrow = memo(function IcicleGraphArrow({
   navigateTo,
   sortBy,
   flamegraphLoading,
+  mappingsListFromMetadata,
 }: IcicleGraphArrowProps): React.JSX.Element {
   const [isContextMenuOpen, setIsContextMenuOpen] = useState<boolean>(false);
   const dispatch = useAppDispatch();
@@ -126,7 +128,6 @@ export const IcicleGraphArrow = memo(function IcicleGraphArrow({
 
   const currentSearchString = (selectQueryParam('search_string') as string) ?? '';
   const {compareMode} = useProfileViewContext();
-  // const isColorStackLegendEnabled = selectQueryParam('color_stack_legend') === 'true';
   const currentColorProfile = useCurrentColorProfile();
   const colorForSimilarNodes = currentColorProfile.colorForSimilarNodes;
 
@@ -209,7 +210,7 @@ export const IcicleGraphArrow = memo(function IcicleGraphArrow({
     }
 
     // first time hiding a binary
-    const newMappingsList = mappingsList.filter(mapping => mapping !== binaryToRemove);
+    const newMappingsList = mappingsListFromMetadata.filter(mapping => mapping !== binaryToRemove);
     setBinaryFrameFilter(newMappingsList);
   };
 

--- a/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/useMappingList.ts
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/useMappingList.ts
@@ -1,0 +1,42 @@
+// Copyright 2022 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {useMemo} from 'react';
+
+import {getLastItem} from '@parca/utilities';
+
+const useMappingList = (mappings: string[] | undefined): string[] => {
+  const mappingsList = useMemo(() => {
+    if (mappings === undefined) {
+      return [];
+    }
+    const list =
+      mappings
+        ?.map(mapping => {
+          return getLastItem(mapping) as string;
+        })
+        .flat() ?? [];
+
+    // We add a EVERYTHING ELSE mapping to the list.
+    list.push('');
+
+    // We sort the mappings alphabetically to make sure that the order is always the same.
+    list.sort((a, b) => a.localeCompare(b));
+
+    return list;
+  }, [mappings]);
+
+  return mappingsList;
+};
+
+export default useMappingList;

--- a/ui/packages/shared/profile/src/ProfileIcicleGraph/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph/index.tsx
@@ -220,7 +220,6 @@ const ProfileIcicleGraph = function ProfileIcicleGraphNonMemo({
   width,
   isHalfScreen,
   mappings,
-  mappingsLoading,
 }: ProfileIcicleGraphProps): JSX.Element {
   const {onError, authenticationErrorMessage, isDarkMode} = useParcaContext();
   const {compareMode} = useProfileViewContext();
@@ -327,13 +326,16 @@ const ProfileIcicleGraph = function ProfileIcicleGraphNonMemo({
     isLoading,
   ]);
 
+  const loadingState =
+    !loading && (arrow !== undefined || graph !== undefined) && mappings !== undefined;
+
   useEffect(() => {
-    if (!loading && (arrow !== undefined || graph !== undefined)) {
+    if (loadingState) {
       setIsLoading(false);
     } else {
       setIsLoading(true);
     }
-  }, [loading, arrow, graph]);
+  }, [loadingState]);
 
   if (error != null) {
     onError?.(error);
@@ -396,16 +398,16 @@ const ProfileIcicleGraph = function ProfileIcicleGraphNonMemo({
     graph,
     arrow,
     total,
+    loading,
+    width,
     filtered,
     curPath,
     setNewCurPath,
     profileType,
     navigateTo,
-    width,
     storeSortBy,
     isHalfScreen,
     isDarkMode,
-    loading,
   ]);
 
   if (isTrimmed) {
@@ -427,7 +429,7 @@ const ProfileIcicleGraph = function ProfileIcicleGraphNonMemo({
             navigateTo={navigateTo}
             compareMode={compareMode}
             mappings={mappings}
-            mappingsLoading={mappingsLoading}
+            loading={isLoading}
           />
         )}
         <div className="min-h-48" id="h-icicle-graph">

--- a/ui/packages/shared/profile/src/ProfileIcicleGraph/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph/index.tsx
@@ -40,6 +40,7 @@ import SortBySelect from './ActionButtons/SortBySelect';
 import IcicleGraph from './IcicleGraph';
 import IcicleGraphArrow, {FIELD_FUNCTION_NAME} from './IcicleGraphArrow';
 import ColorStackLegend from './IcicleGraphArrow/ColorStackLegend';
+import useMappingList from './IcicleGraphArrow/useMappingList';
 
 const numberFormatter = new Intl.NumberFormat('en-US');
 
@@ -226,6 +227,8 @@ const ProfileIcicleGraph = function ProfileIcicleGraphNonMemo({
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const isColorStackLegendEnabled = selectQueryParam('color_stack_legend') === 'true';
 
+  const mappingsList = useMappingList(mappings);
+
   const [storeSortBy = FIELD_FUNCTION_NAME] = useURLState({
     param: 'sort_by',
     navigateTo,
@@ -391,6 +394,7 @@ const ProfileIcicleGraph = function ProfileIcicleGraphNonMemo({
           sortBy={storeSortBy as string}
           flamegraphLoading={isLoading}
           isHalfScreen={isHalfScreen}
+          mappingsListFromMetadata={mappingsList}
         />
       );
   }, [
@@ -408,6 +412,7 @@ const ProfileIcicleGraph = function ProfileIcicleGraphNonMemo({
     storeSortBy,
     isHalfScreen,
     isDarkMode,
+    mappingsList,
   ]);
 
   if (isTrimmed) {


### PR DESCRIPTION
Temporarily returns the labels metadata call as an empty array.

This PR also contains a fix to ensure that the icicle graph and the legend of binaries are shown together.