### PR TITLE
ui/shared/profile: Don't show cores/s values

### DIFF
--- a/ui/packages/shared/profile/src/GraphTooltipArrow/Content.tsx
+++ b/ui/packages/shared/profile/src/GraphTooltipArrow/Content.tsx
@@ -33,6 +33,7 @@ interface GraphTooltipArrowContentProps {
   row: number | null;
   level: number;
   isFixed: boolean;
+  compareAbsolute: boolean;
 }
 
 const NoData = (): React.JSX.Element => {
@@ -48,6 +49,7 @@ const GraphTooltipArrowContent = ({
   row,
   level,
   isFixed,
+  compareAbsolute,
 }: GraphTooltipArrowContentProps): React.JSX.Element => {
   const graphTooltipData = useGraphTooltip({
     table,
@@ -57,6 +59,7 @@ const GraphTooltipArrowContent = ({
     totalUnfiltered,
     row,
     level,
+    compareAbsolute,
   });
 
   if (graphTooltipData === null) {
@@ -67,9 +70,7 @@ const GraphTooltipArrowContent = ({
     name,
     locationAddress,
     cumulativeText,
-    cumulativePerSecondText,
     flatText,
-    flatPerSecondText,
     diffText,
     diff,
     row: rowNumber,
@@ -102,32 +103,12 @@ const GraphTooltipArrowContent = ({
                       <div>{cumulativeText}</div>
                     </td>
                   </tr>
-                  {profileType?.delta ?? false ? (
-                    <tr>
-                      <td className="w-1/4"></td>
-                      <td className="w-3/4">
-                        <div>{cumulativePerSecondText}</div>
-                      </td>
-                    </tr>
-                  ) : (
-                    <></>
-                  )}
                   <tr>
                     <td className="w-1/4 pt-2">Flat</td>
                     <td className="w-3/4 pt-2">
                       <div>{flatText}</div>
                     </td>
                   </tr>
-                  {profileType?.delta ?? false ? (
-                    <tr>
-                      <td className="w-1/4"></td>
-                      <td className="w-3/4">
-                        <div>{flatPerSecondText}</div>
-                      </td>
-                    </tr>
-                  ) : (
-                    <></>
-                  )}
                   {diff !== 0n && (
                     <tr>
                       <td className="w-1/4 pt-2">Diff</td>

--- a/ui/packages/shared/profile/src/GraphTooltipArrow/DockedGraphTooltip/index.tsx
+++ b/ui/packages/shared/profile/src/GraphTooltipArrow/DockedGraphTooltip/index.tsx
@@ -32,6 +32,7 @@ interface Props {
   level: number;
   profileType?: ProfileType;
   unit?: string;
+  compareAbsolute: boolean;
 }
 
 const InfoSection = ({
@@ -63,6 +64,7 @@ export const DockedGraphTooltip = ({
   level,
   profileType,
   unit,
+  compareAbsolute,
 }: Props): JSX.Element => {
   let {width} = useWindowSize();
   const {profileExplorer} = useParcaContext();
@@ -77,6 +79,7 @@ export const DockedGraphTooltip = ({
     totalUnfiltered,
     row,
     level,
+    compareAbsolute,
   });
 
   const {
@@ -93,15 +96,7 @@ export const DockedGraphTooltip = ({
     return <></>;
   }
 
-  const {
-    name,
-    cumulativeText,
-    cumulativePerSecondText,
-    flatText,
-    flatPerSecondText,
-    diffText,
-    diff,
-  } = graphTooltipData;
+  const {name, cumulativeText, flatText, diffText, diff} = graphTooltipData;
 
   const labels = labelPairs.map(
     (l): React.JSX.Element => (
@@ -118,9 +113,6 @@ export const DockedGraphTooltip = ({
   const inlinedText = inlined === null ? 'merged' : inlined ? 'yes' : 'no';
   const addressText = locationAddress !== 0n ? hexifyAddress(locationAddress) : <NoData />;
 
-  const cumulativeTextBoth = `${cumulativeText}\n${cumulativePerSecondText}`;
-  const flatTextBoth = `${flatText}\n${flatPerSecondText}`;
-
   return (
     <div
       className="fixed bottom-0 z-20 overflow-hidden rounded-t-lg border-l border-r border-t border-gray-400 bg-white bg-opacity-90 px-8 py-3 dark:border-gray-600 dark:bg-black dark:bg-opacity-80"
@@ -135,14 +127,14 @@ export const DockedGraphTooltip = ({
               {name !== ''
                 ? name
                 : locationAddress !== 0n
-                ? hexifyAddress(locationAddress)
-                : 'unknown'}
+                  ? hexifyAddress(locationAddress)
+                  : 'unknown'}
             </p>
           )}
         </div>
         <div className="flex justify-between gap-3">
-          <InfoSection title="Cumulative" value={cumulativeTextBoth} minWidth="w-44" />
-          <InfoSection title="Flat" value={flatTextBoth} minWidth="w-44" />
+          <InfoSection title="Cumulative" value={cumulativeText} minWidth="w-44" />
+          <InfoSection title="Flat" value={flatText} minWidth="w-44" />
           {diff !== 0n ? <InfoSection title="Diff" value={diffText} minWidth="w-44" /> : null}
           <InfoSection
             title="File"

--- a/ui/packages/shared/profile/src/GraphTooltipArrow/DockedGraphTooltip/index.tsx
+++ b/ui/packages/shared/profile/src/GraphTooltipArrow/DockedGraphTooltip/index.tsx
@@ -127,8 +127,8 @@ export const DockedGraphTooltip = ({
               {name !== ''
                 ? name
                 : locationAddress !== 0n
-                  ? hexifyAddress(locationAddress)
-                  : 'unknown'}
+                ? hexifyAddress(locationAddress)
+                : 'unknown'}
             </p>
           )}
         </div>

--- a/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/ContextMenu.tsx
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/ContextMenu.tsx
@@ -111,10 +111,10 @@ const ContextMenu = ({
     row === 0
       ? ''
       : name !== ''
-        ? name
-        : locationAddress !== 0n
-          ? hexifyAddress(locationAddress)
-          : '';
+      ? name
+      : locationAddress !== 0n
+      ? hexifyAddress(locationAddress)
+      : '';
 
   const buildIdText = !isMappingBuildIDAvailable ? '' : mappingBuildID;
   const inlinedText = inlined === null ? 'merged' : inlined ? 'yes' : 'no';

--- a/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/ContextMenu.tsx
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/ContextMenu.tsx
@@ -34,6 +34,7 @@ interface ContextMenuProps {
   totalUnfiltered: bigint;
   row: number;
   level: number;
+  compareAbsolute: boolean;
   trackVisibility: (isVisible: boolean) => void;
   curPath: string[];
   setCurPath: (path: string[]) => void;
@@ -48,6 +49,7 @@ const ContextMenu = ({
   totalUnfiltered,
   row,
   level,
+  compareAbsolute,
   trackVisibility,
   curPath,
   setCurPath,
@@ -69,6 +71,7 @@ const ContextMenu = ({
     totalUnfiltered,
     row,
     level,
+    compareAbsolute,
   });
 
   const {
@@ -108,10 +111,10 @@ const ContextMenu = ({
     row === 0
       ? ''
       : name !== ''
-      ? name
-      : locationAddress !== 0n
-      ? hexifyAddress(locationAddress)
-      : '';
+        ? name
+        : locationAddress !== 0n
+          ? hexifyAddress(locationAddress)
+          : '';
 
   const buildIdText = !isMappingBuildIDAvailable ? '' : mappingBuildID;
   const inlinedText = inlined === null ? 'merged' : inlined ? 'yes' : 'no';

--- a/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/IcicleGraphNodes.tsx
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/IcicleGraphNodes.tsx
@@ -26,9 +26,7 @@ import {ProfileType} from '@parca/parser';
 import {
   FIELD_CHILDREN,
   FIELD_CUMULATIVE,
-  FIELD_CUMULATIVE_PER_SECOND,
   FIELD_DIFF,
-  FIELD_DIFF_PER_SECOND,
   FIELD_FUNCTION_NAME,
   FIELD_MAPPING_FILE,
 } from './index';
@@ -224,18 +222,12 @@ export const IcicleNode = React.memo(function IcicleNodeNoMemo({
   const mappingColumn = table.getChild(FIELD_MAPPING_FILE);
   const functionNameColumn = table.getChild(FIELD_FUNCTION_NAME);
   const cumulativeColumn = table.getChild(FIELD_CUMULATIVE);
-  const cumulativePerSecondColumn = table.getChild(FIELD_CUMULATIVE_PER_SECOND);
   const diffColumn = table.getChild(FIELD_DIFF);
-  const diffPerSecondColumn = table.getChild(FIELD_DIFF_PER_SECOND);
   // get the actual values from the columns
   const mappingFile: string | null = arrowToString(mappingColumn?.get(row));
   const functionName: string | null = arrowToString(functionNameColumn?.get(row));
   const cumulative = cumulativeColumn?.get(row) !== null ? BigInt(cumulativeColumn?.get(row)) : 0n;
-  const cumulativePerSecond: number | null =
-    cumulativePerSecondColumn?.get(row) != null ? cumulativePerSecondColumn.get(row) : 0;
   const diff: bigint | null = diffColumn?.get(row) !== null ? BigInt(diffColumn?.get(row)) : null;
-  const diffPerSecond: number | null =
-    diffPerSecondColumn?.get(row) != null ? diffPerSecondColumn.get(row) : null;
   const childRows: number[] = Array.from(table.getChild(FIELD_CHILDREN)?.get(row) ?? []);
 
   const highlightedNodes = useMemo(() => {
@@ -274,15 +266,6 @@ export const IcicleNode = React.memo(function IcicleNodeNoMemo({
       });
       break;
     case FIELD_CUMULATIVE:
-      if (profileType?.delta ?? false) {
-        childRows.sort((a, b) => {
-          const aCumulativePerSecond = cumulativePerSecondColumn?.get(a);
-          const bCumulativePerSecond = cumulativePerSecondColumn?.get(b);
-          return bCumulativePerSecond - aCumulativePerSecond;
-        });
-        break;
-      }
-
       childRows.sort((a, b) => {
         const aCumulative: bigint = cumulativeColumn?.get(a);
         const bCumulative: bigint = cumulativeColumn?.get(b);
@@ -291,48 +274,22 @@ export const IcicleNode = React.memo(function IcicleNodeNoMemo({
       break;
     case FIELD_DIFF:
       childRows.sort((a, b) => {
-        if (profileType?.delta ?? false) {
-          let aRatio: number | null = null;
-          let bRatio: number | null = null;
-
-          const aDiff: number | null = diffPerSecondColumn?.get(a);
-          if (aDiff !== null) {
-            const cumulative: number = cumulativePerSecondColumn?.get(a);
-            const prev = cumulative - aDiff;
-            aRatio = aDiff / prev;
-          }
-
-          const bDiff: number | null = diffPerSecondColumn?.get(b);
-          if (bDiff !== null) {
-            const cumulative: number = cumulativePerSecondColumn?.get(b);
-            const prev = cumulative - bDiff;
-            bRatio = bDiff / prev;
-          }
-
-          if (aRatio !== null && bRatio !== null) {
-            return bRatio - aRatio;
-          }
-          if (aRatio === null && bRatio !== null) {
-            return -1;
-          }
-          if (aRatio !== null && bRatio === null) {
-            return 1;
-          }
-          // both are null
-          return 0;
-        }
-
         let aRatio: number | null = null;
-        const aDiff: bigint | null = diffColumn?.get(a);
+        const aDiff: bigint | null =
+          diffColumn?.get(a) !== null ? BigInt(diffColumn?.get(a)) : null;
         if (aDiff !== null) {
-          const cumulative: bigint = cumulativeColumn?.get(a) ?? 0n;
+          const cumulative: bigint =
+            cumulativeColumn?.get(a) !== null ? BigInt(cumulativeColumn?.get(a)) : 0n;
+          console.log(typeof cumulative, typeof aDiff);
           const prev: bigint = cumulative - aDiff;
           aRatio = Number(aDiff) / Number(prev);
         }
         let bRatio: number | null = null;
-        const bDiff: bigint | null = diffColumn?.get(b);
+        const bDiff: bigint | null =
+          diffColumn?.get(b) !== null ? BigInt(diffColumn?.get(b)) : null;
         if (bDiff !== null) {
-          const cumulative: bigint = cumulativeColumn?.get(b) ?? 0n;
+          const cumulative: bigint =
+            cumulativeColumn?.get(b) !== null ? BigInt(cumulativeColumn?.get(b)) : 0n;
           const prev: bigint = cumulative - bDiff;
           bRatio = Number(bDiff) / Number(prev);
         }
@@ -357,9 +314,7 @@ export const IcicleNode = React.memo(function IcicleNodeNoMemo({
     isDarkMode: darkMode,
     compareMode,
     cumulative,
-    cumulativePerSecond,
     diff,
-    diffPerSecond,
     mappingColors,
     mappingFile,
   });

--- a/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/index.tsx
@@ -50,11 +50,8 @@ export const FIELD_FUNCTION_START_LINE = 'function_startline';
 export const FIELD_CHILDREN = 'children';
 export const FIELD_LABELS = 'labels';
 export const FIELD_CUMULATIVE = 'cumulative';
-export const FIELD_CUMULATIVE_PER_SECOND = 'cumulative_per_second';
 export const FIELD_FLAT = 'flat';
-export const FIELD_FLAT_PER_SECOND = 'flat_per_second';
 export const FIELD_DIFF = 'diff';
-export const FIELD_DIFF_PER_SECOND = 'diff_per_second';
 
 interface IcicleGraphArrowProps {
   arrow: FlamegraphArrow;
@@ -68,6 +65,7 @@ interface IcicleGraphArrowProps {
   flamegraphLoading: boolean;
   isHalfScreen: boolean;
   mappingsListFromMetadata: string[];
+  compareAbsolute: boolean;
 }
 
 export const getMappingColors = (
@@ -97,6 +95,7 @@ export const IcicleGraphArrow = memo(function IcicleGraphArrow({
   sortBy,
   flamegraphLoading,
   mappingsListFromMetadata,
+  compareAbsolute,
 }: IcicleGraphArrowProps): React.JSX.Element {
   const [isContextMenuOpen, setIsContextMenuOpen] = useState<boolean>(false);
   const dispatch = useAppDispatch();
@@ -330,6 +329,7 @@ export const IcicleGraphArrow = memo(function IcicleGraphArrow({
                 totalUnfiltered={total + filtered}
                 profileType={profileType}
                 unit={arrow.unit}
+                compareAbsolute={compareAbsolute}
               />
             </GraphTooltipArrow>
           )

--- a/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/index.tsx
@@ -300,6 +300,7 @@ export const IcicleGraphArrow = memo(function IcicleGraphArrow({
           total={total}
           totalUnfiltered={total + filtered}
           profileType={profileType}
+          compareAbsolute={compareAbsolute}
           trackVisibility={trackVisibility}
           curPath={curPath}
           setCurPath={setCurPath}
@@ -316,6 +317,7 @@ export const IcicleGraphArrow = memo(function IcicleGraphArrow({
             totalUnfiltered={total + filtered}
             profileType={profileType}
             unit={arrow.unit}
+            compareAbsolute={compareAbsolute}
           />
         ) : (
           !isContextMenuOpen && (

--- a/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/useNodeColor.ts
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/useNodeColor.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import {EVERYTHING_ELSE} from '@parca/store';
-import {diffColor, diffColorPerSecond, getLastItem} from '@parca/utilities';
+import {diffColor, getLastItem} from '@parca/utilities';
 
 interface mappingColors {
   [key: string]: string;
@@ -22,9 +22,7 @@ interface Props {
   isDarkMode: boolean;
   compareMode: boolean;
   cumulative: bigint;
-  cumulativePerSecond: number | null;
   diff: bigint | null;
-  diffPerSecond: number | null;
   mappingColors: mappingColors;
   mappingFile: string | null;
 }
@@ -33,17 +31,11 @@ const useNodeColor = ({
   isDarkMode,
   compareMode,
   cumulative,
-  cumulativePerSecond,
   diff,
-  diffPerSecond,
   mappingColors,
   mappingFile,
 }: Props): string => {
   if (compareMode) {
-    if (cumulativePerSecond !== null && diffPerSecond !== null) {
-      return diffColorPerSecond(diffPerSecond, cumulativePerSecond, isDarkMode);
-    }
-
     return diffColor(diff ?? 0n, cumulative, isDarkMode);
   }
 

--- a/ui/packages/shared/profile/src/ProfileIcicleGraph/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph/index.tsx
@@ -368,6 +368,7 @@ const ProfileIcicleGraph = function ProfileIcicleGraphNonMemo({
           flamegraphLoading={isLoading}
           isHalfScreen={isHalfScreen}
           mappingsListFromMetadata={mappingsList}
+          compareAbsolute={isCompareAbsolute}
         />
       );
   }, [
@@ -385,6 +386,7 @@ const ProfileIcicleGraph = function ProfileIcicleGraphNonMemo({
     isHalfScreen,
     isDarkMode,
     mappingsList,
+    isCompareAbsolute,
   ]);
 
   if (error != null) {

--- a/ui/packages/shared/utilities/src/index.ts
+++ b/ui/packages/shared/utilities/src/index.ts
@@ -326,18 +326,6 @@ export const diffColor = (diff: bigint, cumulative: bigint, isDarkMode: boolean)
   return diffColorRatio(hasDiff, diffRatio, isDarkMode);
 };
 
-export const diffColorPerSecond = (
-  diff: number,
-  cumulative: number,
-  isDarkMode: boolean
-): string => {
-  const prevValue = cumulative - diff;
-  const diffRatio = prevValue > 0 ? (diff !== 0 ? diff / prevValue : 0) : 1.0;
-  const hasDiff = Math.abs(diffRatio) > DIFF_RATIO_THRESHOLD;
-
-  return diffColorRatio(hasDiff, diffRatio, isDarkMode);
-};
-
 const diffColorRatio = (hasDiff: boolean, diffRatio: number, isDarkMode: boolean): string => {
   const diffTransparency = hasDiff ? Math.min((Math.abs(diffRatio) / 2 + 0.5) * 0.8, 0.8) : 0;
 
@@ -348,8 +336,8 @@ const diffColorRatio = (hasDiff: boolean, diffRatio: number, isDarkMode: boolean
   const color: string = !hasDiff
     ? newSpanColor
     : diffRatio > 0
-    ? increasedSpanColor
-    : reducedSpanColor;
+      ? increasedSpanColor
+      : reducedSpanColor;
 
   return color;
 };

--- a/ui/packages/shared/utilities/src/index.ts
+++ b/ui/packages/shared/utilities/src/index.ts
@@ -336,8 +336,8 @@ const diffColorRatio = (hasDiff: boolean, diffRatio: number, isDarkMode: boolean
   const color: string = !hasDiff
     ? newSpanColor
     : diffRatio > 0
-      ? increasedSpanColor
-      : reducedSpanColor;
+    ? increasedSpanColor
+    : reducedSpanColor;
 
   return color;
 };


### PR DESCRIPTION
The cores/s values were introduced to make profiles more comparable. With the introduction of relative comparisons, however, there is really no need for cores/s anymore.

For relative comparisons, we only show the difference as percentage, as the raw values are skewed by the scaling.
