### PR TITLE
fix: remove unused `@ts-expect-error` directive

### DIFF
--- a/ui/packages/shared/profile/src/MetricsGraphStrips/index.tsx
+++ b/ui/packages/shared/profile/src/MetricsGraphStrips/index.tsx
@@ -78,7 +78,6 @@ export const MetricsGraphStrips = ({
 }: Props): JSX.Element => {
   const [collapsedIndices, setCollapsedIndices] = useState<number[]>([]);
 
-  // @ts-expect-error
   const color = d3.scaleOrdinal(d3.schemeObservable10);
 
   const valueBounds = d3.extent(data.flatMap(d => d.map(p => p.value))) as [number, number];


### PR DESCRIPTION
:wave: seeing some build issue in https://github.com/Homebrew/homebrew-core/pull/208419

```
> @parca/profile@0.16.477 build /private/tmp/parca-20250220-73005-h3o18b/parca-0.23.0/ui/packages/shared/profile
> tsc && pnpm run compile:styles

src/MetricsGraphStrips/index.tsx(81,3): error TS2578: Unused '@ts-expect-error' directive.
 ELIFECYCLE  Command failed with exit code 2.
```

https://github.com/Homebrew/homebrew-core/actions/runs/13440782872/job/37554636671#step:4:303