### PR TITLE
ui: Small improvements

### DIFF
--- a/ui/packages/shared/profile/src/MetricsGraph/MetricsTooltip/index.tsx
+++ b/ui/packages/shared/profile/src/MetricsGraph/MetricsTooltip/index.tsx
@@ -106,7 +106,7 @@ const MetricsTooltip = ({
 
   return (
     <div ref={setPopperElement} style={styles.popper} {...attributes.popper} className="z-20">
-      <div className="flex max-w-md">
+      <div className="flex max-w-lg">
         <div className="m-auto">
           <div
             className="rounded-lg border-gray-300 bg-gray-50 p-3 opacity-90 shadow-lg dark:border-gray-500 dark:bg-gray-900"
@@ -121,7 +121,7 @@ const MetricsTooltip = ({
                       {delta ? (
                         <>
                           <tr>
-                            <td className="w-1/4">Per Second</td>
+                            <td className="w-1/4 pr-3">Per&nbsp;Second</td>
                             <td className="w-3/4">
                               {valueFormatter(
                                 highlighted.valuePerSecond,

--- a/ui/packages/shared/profile/src/ProfileSelector/QueryControls.tsx
+++ b/ui/packages/shared/profile/src/ProfileSelector/QueryControls.tsx
@@ -217,17 +217,17 @@ export function QueryControls({
       <DateTimeRangePicker onRangeSelection={setTimeRangeSelection} range={timeRangeSelection} />
 
       <div>
-          <label className="text-xs">&nbsp;</label>
-          <Button
-            disabled={searchDisabled}
-            onClick={(e: React.MouseEvent<HTMLElement>) => {
-              e.preventDefault();
-              setQueryExpression(true);
-            }}
-            id="h-matcher-search-button"
-          >
-            Search
-          </Button>
+        <label className="text-xs">&nbsp;</label>
+        <Button
+          disabled={searchDisabled}
+          onClick={(e: React.MouseEvent<HTMLElement>) => {
+            e.preventDefault();
+            setQueryExpression(true);
+          }}
+          id="h-matcher-search-button"
+        >
+          Search
+        </Button>
       </div>
     </div>
   );

--- a/ui/packages/shared/profile/src/ProfileSelector/QueryControls.tsx
+++ b/ui/packages/shared/profile/src/ProfileSelector/QueryControls.tsx
@@ -16,7 +16,7 @@ import {RpcError} from '@protobuf-ts/runtime-rpc';
 import Select, {type SelectInstance} from 'react-select';
 
 import {ProfileTypesResponse, QueryServiceClient} from '@parca/client';
-import {Button, ButtonGroup, DateTimeRange, DateTimeRangePicker} from '@parca/components';
+import {Button, DateTimeRange, DateTimeRangePicker} from '@parca/components';
 import {ProfileType, Query} from '@parca/parser';
 
 import MatchersInput from '../MatchersInput';
@@ -90,7 +90,7 @@ export function QueryControls({
   profileTypesError,
 }: QueryControlsProps): JSX.Element {
   return (
-    <div className="flex w-full flex-wrap items-end gap-2">
+    <div className="flex w-full flex-wrap items-start gap-2">
       {showProfileTypeSelector && (
         <div>
           <label className="text-xs">Profile type</label>
@@ -216,18 +216,19 @@ export function QueryControls({
 
       <DateTimeRangePicker onRangeSelection={setTimeRangeSelection} range={timeRangeSelection} />
 
-      <ButtonGroup>
-        <Button
-          disabled={searchDisabled}
-          onClick={(e: React.MouseEvent<HTMLElement>) => {
-            e.preventDefault();
-            setQueryExpression(true);
-          }}
-          id="h-matcher-search-button"
-        >
-          Search
-        </Button>
-      </ButtonGroup>
+      <div>
+          <label className="text-xs">&nbsp;</label>
+          <Button
+            disabled={searchDisabled}
+            onClick={(e: React.MouseEvent<HTMLElement>) => {
+              e.preventDefault();
+              setQueryExpression(true);
+            }}
+            id="h-matcher-search-button"
+          >
+            Search
+          </Button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Metrics Graph 

The MetricsGraph Tooltip now shows the "Per Second" in one line rather than having it split in two. All that was necessary was using a `&nbsp;`. 

Old (two lines)
![old-tooltip](https://github.com/user-attachments/assets/c57fd638-85d2-477b-b304-5bc7b3cc8983)

New (one line)
![new-tooltip](https://github.com/user-attachments/assets/d7d0efeb-ddce-446c-8edb-0c1b95137b38)

## Query Selectors 

When multiple selectors are used in the query UI, the buttons and dropdowns used to move down. This look odd and somewhat broken.

![old-selectors](https://github.com/user-attachments/assets/c846be3d-b5a0-4194-9939-750c60a86d9b)

This is now fixed. 

![new-selectors](https://github.com/user-attachments/assets/cd38b1d1-33a7-480c-8982-1679156b5518)
