### PR TITLE
area/ui: use TextDecoder to decode Arrow table into a string format

### DIFF
--- a/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/utils.ts
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/utils.ts
@@ -102,7 +102,7 @@ export const arrowToString = (buffer: any): string | null => {
     return buffer;
   }
   if (ArrayBuffer.isView(buffer)) {
-    return String.fromCharCode.apply(null, buffer as unknown as number[]);
+    return new TextDecoder().decode(buffer);
   }
   return '';
 };


### PR DESCRIPTION
Using `String.fromCharCode.apply(null, buffer as unknown as number[])` is causing a "Maximum call stack size exceeded" error, especially with large amount of arrow data.

Using `TextDecoder`  instead of `String.fromCharCode` handles large arrays more efficiently.