### PR TITLE
ui/packages/shared/profile: Fix DiffProfileSource matchers call

### DIFF
--- a/ui/packages/shared/profile/src/ProfileSource.tsx
+++ b/ui/packages/shared/profile/src/ProfileSource.tsx
@@ -175,7 +175,7 @@ export class ProfileDiffSource implements ProfileSource {
   Matchers(): string[] {
     // Currently, this only returns the matchers of the base profile.
     // For the most part this should be acceptable. But it might not cover the full picture.
-    return this.a.Matchers()
+    return this.a.Matchers();
   }
 
   Describe(): JSX.Element {

--- a/ui/packages/shared/profile/src/ProfileSource.tsx
+++ b/ui/packages/shared/profile/src/ProfileSource.tsx
@@ -26,6 +26,7 @@ export interface ProfileSource {
   QueryRequest: () => QueryRequest;
   ProfileType: () => ProfileType;
   DiffSelection: () => ProfileDiffSelection;
+  Matchers: () => string[];
   toString: (timezone?: string) => string;
 }
 
@@ -171,6 +172,12 @@ export class ProfileDiffSource implements ProfileSource {
     return this.profileType;
   }
 
+  Matchers(): string[] {
+    // Currently, this only returns the matchers of the base profile.
+    // For the most part this should be acceptable. But it might not cover the full picture.
+    return this.a.Matchers()
+  }
+
   Describe(): JSX.Element {
     return (
       <>
@@ -241,10 +248,10 @@ export class MergedProfileSource implements ProfileSource {
     return this.profileType;
   }
 
-  stringMatchers(): string[] {
+  Matchers(): string[] {
     return this.query.matchers
       .filter((m: Matcher) => m.key !== '__name__')
-      .map((m: Matcher) => `${m.key}=${m.value}`);
+      .map((m: Matcher) => `${m.key}${m.matcherType}"${m.value}"`);
   }
 
   toString(timezone?: string): string {

--- a/ui/packages/shared/profile/src/ProfileViewWithData.tsx
+++ b/ui/packages/shared/profile/src/ProfileViewWithData.tsx
@@ -82,7 +82,7 @@ export const ProfileViewWithData = ({
     profileSource.ProfileType().toString(),
     undefined,
     undefined,
-    profileSource.Matchers(),
+    profileSource.Matchers()
   );
 
   const {isLoading: profilemetadataLoading, response: profilemetadataResponse} = useQuery(

--- a/ui/packages/shared/profile/src/ProfileViewWithData.tsx
+++ b/ui/packages/shared/profile/src/ProfileViewWithData.tsx
@@ -19,7 +19,7 @@ import {saveAsBlob} from '@parca/utilities';
 
 import {useLabelNames} from './MatchersInput';
 import {FIELD_FUNCTION_NAME} from './ProfileIcicleGraph/IcicleGraphArrow';
-import {MergedProfileSource, ProfileSource} from './ProfileSource';
+import {ProfileSource} from './ProfileSource';
 import {ProfileView} from './ProfileView';
 import {useQuery} from './useQuery';
 import {downloadPprof} from './utils';
@@ -77,17 +77,12 @@ export const ProfileViewWithData = ({
     binaryFrameFilter,
   });
 
-  const mergedProfileSource = profileSource as MergedProfileSource;
-  const matchers = mergedProfileSource.query.matchers.map(
-    m => `${m.key}${m.matcherType}"${m.value}"`
-  );
-
   const {result: profileLabelsResponse} = useLabelNames(
     queryClient,
     profileSource.ProfileType().toString(),
     undefined,
     undefined,
-    matchers
+    profileSource.Matchers(),
   );
 
   const {isLoading: profilemetadataLoading, response: profilemetadataResponse} = useQuery(


### PR DESCRIPTION
Whenever the `profileSource` isn't a `MergedProfileSource` the `profileSource` becomes undefined. Therefore it errors:
```
Uncaught TypeError: Cannot read properties of undefined (reading 'matchers')
```

Adding a `Matchers()` to the interface that both `MergedProfileSource` and `DiffProfileSource` implement fixes this problem. 
The matchers are then used to pass them to the `Labels` API query that retrieves all labels to group by.
