### PR TITLE
fix(snap): store profiles in SNAP_COMMON by default

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -65,5 +65,5 @@ if [[ -z "$remote_store_token" ]]; then
     snapctl set remote-store-bearer-token=""
 fi
 
-mkdir -p "${SNAP_DATA}/profiles"
+mkdir -p "${SNAP_COMMON}/profiles"
 cp -pnr "${SNAP}/usr/share/parca/example-config.yaml" "${SNAP_DATA}/parca.yaml"

--- a/snap/parca-wrapper
+++ b/snap/parca-wrapper
@@ -62,7 +62,7 @@ else
     if [[ "${storage_persist}" == "true" ]]; then
         opts+=(
             "--enable-persistence=true"
-            "--storage-path=${SNAP_DATA}/profiles"
+            "--storage-path=${SNAP_COMMON}/profiles"
         )
     else
         opts+=(


### PR DESCRIPTION
Until this commit, the default storage location for profiles on disk was in `$SNAP_DATA/profiles`, but as highlighted in both #4708 and in https://snapcraft.io/docs/data-locations, the `$SNAP_DATA` directory is versioned per-revision of the snap, whereas `$SNAP_COMMON` persists across revisions.

This change leaves config in the same location in `$SNAP_DATA`, because versioning config files with revisions might still be desirable.

Existing installs should not be affected, as the default is set on first run.

Fixes #4708