### PR TITLE
area/ui: Ensure all dates are in UTC

### DIFF
--- a/ui/packages/shared/components/src/DateTimeRangePicker/utils.ts
+++ b/ui/packages/shared/components/src/DateTimeRangePicker/utils.ts
@@ -172,8 +172,9 @@ export class DateTimeRange {
     }
     const formattedFrom = formatDateStringForUI(this.from);
     const formattedTo = formatDateStringForUI(this.to)
-      .replace(getUtcStringForDate(this.from as AbsoluteDate, 'll'), '')
+      .replace(getUtcStringForDate(this.from as AbsoluteDate, 'YYYY-MM-DD'), '')
       .trim();
+
     return `${formattedFrom} → ${formattedTo}`;
   }
 
@@ -336,7 +337,7 @@ const getRelativeDateMs = (date: RelativeDate): number => {
   }
 };
 
-export const getUtcStringForDate = (date: AbsoluteDate, format = 'lll'): string => {
+export const getUtcStringForDate = (date: AbsoluteDate, format = 'YYYY-MM-DD HH:mm:ss'): string => {
   return moment
     .tz(date.getTime().toISOString(), Intl.DateTimeFormat().resolvedOptions().timeZone)
     .utc()
@@ -346,7 +347,7 @@ export const getUtcStringForDate = (date: AbsoluteDate, format = 'lll'): string 
 export const getStringForDateInTimezone = (
   date: AbsoluteDate,
   timezone: string,
-  format = 'lll'
+  format = 'YYYY-MM-DD HH:mm:ss'
 ): string => {
   return moment.tz(date.getTime().toISOString(), timezone).format(format);
 };


### PR DESCRIPTION
We should be displaying all date and time in the UTC 24H format.
![image](https://github.com/user-attachments/assets/7135ed75-f9bd-41e0-b857-405279386244)

Replaces all usage of `lll` with `YYYY-MM-DD HH:mm:ss` as `lll` formats the date to be "Mar 20, 2024 11:30 AM" for example.
<img width="335" alt="image" src="https://github.com/user-attachments/assets/b484a3e1-ad21-4ea4-8436-340869886720">
