### PR TITLE
bug fix: Clicking on a sample should highlight it when there are query filters and sum by values

### DIFF
--- a/ui/packages/shared/profile/src/ProfileMetricsGraph/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileMetricsGraph/index.tsx
@@ -238,6 +238,7 @@ const ProfileMetricsGraph = ({
             height={height}
             width={width}
             margin={margin}
+            sumBy={sumBy}
           />
         ) : (
           <ProfileMetricsEmptyState message="No data found. Try a different query." />


### PR DESCRIPTION
When profiling data is filtered with both matchers and sumBy value(s), selecting a profile in the metrics graph fails to highlight the point.

Steps to reproduce:
1. Go to demo.parca.dev/devel
2. Filter profiles (e.g., container="parca-agent")
3. Add a sumBy value (e.g., "comm")
4. Attempt to select a profile in the metrics graph

This is happening because the `findSelectedProfile` function uses label matchers from the query expression to determine 
the selected series. With sumBy, series are limited to the sumBy value, causing the function to fail as it looks for non-existent label sets.

The fix here ensures that we are correctly identifying the selected series based on the profile matchers alone or a combination of the profile matchers and the sumBy value (and prioritizing the sumBy label names and values if present).