### PR TITLE
pkg/parcacol: non-delta profiles are always grouped by label

### DIFF
--- a/pkg/parcacol/querier.go
+++ b/pkg/parcacol/querier.go
@@ -655,10 +655,10 @@ func (q *Querier) queryRangeNonDelta(ctx context.Context, filterExpr logicalplan
 			[]*logicalplan.AggregationFunction{
 				valueSum,
 			},
-			append(
-				[]logicalplan.Expr{
-					logicalplan.Col(profile.ColumnTimestamp),
-				}, getSumByAggregateExprs(sumBy)...),
+			[]logicalplan.Expr{
+				logicalplan.Col(profile.ColumnTimestamp),
+				logicalplan.DynCol(profile.ColumnLabels),
+			},
 		).
 		Execute(ctx, func(ctx context.Context, r arrow.Record) error {
 			r.Retain()

--- a/pkg/query/columnquery_test.go
+++ b/pkg/query/columnquery_test.go
@@ -222,7 +222,6 @@ func TestColumnQueryAPIQueryRange(t *testing.T) {
 		Query: `memory:alloc_objects:count:space:bytes{job="default"}`,
 		Start: timestamppb.New(timestamp.Time(0)),
 		End:   timestamppb.New(timestamp.Time(9223372036854775807)),
-		SumBy: []string{"job"},
 	})
 	require.NoError(t, err)
 	require.Equal(t, 1, len(res.Series))


### PR DESCRIPTION
Previously, we removed grouping by labels if no sum-by labels are given.
Non-delta profiles will never get sum-by labels from the UI and therefore we can hardcode grouping by labels.
