### PR TITLE
area/ui: fix height for selector's search

### DIFF
--- a/ui/packages/shared/profile/src/SimpleMatchers/Select.tsx
+++ b/ui/packages/shared/profile/src/SimpleMatchers/Select.tsx
@@ -209,7 +209,7 @@ const CustomSelect: React.FC<CustomSelectProps> = ({
         >
           {searchable && (
             <div className="sticky z-10 top-[-5px] w-auto max-w-full">
-              <div className={cx('relative h-full', editable ? 'h-full min-h-[50px]' : 'h-[45px]')}>
+              <div className={cx('relative', editable ? 'h-full min-h-[50px]' : 'h-[45px]')}>
                 {editable ? (
                   <textarea
                     ref={searchInputRef as React.LegacyRef<HTMLTextAreaElement>}


### PR DESCRIPTION
Fixes a bug where the height of the label value's input is too short.
Before
<img width="322" alt="image" src="https://github.com/user-attachments/assets/9f4fa4e5-41d7-49b1-912d-2c01aa4684d0">

After
<img width="322" alt="image" src="https://github.com/user-attachments/assets/ab654134-2495-4d0b-852d-1c04f18866ab">
