### PR TITLE
area/ui: Enable displaying utilization label names and values

### DIFF
--- a/ui/packages/shared/profile/src/MatchersInput/SuggestionsList.tsx
+++ b/ui/packages/shared/profile/src/MatchersInput/SuggestionsList.tsx
@@ -52,12 +52,18 @@ interface Props {
   focusedInput: boolean;
   isLabelNamesLoading: boolean;
   isLabelValuesLoading: boolean;
+  shouldTrimPrefix: boolean;
 }
 
 const LoadingSpinner = (): JSX.Element => {
   const {loader: Spinner} = useParcaContext();
 
   return <div className="pt-2 pb-4">{Spinner}</div>;
+};
+
+const transformLabelsForSuggestions = (labelNames: string, shouldTrimPrefix = false): string => {
+  const trimmedLabel = shouldTrimPrefix ? labelNames.split('.').pop() ?? labelNames : labelNames;
+  return trimmedLabel;
 };
 
 const SuggestionsList = ({
@@ -68,6 +74,7 @@ const SuggestionsList = ({
   focusedInput,
   isLabelNamesLoading,
   isLabelValuesLoading,
+  shouldTrimPrefix = false,
 }: Props): JSX.Element => {
   const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(null);
   const {styles, attributes} = usePopper(inputRef, popperElement, {
@@ -234,8 +241,8 @@ const SuggestionsList = ({
                       onHighlight={() => setHighlightedSuggestionIndex(i)}
                       onApplySuggestion={() => applySuggestionWithIndex(i)}
                       onResetHighlight={() => resetHighlight()}
-                      value={l.value}
-                      key={l.value}
+                      value={transformLabelsForSuggestions(l.value, shouldTrimPrefix)}
+                      key={transformLabelsForSuggestions(l.value, shouldTrimPrefix)}
                     />
                   ))}
                 </>

--- a/ui/packages/shared/profile/src/MatchersInput/index.tsx
+++ b/ui/packages/shared/profile/src/MatchersInput/index.tsx
@@ -23,6 +23,7 @@ import {Query} from '@parca/parser';
 import {millisToProtoTimestamp, sanitizeLabelValue} from '@parca/utilities';
 
 import {UtilizationLabels} from '../ProfileSelector';
+import {useUtilizationLabels} from '../contexts/UtilizationLabelsContext';
 import useGrpcQuery from '../useGrpcQuery';
 import SuggestionsList, {Suggestion, Suggestions} from './SuggestionsList';
 
@@ -32,7 +33,6 @@ interface MatchersInputProps {
   runQuery: () => void;
   currentQuery: Query;
   profileType: string;
-  utilizationLabels?: UtilizationLabels;
 }
 
 export interface ILabelNamesResult {
@@ -149,13 +149,13 @@ const MatchersInput = ({
   runQuery,
   currentQuery,
   profileType,
-  utilizationLabels,
 }: MatchersInputProps): JSX.Element => {
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
   const [focusedInput, setFocusedInput] = useState(false);
   const [lastCompleted, setLastCompleted] = useState<Suggestion>(new Suggestion('', '', ''));
   const [currentLabelName, setCurrentLabelName] = useState<string | null>(null);
   const [labelNameMappings, setLabelNameMappings] = useState<LabelNameMapping[]>([]);
+  const utilizationLabels = useUtilizationLabels();
 
   const {loading: labelNamesLoading, result} = useLabelNames(queryClient, profileType);
   const {response: labelNamesResponse, error: labelNamesError} = result;

--- a/ui/packages/shared/profile/src/MatchersInput/index.tsx
+++ b/ui/packages/shared/profile/src/MatchersInput/index.tsx
@@ -30,6 +30,7 @@ interface MatchersInputProps {
   runQuery: () => void;
   currentQuery: Query;
   profileType: string;
+  utilizationLabelNames?: string[];
 }
 
 export interface ILabelNamesResult {
@@ -117,6 +118,7 @@ const MatchersInput = ({
   runQuery,
   currentQuery,
   profileType,
+  utilizationLabelNames,
 }: MatchersInputProps): JSX.Element => {
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
   const [focusedInput, setFocusedInput] = useState(false);
@@ -131,13 +133,16 @@ const MatchersInput = ({
     result: {response: labelValues},
   } = useLabelValues(queryClient, currentLabelName ?? '', profileType);
 
-  const labelNames = useMemo(() => {
+  const labelNamesFromAPI = useMemo(() => {
     return (labelNamesError === undefined || labelNamesError == null) &&
       labelNamesResponse !== undefined &&
       labelNamesResponse != null
       ? labelNamesResponse.labelNames.filter(e => e !== '__name__')
       : [];
   }, [labelNamesError, labelNamesResponse]);
+
+  const labelNames =
+    utilizationLabelNames !== undefined ? utilizationLabelNames : labelNamesFromAPI;
 
   const value = currentQuery.matchersString();
 

--- a/ui/packages/shared/profile/src/ProfileSelector/QueryControls.tsx
+++ b/ui/packages/shared/profile/src/ProfileSelector/QueryControls.tsx
@@ -23,7 +23,6 @@ import MatchersInput from '../MatchersInput';
 import ProfileTypeSelector from '../ProfileTypeSelector';
 import SimpleMatchers from '../SimpleMatchers';
 import ViewMatchers from '../ViewMatchers';
-import {UtilizationLabels} from '../contexts/UtilizationLabelsContext';
 
 interface SelectOption {
   label: string;

--- a/ui/packages/shared/profile/src/ProfileSelector/QueryControls.tsx
+++ b/ui/packages/shared/profile/src/ProfileSelector/QueryControls.tsx
@@ -23,7 +23,7 @@ import MatchersInput from '../MatchersInput';
 import ProfileTypeSelector from '../ProfileTypeSelector';
 import SimpleMatchers from '../SimpleMatchers';
 import ViewMatchers from '../ViewMatchers';
-import {UtilizationLabels} from './index';
+import {UtilizationLabels} from '../contexts/UtilizationLabelsContext';
 
 interface SelectOption {
   label: string;
@@ -62,7 +62,6 @@ interface QueryControlsProps {
   setUserSumBySelection: (sumBy: string[]) => void;
   sumByRef: React.RefObject<SelectInstance>;
   profileType: ProfileType;
-  utilizationLabels?: UtilizationLabels;
 }
 
 export function QueryControls({
@@ -90,7 +89,6 @@ export function QueryControls({
   profileType,
   showSumBySelector,
   profileTypesError,
-  utilizationLabels,
 }: QueryControlsProps): JSX.Element {
   return (
     <div className="flex w-full flex-wrap items-start gap-2">
@@ -156,7 +154,6 @@ export function QueryControls({
             currentQuery={query}
             profileType={selectedProfileName}
             queryClient={queryClient}
-            utilizationLabels={utilizationLabels}
           />
         ) : (
           <SimpleMatchers
@@ -166,7 +163,6 @@ export function QueryControls({
             profileType={selectedProfileName}
             queryBrowserRef={queryBrowserRef}
             queryClient={queryClient}
-            utilizationLabels={utilizationLabels}
           />
         )}
       </div>

--- a/ui/packages/shared/profile/src/ProfileSelector/QueryControls.tsx
+++ b/ui/packages/shared/profile/src/ProfileSelector/QueryControls.tsx
@@ -23,6 +23,7 @@ import MatchersInput from '../MatchersInput';
 import ProfileTypeSelector from '../ProfileTypeSelector';
 import SimpleMatchers from '../SimpleMatchers';
 import ViewMatchers from '../ViewMatchers';
+import {UtilizationLabels} from './index';
 
 interface SelectOption {
   label: string;
@@ -61,6 +62,7 @@ interface QueryControlsProps {
   setUserSumBySelection: (sumBy: string[]) => void;
   sumByRef: React.RefObject<SelectInstance>;
   profileType: ProfileType;
+  utilizationLabels?: UtilizationLabels;
 }
 
 export function QueryControls({
@@ -88,6 +90,7 @@ export function QueryControls({
   profileType,
   showSumBySelector,
   profileTypesError,
+  utilizationLabels,
 }: QueryControlsProps): JSX.Element {
   return (
     <div className="flex w-full flex-wrap items-start gap-2">
@@ -153,6 +156,7 @@ export function QueryControls({
             currentQuery={query}
             profileType={selectedProfileName}
             queryClient={queryClient}
+            utilizationLabels={utilizationLabels}
           />
         ) : (
           <SimpleMatchers
@@ -162,6 +166,7 @@ export function QueryControls({
             profileType={selectedProfileName}
             queryBrowserRef={queryBrowserRef}
             queryClient={queryClient}
+            utilizationLabels={utilizationLabels}
           />
         )}
       </div>

--- a/ui/packages/shared/profile/src/ProfileSelector/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileSelector/index.tsx
@@ -64,6 +64,12 @@ export interface UtilizationMetrics {
   };
 }
 
+export interface UtilizationLabels {
+  utilizationLabelNames?: string[];
+  utilizationFetchLabelValues?: (labelName: string) => void;
+  utilizationLabelValues?: string[];
+}
+
 interface ProfileSelectorProps extends ProfileSelectorFeatures {
   queryClient: QueryServiceClient;
   querySelection: QuerySelection;
@@ -78,6 +84,7 @@ interface ProfileSelectorProps extends ProfileSelectorFeatures {
   suffix?: string;
   utilizationMetrics?: UtilizationMetrics[];
   utilizationMetricsLoading?: boolean;
+  utilizationLabels?: UtilizationLabels;
 }
 
 export interface IProfileTypesResult {
@@ -123,6 +130,7 @@ const ProfileSelector = ({
   setDisplayHideMetricsGraphButton,
   utilizationMetrics,
   utilizationMetricsLoading,
+  utilizationLabels,
 }: ProfileSelectorProps): JSX.Element => {
   const {
     loading: profileTypesLoading,
@@ -292,6 +300,7 @@ const ProfileSelector = ({
           queryClient={queryClient}
           sumByRef={sumByRef}
           labels={labels}
+          utilizationLabels={utilizationLabels}
           sumBySelection={sumBySelection ?? []}
           setUserSumBySelection={setUserSumBySelection}
           profileType={profileType}

--- a/ui/packages/shared/profile/src/ProfileSelector/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileSelector/index.tsx
@@ -66,7 +66,7 @@ export interface UtilizationMetrics {
 
 export interface UtilizationLabels {
   utilizationLabelNames?: string[];
-  utilizationFetchLabelValues?: (labelName: string) => void;
+  utilizationFetchLabelValues?: (key: string) => Promise<string[]>;
   utilizationLabelValues?: string[];
 }
 

--- a/ui/packages/shared/profile/src/ProfileSelector/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileSelector/index.tsx
@@ -30,6 +30,7 @@ import {type NavigateFunction} from '@parca/utilities';
 import {ProfileSelection} from '..';
 import {useLabelNames} from '../MatchersInput/index';
 import {useMetricsGraphDimensions} from '../MetricsGraph/useMetricsGraphDimensions';
+import {UtilizationLabelsProvider} from '../contexts/UtilizationLabelsContext';
 import {useDefaultSumBy, useSumBySelection} from '../useSumBy';
 import {MetricsGraphSection} from './MetricsGraphSection';
 import {QueryControls} from './QueryControls';
@@ -276,63 +277,64 @@ const ProfileSelector = ({
   const sumByRef = useRef(null);
 
   return (
-    <>
-      <div className="mb-2 flex">
-        <QueryControls
-          showProfileTypeSelector={showProfileTypeSelector}
-          showSumBySelector={showSumBySelector}
-          disableExplorativeQuerying={disableExplorativeQuerying}
-          profileTypesData={profileTypesData}
-          profileTypesLoading={profileTypesLoading}
-          selectedProfileName={selectedProfileName}
-          setProfileName={setProfileName}
-          setMatchersString={setMatchersString}
-          setQueryExpression={setQueryExpression}
-          query={query}
-          queryBrowserRef={queryBrowserRef}
-          timeRangeSelection={timeRangeSelection}
-          setTimeRangeSelection={setTimeRangeSelection}
-          searchDisabled={searchDisabled}
-          queryBrowserMode={queryBrowserMode as string}
-          setQueryBrowserMode={setQueryBrowserMode}
-          advancedModeForQueryBrowser={advancedModeForQueryBrowser}
-          setAdvancedModeForQueryBrowser={setAdvancedModeForQueryBrowser}
+    <UtilizationLabelsProvider value={utilizationLabels}>
+      <>
+        <div className="mb-2 flex">
+          <QueryControls
+            showProfileTypeSelector={showProfileTypeSelector}
+            showSumBySelector={showSumBySelector}
+            disableExplorativeQuerying={disableExplorativeQuerying}
+            profileTypesData={profileTypesData}
+            profileTypesLoading={profileTypesLoading}
+            selectedProfileName={selectedProfileName}
+            setProfileName={setProfileName}
+            setMatchersString={setMatchersString}
+            setQueryExpression={setQueryExpression}
+            query={query}
+            queryBrowserRef={queryBrowserRef}
+            timeRangeSelection={timeRangeSelection}
+            setTimeRangeSelection={setTimeRangeSelection}
+            searchDisabled={searchDisabled}
+            queryBrowserMode={queryBrowserMode as string}
+            setQueryBrowserMode={setQueryBrowserMode}
+            advancedModeForQueryBrowser={advancedModeForQueryBrowser}
+            setAdvancedModeForQueryBrowser={setAdvancedModeForQueryBrowser}
+            queryClient={queryClient}
+            sumByRef={sumByRef}
+            labels={labels}
+            sumBySelection={sumBySelection ?? []}
+            setUserSumBySelection={setUserSumBySelection}
+            profileType={profileType}
+            profileTypesError={error}
+          />
+          {comparing && (
+            <div>
+              <IconButton onClick={() => closeProfile()} icon={<CloseIcon />} />
+            </div>
+          )}
+        </div>
+        <MetricsGraphSection
+          showMetricsGraph={showMetricsGraph}
+          setDisplayHideMetricsGraphButton={setDisplayHideMetricsGraphButton}
+          heightStyle={heightStyle}
+          querySelection={querySelection}
+          profileSelection={profileSelection}
+          comparing={comparing}
+          sumBy={querySelection.sumBy ?? defaultSumBy ?? []}
+          defaultSumByLoading={defaultSumByLoading}
           queryClient={queryClient}
-          sumByRef={sumByRef}
-          labels={labels}
-          utilizationLabels={utilizationLabels}
-          sumBySelection={sumBySelection ?? []}
-          setUserSumBySelection={setUserSumBySelection}
-          profileType={profileType}
-          profileTypesError={error}
+          queryExpressionString={queryExpressionString}
+          setTimeRangeSelection={setTimeRangeSelection}
+          selectQuery={selectQuery}
+          selectProfile={selectProfile}
+          query={query}
+          setQueryExpression={setQueryExpression}
+          setNewQueryExpression={setNewQueryExpression}
+          utilizationMetrics={utilizationMetrics}
+          utilizationMetricsLoading={utilizationMetricsLoading}
         />
-        {comparing && (
-          <div>
-            <IconButton onClick={() => closeProfile()} icon={<CloseIcon />} />
-          </div>
-        )}
-      </div>
-      <MetricsGraphSection
-        showMetricsGraph={showMetricsGraph}
-        setDisplayHideMetricsGraphButton={setDisplayHideMetricsGraphButton}
-        heightStyle={heightStyle}
-        querySelection={querySelection}
-        profileSelection={profileSelection}
-        comparing={comparing}
-        sumBy={querySelection.sumBy ?? defaultSumBy ?? []}
-        defaultSumByLoading={defaultSumByLoading}
-        queryClient={queryClient}
-        queryExpressionString={queryExpressionString}
-        setTimeRangeSelection={setTimeRangeSelection}
-        selectQuery={selectQuery}
-        selectProfile={selectProfile}
-        query={query}
-        setQueryExpression={setQueryExpression}
-        setNewQueryExpression={setNewQueryExpression}
-        utilizationMetrics={utilizationMetrics}
-        utilizationMetricsLoading={utilizationMetricsLoading}
-      />
-    </>
+      </>
+    </UtilizationLabelsProvider>
   );
 };
 

--- a/ui/packages/shared/profile/src/SimpleMatchers/index.tsx
+++ b/ui/packages/shared/profile/src/SimpleMatchers/index.tsx
@@ -134,8 +134,6 @@ const SimpleMatchers = ({
     return matchers.map(matcher => matcher.key);
   }, [currentQuery]);
 
-  // TODO: This is a temporary solution to use the label values from the query client or the utilization labels.
-  // We need to find a better solution to handle this. e.g. using a Context to pass the label values to the SimpleMatchers component.
   const fetchLabelValues = useCallback(
     async (labelName: string): Promise<string[]> => {
       if (labelName == null || labelName === '' || profileType == null || profileType === '') {
@@ -165,11 +163,11 @@ const SimpleMatchers = ({
     [queryClient, metadata, profileType, reactQueryClient]
   );
 
+  // TODO: This is a temporary solution to use the label values from the query client or the utilization labels.
+  // We need to find a better solution to handle this. e.g. using a Context to pass the label values to the SimpleMatchers component.
   const fetchLabelValuesUtilization = useCallback(
     async (labelName: string): Promise<string[]> => {
-      utilizationLabels?.utilizationFetchLabelValues?.(labelName);
-
-      return utilizationLabels?.utilizationLabelValues ?? [];
+      return (await utilizationLabels?.utilizationFetchLabelValues?.(labelName)) ?? [];
     },
     [utilizationLabels]
   );

--- a/ui/packages/shared/profile/src/SimpleMatchers/index.tsx
+++ b/ui/packages/shared/profile/src/SimpleMatchers/index.tsx
@@ -23,7 +23,7 @@ import {Query} from '@parca/parser';
 import {sanitizeLabelValue} from '@parca/utilities';
 
 import {useLabelNames} from '../MatchersInput';
-import {UtilizationLabels} from '../ProfileSelector';
+import {useUtilizationLabels} from '../contexts/UtilizationLabelsContext';
 import Select, {type SelectItem} from './Select';
 
 interface Props {
@@ -32,7 +32,6 @@ interface Props {
   runQuery: () => void;
   currentQuery: Query;
   profileType: string;
-  utilizationLabels?: UtilizationLabels;
   queryBrowserRef: React.RefObject<HTMLDivElement>;
 }
 
@@ -107,8 +106,8 @@ const SimpleMatchers = ({
   currentQuery,
   profileType,
   queryBrowserRef,
-  utilizationLabels,
 }: Props): JSX.Element => {
+  const utilizationLabels = useUtilizationLabels();
   const [queryRows, setQueryRows] = useState<QueryRow[]>([
     {labelName: '', operator: '=', labelValue: '', labelValues: [], isLoading: false},
   ]);

--- a/ui/packages/shared/profile/src/contexts/MatchersInputLabelsContext.tsx
+++ b/ui/packages/shared/profile/src/contexts/MatchersInputLabelsContext.tsx
@@ -42,6 +42,8 @@ interface LabelsProviderProps {
   profileType: string;
 }
 
+// With there being the possibility of having utilization labels, we need to be able to determine whether the labels to be used are utilization labels or profiling data labels.
+// This context is used to determine this.
 export function LabelsProvider({
   children,
   queryClient,

--- a/ui/packages/shared/profile/src/contexts/MatchersInputLabelsContext.tsx
+++ b/ui/packages/shared/profile/src/contexts/MatchersInputLabelsContext.tsx
@@ -1,0 +1,128 @@
+// Copyright 2022 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React, {createContext, useContext, useMemo} from 'react';
+
+import {QueryServiceClient} from '@parca/client';
+
+import {useFetchUtilizationLabelValues, useLabelNames, useLabelValues} from '../MatchersInput';
+import {useUtilizationLabels} from './UtilizationLabelsContext';
+
+interface LabelNameMapping {
+  displayName: string;
+  fullName: string;
+}
+
+interface LabelsContextType {
+  labelNames: string[];
+  labelValues: string[];
+  labelNameMappings: LabelNameMapping[];
+  isLabelNamesLoading: boolean;
+  isLabelValuesLoading: boolean;
+  currentLabelName: string | null;
+  setCurrentLabelName: (name: string | null) => void;
+  shouldHandlePrefixes: boolean;
+}
+
+const LabelsContext = createContext<LabelsContextType | null>(null);
+
+interface LabelsProviderProps {
+  children: React.ReactNode;
+  queryClient: QueryServiceClient;
+  profileType: string;
+}
+
+export function LabelsProvider({
+  children,
+  queryClient,
+  profileType,
+}: LabelsProviderProps): JSX.Element {
+  const [currentLabelName, setCurrentLabelName] = React.useState<string | null>(null);
+  const utilizationLabels = useUtilizationLabels();
+
+  const {result: labelNamesResponse, loading: isLabelNamesLoading} = useLabelNames(
+    queryClient,
+    profileType
+  );
+
+  const labelNamesFromAPI = useMemo(() => {
+    return (labelNamesResponse.error === undefined || labelNamesResponse.error == null) &&
+      labelNamesResponse !== undefined &&
+      labelNamesResponse != null
+      ? labelNamesResponse.response?.labelNames.filter(e => e !== '__name__') ?? []
+      : [];
+  }, [labelNamesResponse]);
+
+  const {result: labelValuesOriginal, loading: isLabelValuesLoading} = useLabelValues(
+    queryClient,
+    currentLabelName ?? '',
+    profileType
+  );
+
+  const utilizationLabelValues = useFetchUtilizationLabelValues(
+    currentLabelName ?? '',
+    utilizationLabels
+  );
+
+  const shouldHandlePrefixes = utilizationLabels?.utilizationLabelNames !== undefined;
+
+  const labelNameMappings = useMemo(() => {
+    const names = utilizationLabels?.utilizationLabelNames ?? labelNamesFromAPI;
+    return names.map(name => ({
+      displayName: name.replace(/^(attributes\.|attributes_resource\.)/, ''),
+      fullName: name,
+    }));
+  }, [labelNamesFromAPI, utilizationLabels?.utilizationLabelNames]);
+
+  const labelNames = useMemo(() => {
+    return shouldHandlePrefixes ? labelNameMappings.map(m => m.displayName) : labelNamesFromAPI;
+  }, [labelNameMappings, labelNamesFromAPI, shouldHandlePrefixes]);
+
+  const labelValues = useMemo(() => {
+    return utilizationLabels?.utilizationFetchLabelValues !== undefined
+      ? utilizationLabelValues
+      : labelValuesOriginal.response;
+  }, [labelValuesOriginal, utilizationLabelValues, utilizationLabels]);
+
+  const value = useMemo(
+    () => ({
+      labelNames,
+      labelValues,
+      labelNameMappings,
+      isLabelNamesLoading,
+      isLabelValuesLoading,
+      currentLabelName,
+      setCurrentLabelName,
+      shouldHandlePrefixes,
+    }),
+    [
+      labelNames,
+      labelValues,
+      labelNameMappings,
+      isLabelNamesLoading,
+      isLabelValuesLoading,
+      currentLabelName,
+      shouldHandlePrefixes,
+    ]
+  );
+
+  return <LabelsContext.Provider value={value}>{children}</LabelsContext.Provider>;
+}
+
+export function useLabels(): LabelsContextType {
+  const context = useContext(LabelsContext);
+  if (context === null) {
+    throw new Error('useLabels must be used within a LabelsProvider');
+  }
+  return context;
+}

--- a/ui/packages/shared/profile/src/contexts/SimpleMatchersLabelContext.tsx
+++ b/ui/packages/shared/profile/src/contexts/SimpleMatchersLabelContext.tsx
@@ -35,6 +35,9 @@ interface LabelProviderProps {
   labelNameFromMatchers: string[];
 }
 
+// With there being the possibility of having utilization labels, we need to be able to determine whether the labels to be used are utilization labels or profiling data labels.
+// This context is used to determine this.
+
 export function LabelProvider({
   children,
   queryClient,

--- a/ui/packages/shared/profile/src/contexts/SimpleMatchersLabelContext.tsx
+++ b/ui/packages/shared/profile/src/contexts/SimpleMatchersLabelContext.tsx
@@ -1,0 +1,75 @@
+// Copyright 2022 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {createContext, useContext, useMemo} from 'react';
+
+import {QueryServiceClient} from '@parca/client';
+
+import {useLabelNames} from '../MatchersInput';
+import {transformLabelsForSelect} from '../SimpleMatchers';
+import type {SelectItem} from '../SimpleMatchers/Select';
+import {useUtilizationLabels} from './UtilizationLabelsContext';
+
+interface LabelContextValue {
+  labelNameOptions: SelectItem[];
+  isLoading: boolean;
+  error: Error | null;
+}
+
+const LabelContext = createContext<LabelContextValue | null>(null);
+
+interface LabelProviderProps {
+  children: React.ReactNode;
+  queryClient: QueryServiceClient;
+  profileType: string;
+  labelNameFromMatchers: string[];
+}
+
+export function LabelProvider({
+  children,
+  queryClient,
+  profileType,
+  labelNameFromMatchers,
+}: LabelProviderProps): JSX.Element {
+  const utilizationLabels = useUtilizationLabels();
+  const {loading, result} = useLabelNames(queryClient, profileType);
+
+  const value = useMemo(() => {
+    const baseLabels =
+      result.error != null ? [] : result.response?.labelNames.filter(e => e !== '__name__') ?? [];
+
+    const labelsToUse =
+      utilizationLabels?.utilizationLabelNames?.length !== undefined
+        ? utilizationLabels?.utilizationLabelNames ?? []
+        : baseLabels;
+
+    const uniqueLabels = Array.from(new Set([...labelsToUse, ...labelNameFromMatchers]));
+    const shouldTrimPrefix = Boolean(utilizationLabels?.utilizationLabelNames);
+
+    return {
+      labelNameOptions: transformLabelsForSelect(uniqueLabels, shouldTrimPrefix),
+      isLoading: loading,
+      error: result.error ?? null,
+    };
+  }, [result, loading, utilizationLabels, labelNameFromMatchers]);
+
+  return <LabelContext.Provider value={value}>{children}</LabelContext.Provider>;
+}
+
+export function useLabels(): LabelContextValue {
+  const context = useContext(LabelContext);
+  if (context === null) {
+    throw new Error('useLabels must be used within a LabelProvider');
+  }
+  return context;
+}

--- a/ui/packages/shared/profile/src/contexts/UtilizationLabelsContext.tsx
+++ b/ui/packages/shared/profile/src/contexts/UtilizationLabelsContext.tsx
@@ -1,0 +1,41 @@
+// Copyright 2022 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {ReactNode, createContext, useContext} from 'react';
+
+export interface UtilizationLabels {
+  utilizationLabelNames?: string[];
+  utilizationFetchLabelValues?: (key: string) => Promise<string[]>;
+  utilizationLabelValues?: string[];
+}
+
+interface UtilizationLabelsProviderProps {
+  children: ReactNode;
+  value: UtilizationLabels | undefined;
+}
+
+const UtilizationLabelsContext = createContext<UtilizationLabels | undefined>(undefined);
+
+export function UtilizationLabelsProvider({
+  children,
+  value,
+}: UtilizationLabelsProviderProps): JSX.Element {
+  return (
+    <UtilizationLabelsContext.Provider value={value}>{children}</UtilizationLabelsContext.Provider>
+  );
+}
+
+export function useUtilizationLabels(): UtilizationLabels | undefined {
+  const context = useContext(UtilizationLabelsContext);
+  return context;
+}

--- a/ui/packages/shared/profile/src/contexts/UtilizationLabelsContext.tsx
+++ b/ui/packages/shared/profile/src/contexts/UtilizationLabelsContext.tsx
@@ -24,6 +24,9 @@ interface UtilizationLabelsProviderProps {
   value: UtilizationLabels | undefined;
 }
 
+// The UtilizationLabelsContext is used to store the utilization label names and values. It also
+// contains the function utilizationFetchLabelValues to fetch the utilization label values.
+// This context was created so as to avoid props drilling.
 const UtilizationLabelsContext = createContext<UtilizationLabels | undefined>(undefined);
 
 export function UtilizationLabelsProvider({


### PR DESCRIPTION
This pull request introduces several changes to the `ProfileSelector`, `MatchersInput`, and `SimpleMatchers` components to enhance fetching label names and values for profiling data label or utilization metrics. 

The most significant changes include the addition of a new context for utilization labels (avoiding the use of props drilling), updates to the `SimpleMatchers` and `MatchersInput` components to fetch label names and values based on whether we're in profiling data mode or utilization metrics mode.