### PR TITLE
pkg/parcacol: Sum into a single series if no sum by given

### DIFF
--- a/pkg/parcacol/querier.go
+++ b/pkg/parcacol/querier.go
@@ -630,10 +630,6 @@ func (q *Querier) queryRangeDelta(
 }
 
 func getSumByAggregateExprs(sumBy []string) []logicalplan.Expr {
-	if len(sumBy) == 0 {
-		return []logicalplan.Expr{logicalplan.DynCol(profile.ColumnLabels)}
-	}
-
 	exprs := make([]logicalplan.Expr, 0, len(sumBy))
 	for _, s := range sumBy {
 		exprs = append(exprs, logicalplan.Col(profile.ColumnLabelsPrefix+s))

--- a/pkg/query/columnquery_test.go
+++ b/pkg/query/columnquery_test.go
@@ -222,6 +222,7 @@ func TestColumnQueryAPIQueryRange(t *testing.T) {
 		Query: `memory:alloc_objects:count:space:bytes{job="default"}`,
 		Start: timestamppb.New(timestamp.Time(0)),
 		End:   timestamppb.New(timestamp.Time(9223372036854775807)),
+		SumBy: []string{"job"},
 	})
 	require.NoError(t, err)
 	require.Equal(t, 1, len(res.Series))
@@ -459,6 +460,7 @@ func TestColumnQueryAPIQueryFgprof(t *testing.T) {
 		Query: `fgprof:samples:count:wallclock:nanoseconds:delta`,
 		Start: timestamppb.New(timestamp.Time(0)),
 		End:   timestamppb.New(timestamp.Time(9223372036854775807)),
+		SumBy: []string{"job"},
 	})
 	require.NoError(t, err)
 	require.Equal(t, 1, len(res.Series))


### PR DESCRIPTION
Previously we would sum by all labels but this doesn't scale when there are hundreds of series available. Instead, we now have `sum by()` create a single series, much like in Prometheus. This is easier to draw and less confusing to the users.
