### PR TITLE
area/ui: Fix the source view not scrolling to its line

### DIFF
--- a/ui/packages/shared/profile/src/SourceView/useSelectedLineRange.ts
+++ b/ui/packages/shared/profile/src/SourceView/useSelectedLineRange.ts
@@ -28,6 +28,10 @@ const useLineRange = (): LineRange => {
       return [-1, -1];
     }
     const [start, end] = (sourceLine as string).split('-');
+
+    if (end === undefined) {
+      return [parseInt(start, 10), parseInt(start, 10)];
+    }
     return [parseInt(start, 10), parseInt(end, 10)];
   }, [sourceLine]);
 


### PR DESCRIPTION
Opening the source code viewer from the icicle graph didn’t scroll to the selected line because it only set a start line without an end line. This caused the scrolling issue. 

The problem is now fixed by setting the end line equal to the start line if the end can’t be determined.