### PR TITLE
area/ui: Pass the `viewComponent` button to the QueryControls component

### DIFF
--- a/ui/packages/shared/profile/src/ProfileSelector/QueryControls.tsx
+++ b/ui/packages/shared/profile/src/ProfileSelector/QueryControls.tsx
@@ -105,7 +105,7 @@ export function QueryControls({
         </div>
       )}
 
-      <div className="w-full flex-1 flex flex-col gap-1" ref={queryBrowserRef}>
+      <div className="w-full flex-1 flex flex-col gap-1 mt-auto" ref={queryBrowserRef}>
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
             <label className="text-xs">Query</label>
@@ -133,6 +133,7 @@ export function QueryControls({
               </>
             )}
           </div>
+          {viewComponent?.createViewComponent}
         </div>
 
         {viewComponent?.disableExplorativeQuerying === true &&

--- a/ui/packages/shared/profile/src/ProfileSelector/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileSelector/index.tsx
@@ -308,6 +308,7 @@ const ProfileSelector = ({
             setUserSumBySelection={setUserSumBySelection}
             profileType={profileType}
             profileTypesError={error}
+            viewComponent={viewComponent}
           />
           {comparing && (
             <div>


### PR DESCRIPTION
This fixes the bug of the "Create a view from this query" button not rendering upstream.