### PR TITLE
symbolizer: shell out to addr2line

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ Flags:
                                  Mode to demangle C++ symbols. Default mode
                                  is simplified: no parameters, no templates,
                                  no return type
+      --symbolizer-external-addr-2-line-path=""
+                                 Path to addr2line utility, to be used for
+                                 symbolization instead of native implementation
       --symbolizer-number-of-tries=3
                                  Number of tries to attempt to symbolize an
                                  unsybolized location

--- a/pkg/parca/parca.go
+++ b/pkg/parca/parca.go
@@ -151,8 +151,9 @@ type FlagsStorage struct {
 }
 
 type FlagsSymbolizer struct {
-	DemangleMode  string `default:"simple" help:"Mode to demangle C++ symbols. Default mode is simplified: no parameters, no templates, no return type" enum:"simple,full,none,templates"`
-	NumberOfTries int    `default:"3" help:"Number of tries to attempt to symbolize an unsybolized location"`
+	DemangleMode          string `default:"simple" help:"Mode to demangle C++ symbols. Default mode is simplified: no parameters, no templates, no return type" enum:"simple,full,none,templates"`
+	ExternalAddr2linePath string `default:"" help:"Path to addr2line utility, to be used for symbolization instead of native implementation"`
+	NumberOfTries         int    `default:"3" help:"Number of tries to attempt to symbolize an unsybolized location"`
 }
 
 // FlagsDebuginfo configures the Parca Debuginfo client.
@@ -415,6 +416,7 @@ func Run(ctx context.Context, logger log.Logger, reg *prometheus.Registry, flags
 			symbolizer.NewBadgerCache(db),
 			debuginfo.NewFetcher(debuginfodClients, debuginfoBucket),
 			flags.Debuginfo.CacheDir,
+			flags.Symbolizer.ExternalAddr2linePath,
 			symbolizer.WithDemangleMode(flags.Symbolizer.DemangleMode),
 		),
 		memory.DefaultAllocator,

