### PR TITLE
area/ui: Fix bug of disappearing matchers

### DIFF
--- a/ui/packages/shared/profile/src/ProfileExplorer/ProfileExplorerCompare.tsx
+++ b/ui/packages/shared/profile/src/ProfileExplorer/ProfileExplorerCompare.tsx
@@ -51,7 +51,6 @@ const ProfileExplorerCompare = ({
   navigateTo,
 }: ProfileExplorerCompareProps): JSX.Element => {
   const [showMetricsGraph, setShowMetricsGraph] = useState(true);
-  const [showButton, setShowButton] = useState(false);
 
   const closeProfileA = (): void => {
     closeProfile('A');
@@ -66,17 +65,7 @@ const ProfileExplorerCompare = ({
 
   return (
     <>
-      <div
-        className="flex justify-between gap-2 relative mb-2"
-        onMouseEnter={() => {
-          if (!showMetricsGraph) return;
-          setShowButton(true);
-        }}
-        onMouseLeave={() => {
-          if (!showMetricsGraph) return;
-          setShowButton(false);
-        }}
-      >
+      <div className="flex justify-between gap-2 relative mb-2">
         <div className="flex-column flex-1 p-2 shadow-md rounded-md">
           <ProfileSelector
             queryClient={queryClient}
@@ -90,7 +79,6 @@ const ProfileExplorerCompare = ({
             navigateTo={navigateTo}
             suffix="_a"
             showMetricsGraph={showMetricsGraph}
-            displayHideMetricsGraphButton={showButton}
             setDisplayHideMetricsGraphButton={setShowMetricsGraph}
           />
         </div>
@@ -107,7 +95,6 @@ const ProfileExplorerCompare = ({
             navigateTo={navigateTo}
             suffix="_b"
             showMetricsGraph={showMetricsGraph}
-            displayHideMetricsGraphButton={showButton}
             setDisplayHideMetricsGraphButton={setShowMetricsGraph}
           />
         </div>

--- a/ui/packages/shared/profile/src/ProfileExplorer/ProfileExplorerSingle.tsx
+++ b/ui/packages/shared/profile/src/ProfileExplorer/ProfileExplorerSingle.tsx
@@ -37,21 +37,10 @@ const ProfileExplorerSingle = ({
   navigateTo,
 }: ProfileExplorerSingleProps): JSX.Element => {
   const [showMetricsGraph, setShowMetricsGraph] = useState(true);
-  const [showButton, setShowButton] = useState(false);
 
   return (
     <>
-      <div
-        className="relative"
-        onMouseEnter={() => {
-          if (!showMetricsGraph) return;
-          setShowButton(true);
-        }}
-        onMouseLeave={() => {
-          if (!showMetricsGraph) return;
-          setShowButton(false);
-        }}
-      >
+      <div className="relative">
         <ProfileSelector
           queryClient={queryClient}
           querySelection={query}
@@ -64,7 +53,6 @@ const ProfileExplorerSingle = ({
           navigateTo={navigateTo}
           suffix="_a"
           showMetricsGraph={showMetricsGraph}
-          displayHideMetricsGraphButton={showButton}
           setDisplayHideMetricsGraphButton={setShowMetricsGraph}
         />
       </div>

--- a/ui/packages/shared/profile/src/ProfileSelector/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileSelector/index.tsx
@@ -65,7 +65,6 @@ interface ProfileSelectorProps {
   navigateTo: NavigateFunction;
   suffix?: string;
   showMetricsGraph: boolean;
-  displayHideMetricsGraphButton: boolean;
   setDisplayHideMetricsGraphButton: Dispatch<SetStateAction<boolean>>;
 }
 
@@ -106,7 +105,6 @@ const ProfileSelector = ({
   comparing,
   navigateTo,
   showMetricsGraph,
-  displayHideMetricsGraphButton,
   setDisplayHideMetricsGraphButton,
 }: ProfileSelectorProps): JSX.Element => {
   const {
@@ -444,7 +442,7 @@ const ProfileSelector = ({
           onClick={() => setDisplayHideMetricsGraphButton(!showMetricsGraph)}
           className={cx(
             'hidden z-10 px-3 py-1 text-sm font-medium text-gray-700 dark:text-gray-200 bg-gray-100 rounded-md hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:bg-gray-900',
-            displayHideMetricsGraphButton && showMetricsGraph && 'absolute right-0 bottom-3 !flex',
+            showMetricsGraph && 'absolute right-0 bottom-3 !flex',
             !showMetricsGraph && 'relative !flex ml-auto'
           )}
         >

--- a/ui/packages/shared/profile/src/SimpleMatchers/Select.tsx
+++ b/ui/packages/shared/profile/src/SimpleMatchers/Select.tsx
@@ -70,7 +70,7 @@ const CustomSelect: React.FC<CustomSelectProps> = ({
   const [searchTerm, setSearchTerm] = useState('');
   const containerRef = useRef<HTMLDivElement>(null);
   const optionsRef = useRef<HTMLDivElement>(null);
-  const searchInputRef = useRef<HTMLInputElement>(null);
+  const searchInputRef = useRef<HTMLInputElement | HTMLTextAreaElement>(null);
   const optionRefs = useRef<Array<HTMLElement | null>>([]);
 
   const filteredItems = searchable
@@ -208,21 +208,36 @@ const CustomSelect: React.FC<CustomSelectProps> = ({
           role="listbox"
         >
           {searchable && (
-            <div className="sticky h-[45px] z-10 top-[-5px] border-b border-gray-200">
+            <div
+              className={cx(
+                'sticky z-10 top-[-5px] border-b border-gray-200 w-auto max-w-full',
+                editable ? 'h-full min-h-[50px]' : 'h-[45px]'
+              )}
+            >
               <div className="relative h-full">
-                <input
-                  ref={searchInputRef}
-                  type="text"
-                  className="w-full px-4 h-full text-sm border-none rounded-none ring-0 outline-none bg-gray-50 dark:bg-gray-800 dark:text-white"
-                  placeholder={editable ? 'Type a RegEx to add' : 'Search...'}
-                  value={searchTerm}
-                  onChange={e => setSearchTerm(e.target.value)}
-                />
+                {editable ? (
+                  <textarea
+                    ref={searchInputRef as React.LegacyRef<HTMLTextAreaElement>}
+                    className="w-full px-4 h-full text-sm border-none rounded-none ring-0 outline-none bg-gray-50 dark:bg-gray-800 dark:text-white"
+                    placeholder={editable ? 'Type a RegEx to add' : 'Search...'}
+                    value={searchTerm}
+                    onChange={e => setSearchTerm(e.target.value)}
+                  />
+                ) : (
+                  <input
+                    ref={searchInputRef as React.LegacyRef<HTMLInputElement>}
+                    type="text"
+                    className="w-full px-4 h-full text-sm border-none rounded-none ring-0 outline-none bg-gray-50 dark:bg-gray-800 dark:text-white"
+                    placeholder={editable ? 'Type a RegEx to add' : 'Search...'}
+                    value={searchTerm}
+                    onChange={e => setSearchTerm(e.target.value)}
+                  />
+                )}
 
                 {editable && searchTerm.length > 0 && (
                   <Button
                     variant="neutral"
-                    className="absolute top-[7px] right-[6px] h-[30px]"
+                    className="absolute bottom-[2px] right-[10px] h-[30px]"
                     onClick={() => {
                       onSelection(searchTerm);
                       setIsOpen(false);

--- a/ui/packages/shared/profile/src/SimpleMatchers/Select.tsx
+++ b/ui/packages/shared/profile/src/SimpleMatchers/Select.tsx
@@ -208,17 +208,12 @@ const CustomSelect: React.FC<CustomSelectProps> = ({
           role="listbox"
         >
           {searchable && (
-            <div
-              className={cx(
-                'sticky z-10 top-[-5px] border-b border-gray-200 w-auto max-w-full',
-                editable ? 'h-full min-h-[50px]' : 'h-[45px]'
-              )}
-            >
-              <div className="relative h-full">
+            <div className="sticky z-10 top-[-5px] w-auto max-w-full">
+              <div className={cx('relative h-full', editable ? 'h-full min-h-[50px]' : 'h-[45px]')}>
                 {editable ? (
                   <textarea
                     ref={searchInputRef as React.LegacyRef<HTMLTextAreaElement>}
-                    className="w-full px-4 h-full text-sm border-none rounded-none ring-0 outline-none bg-gray-50 dark:bg-gray-800 dark:text-white"
+                    className="w-full px-4 py-2 h-full text-sm border-b border-gray-200 rounded-none ring-0 outline-none bg-gray-50 dark:bg-gray-800 dark:text-white"
                     placeholder={editable ? 'Type a RegEx to add' : 'Search...'}
                     value={searchTerm}
                     onChange={e => setSearchTerm(e.target.value)}
@@ -237,7 +232,7 @@ const CustomSelect: React.FC<CustomSelectProps> = ({
                 {editable && searchTerm.length > 0 && (
                   <Button
                     variant="neutral"
-                    className="absolute bottom-[2px] right-[10px] h-[30px]"
+                    className="absolute bottom-[10px] right-[10px] h-[30px]"
                     onClick={() => {
                       onSelection(searchTerm);
                       setIsOpen(false);

--- a/ui/packages/shared/profile/src/SimpleMatchers/index.tsx
+++ b/ui/packages/shared/profile/src/SimpleMatchers/index.tsx
@@ -322,7 +322,9 @@ const SimpleMatchers = ({
             placeholder="Select label value"
             selectedKey={row.labelValue}
             className="rounded-none ring-0 focus:ring-0 outline-none max-w-48"
-            optionsClassname="max-w-[300px]"
+            optionsClassname={cx('max-w-[300px]', {
+              'w-[300px]': isRowRegex(row),
+            })}
             searchable={true}
             disabled={row.labelName === ''}
             loading={row.isLoading}


### PR DESCRIPTION
Fixes a bug where when in the simple querying mode and you add a new set of label matchers, and then proceed to move the mouse away before adding a label name, operator or value., the label matcher set is removed entirely, which can be frustrating.

Also fixes the bug where the regex input field gets so small and you don't get to see what is being typed.