### PR TITLE
Fix resovling wrong symbol when symbol table is not continous

### DIFF
--- a/pkg/symbol/addr2line/symtab_test.go
+++ b/pkg/symbol/addr2line/symtab_test.go
@@ -176,16 +176,7 @@ func TestSymtabLiner_PCToLines(t *testing.T) {
 			args: args{
 				addr: 30,
 			},
-			wantLines: []profile.LocationLine{
-				{
-					Function: &metastorev1alpha1.Function{
-						Name:       "baz",
-						SystemName: "baz",
-						Filename:   "?",
-					},
-					Line: 0,
-				},
-			},
+			wantErr: true,
 		},
 		{
 			name: "C++ symbols are demangled",

--- a/pkg/symbol/symbolsearcher/symbol_searcher.go
+++ b/pkg/symbol/symbolsearcher/symbol_searcher.go
@@ -57,6 +57,9 @@ func (s Searcher) Search(addr uint64) (string, error) {
 
 	// sym[i-1] <= addr < sym[i]
 	i--
+	if addr >= s.symbols[i].Value+s.symbols[i].Size {
+		return "", errors.New("failed to find symbol for address")
+	}
 	return s.symbols[i].Name, nil
 }
 


### PR DESCRIPTION
Check the size of symbol before return to avoid resovling wrong symbol.