--- a/pkg/symbolizer/symbolizer.go
+++ b/pkg/symbolizer/symbolizer.go
@@ -14,18 +14,23 @@
 package symbolizer
 
 import (
+	"bufio"
 	"context"
 	"debug/elf"
 	"errors"
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strconv"
+	"strings"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 
 	debuginfopb "github.com/parca-dev/parca/gen/proto/go/parca/debuginfo/v1alpha1"
+	profilepb "github.com/parca-dev/parca/gen/proto/go/parca/metastore/v1alpha1"
 	"github.com/parca-dev/parca/pkg/debuginfo"
 	"github.com/parca-dev/parca/pkg/profile"
 	"github.com/parca-dev/parca/pkg/symbol/addr2line"
@@ -63,9 +68,10 @@ func WithDemangleMode(mode string) Option {
 type Symbolizer struct {
 	logger log.Logger
 
-	debuginfo DebuginfoFetcher
-	cache     SymbolizerCache
-	metadata  DebuginfoMetadata
+	debuginfo             DebuginfoFetcher
+	cache                 SymbolizerCache
+	metadata              DebuginfoMetadata
+	externalAddr2linePath string
 
 	demangler *demangle.Demangler
 
@@ -89,6 +95,7 @@ func New(
 	cache SymbolizerCache,
 	debuginfo DebuginfoFetcher,
 	tmpDir string,
+	externalAddr2linePath string,
 	opts ...Option,
 ) *Symbolizer {
 	const (
@@ -96,12 +103,13 @@ func New(
 	)
 
 	s := &Symbolizer{
-		logger:    log.With(logger, "component", "symbolizer"),
-		cache:     cache,
-		debuginfo: debuginfo,
-		tmpDir:    tmpDir,
-		metadata:  metadata,
-		demangler: demangle.NewDemangler(defaultDemangleMode, false),
+		logger:                log.With(logger, "component", "symbolizer"),
+		cache:                 cache,
+		debuginfo:             debuginfo,
+		externalAddr2linePath: externalAddr2linePath,
+		tmpDir:                tmpDir,
+		metadata:              metadata,
+		demangler:             demangle.NewDemangler(defaultDemangleMode, false),
 	}
 
 	for _, opt := range opts {
@@ -126,7 +134,7 @@ func (s *Symbolizer) Symbolize(
 	req SymbolizationRequest,
 ) error {
 	if err := s.symbolize(ctx, req); err != nil {
-		level.Debug(s.logger).Log("msg", "failed to symbolize", "err", err)
+		level.Debug(s.logger).Log("msg", fmt.Sprintf("failed to symbolize: BuildID %s", req.BuildID), "err", err)
 	}
 
 	return nil
@@ -272,17 +280,122 @@ func (s *Symbolizer) getDebuginfo(ctx context.Context, buildID string) (string, 
 }
 
 type cachedLiner struct {
-	logger    log.Logger
-	demangler *demangle.Demangler
-	filepath  string
-	f         *elf.File
-	quality   *debuginfopb.DebuginfoQuality
-	buildID   string
+	logger                log.Logger
+	demangler             *demangle.Demangler
+	filepath              string
+	f                     *elf.File
+	quality               *debuginfopb.DebuginfoQuality
+	buildID               string
+	externalAddr2linePath string
 
 	// this is the concrete liner
 	liner liner
 
 	cache SymbolizerCache
+}
+
+type externalExecutableLiner struct {
+	cmd       exec.Cmd
+	inputPipe io.WriteCloser
+	scanner   *bufio.Scanner
+
+	logger    log.Logger
+	demangler *demangle.Demangler
+}
+
+func (c *cachedLiner) newExternalExecutableLiner(
+	filepath string,
+) (liner, error) {
+	// Create cmd with pipes and scanner for reading output line by line
+	addr2lineCmd := exec.Command(c.externalAddr2linePath, "--exe", filepath, "-afiC")
+	addr2lineInput, err := addr2lineCmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("error creating input pipe for addr2line: %w", err)
+	}
+	addr2lineOutput, err := addr2lineCmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("error creating output pipe for addr2line: %w", err)
+	}
+	scanner := bufio.NewScanner(addr2lineOutput)
+
+	// Start command to load executable info and wait for input
+	err = addr2lineCmd.Start()
+	if err != nil {
+		return nil, fmt.Errorf("error starting addr2line: %w", err)
+	}
+
+	return &externalExecutableLiner{
+		cmd:       *addr2lineCmd,
+		inputPipe: addr2lineInput,
+		scanner:   scanner,
+		logger:    c.logger,
+		demangler: c.demangler,
+	}, nil
+}
+
+func (l *externalExecutableLiner) Close() error {
+	err := l.inputPipe.Close()
+	if err != nil {
+		return err
+	}
+	err = l.cmd.Wait()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (l *externalExecutableLiner) PCToLines(ctx context.Context, pc uint64) ([]profile.LocationLine, error) {
+	// Write the address to addr2line stdin twice in order to get addresses as a proper delimiter
+	for i := 0; i < 2; i++ {
+		_, err := io.WriteString(l.inputPipe, fmt.Sprintf("0x%x\n", pc))
+		if err != nil {
+			return nil, fmt.Errorf("error writing to addr2line stdin: %w\n", err)
+		}
+	}
+
+	lines := []profile.LocationLine{}
+	// addr2line output consists of a variable number of pairs of lines per address
+	// The first line of each block of output is the address, if we have to skip additional lines
+	// it means the previous read loop left some output unread
+	l.scanner.Scan()
+	addressLine := l.scanner.Text()
+	for !strings.HasPrefix(addressLine, "0x") {
+		l.scanner.Scan()
+		addressLine = l.scanner.Text()
+	}
+
+	keepReading := true
+	l.scanner.Scan()
+	for keepReading {
+		line1 := l.scanner.Text()
+
+		l.scanner.Scan()
+		line2 := l.scanner.Text()
+
+		line1 = strings.TrimSuffix(line1, "\n")
+		line2 = strings.TrimSuffix(line2, "\n")
+
+		fileLocation := strings.Split(line2, ":")
+		lineNum, err := strconv.Atoi(fileLocation[1])
+		if err != nil {
+			lineNum = 0
+		}
+
+		lines = append(lines, profile.LocationLine{
+			Line: int64(lineNum),
+			Function: &profilepb.Function{
+				StartLine: int64(lineNum),
+				Filename:  fileLocation[0],
+				Name:      line1,
+			},
+		})
+
+		l.scanner.Scan()
+		keepReading = !strings.HasPrefix(l.scanner.Text(), "0x")
+	}
+
+	return lines, nil
 }
 
 // newConcreteLiner creates a new liner for the given mapping and object file path.
@@ -293,12 +406,13 @@ func (s *Symbolizer) newLiner(
 	buildID string,
 ) liner {
 	return &cachedLiner{
-		logger:    s.logger,
-		demangler: s.demangler,
-		filepath:  filepath,
-		f:         f,
-		quality:   quality,
-		buildID:   buildID,
+		logger:                s.logger,
+		demangler:             s.demangler,
+		filepath:              filepath,
+		f:                     f,
+		quality:               quality,
+		buildID:               buildID,
+		externalAddr2linePath: s.externalAddr2linePath,
 
 		cache: s.cache,
 	}
@@ -344,6 +458,9 @@ func (c *cachedLiner) PCToLines(ctx context.Context, pc uint64) ([]profile.Locat
 
 func (c *cachedLiner) newConcreteLiner(filepath string, f *elf.File, quality *debuginfopb.DebuginfoQuality) (liner, error) {
 	switch {
+	case c.externalAddr2linePath != "":
+		level.Debug(c.logger).Log("msg", fmt.Sprintf("using external addr2line liner with binary: %s", c.externalAddr2linePath))
+		return c.newExternalExecutableLiner(filepath)
 	case quality.HasDwarf:
 		lnr, err := addr2line.DWARF(c.logger, c.filepath, c.f, c.demangler)
 		if err != nil {

--- a/pkg/symbolizer/symbolizer_test.go
+++ b/pkg/symbolizer/symbolizer_test.go
@@ -67,6 +67,7 @@ func TestSymbolizer(t *testing.T) {
 		&NoopSymbolizerCache{},
 		debuginfo.NewFetcher(debuginfodClient, bucket),
 		symbolizerCacheDir,
+		"",
 	)
 
 	ctx := context.Background()


### PR DESCRIPTION
Use `addr2line` instead of custom addr2line implementation which doesn't symbolize addresses properly for some binaries (see #5291). Even with a fix for https://github.com/go-delve/delve/issues/3861, which is the root cause of the failure in #5291, the current implementation can't symbolize ~50 % of the addresses in the stacks of the ClickHouse binary in my tests. Using [gimli-rs/addr2line](https://github.com/gimli-rs/addr2line) as the `addr2line` implementation works fast and well:
![image](https://github.com/user-attachments/assets/7f1e8d93-5d28-463d-bfb4-0d01075b5603)


Please take this PR as a rough proposal, there are of course details to be fleshed out:
- Probably you want to keep the current implementation under a setting
- If not, probably some code would need to be deleted
- This introduces another dependency, docs and Docker images at least would have to be updated
- Also there are likely code issues, I'm far from a Go expert