### PR TITLE
Don't filter out the "allowed" group by columns

### DIFF
--- a/pkg/query/columnquery.go
+++ b/pkg/query/columnquery.go
@@ -248,9 +248,11 @@ func (q *ColumnQueryAPI) Query(ctx context.Context, req *pb.QueryRequest) (*pb.Q
 			groupByLabels = append(groupByLabels, f)
 			continue
 		}
-		if _, allowed := allowedGroupBy[f]; !allowed {
-			return nil, status.Errorf(codes.InvalidArgument, "invalid group by field: %s", f)
+		if _, allowed := allowedGroupBy[f]; allowed {
+			groupByLabels = append(groupByLabels, f)
+			continue
 		}
+		return nil, status.Errorf(codes.InvalidArgument, "invalid group by field: %s", f)
 	}
 
 	switch req.Mode {


### PR DESCRIPTION
Group by address is working again with this change:
<img width="973" alt="image" src="https://github.com/user-attachments/assets/dd123b2a-ac4f-4f94-96be-fc44dd5dfb18">
