### PR TITLE
pkg/debuginfo: Loosen build ID validation

### DIFF
--- a/pkg/debuginfo/store.go
+++ b/pkg/debuginfo/store.go
@@ -15,7 +15,6 @@ package debuginfo
 
 import (
 	"context"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -413,10 +412,6 @@ func (s *Store) uploadIsStale(upload *debuginfopb.DebuginfoUpload) bool {
 }
 
 func validateInput(id string) error {
-	_, err := hex.DecodeString(id)
-	if err != nil {
-		return fmt.Errorf("failed to validate input: %w", err)
-	}
 	if len(id) <= 2 {
 		return errors.New("unexpectedly short input")
 	}


### PR DESCRIPTION
Go build IDs are not necessarily hex.