### PR TITLE
send "group by" in export requests.

### DIFF
--- a/ui/packages/shared/profile/src/ProfileView/components/Toolbars/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileView/components/Toolbars/index.tsx
@@ -139,6 +139,12 @@ export const VisualisationToolbar: FC<VisualisationToolbarProps> = ({
   const isTableViz = dashboardItems?.includes('table');
   const isGraphViz = dashboardItems?.includes('icicle');
 
+  const req = profileSource?.QueryRequest();
+  if (req) {
+    req.groupBy = {
+      fields: groupBy ?? [],
+    };
+  }
   return (
     <>
       <div className="flex w-full justify-between items-end">
@@ -162,7 +168,7 @@ export const VisualisationToolbar: FC<VisualisationToolbarProps> = ({
           <ShareButton
             profileSource={profileSource}
             queryClient={queryClient}
-            queryRequest={profileSource?.QueryRequest() ?? undefined}
+            queryRequest={req}
             onDownloadPProf={onDownloadPProf}
             pprofdownloading={pprofdownloading ?? false}
             profileViewExternalSubActions={profileViewExternalSubActions}

--- a/ui/packages/shared/profile/src/ProfileView/components/Toolbars/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileView/components/Toolbars/index.tsx
@@ -140,7 +140,7 @@ export const VisualisationToolbar: FC<VisualisationToolbarProps> = ({
   const isGraphViz = dashboardItems?.includes('icicle');
 
   const req = profileSource?.QueryRequest();
-  if (req) {
+  if (req !== null && req !== undefined) {
     req.groupBy = {
       fields: groupBy ?? [],
     };

--- a/ui/packages/shared/profile/src/ProfileViewWithData.tsx
+++ b/ui/packages/shared/profile/src/ProfileViewWithData.tsx
@@ -166,7 +166,9 @@ export const ProfileViewWithData = ({
 
     try {
       setPprofDownloading(true);
-      const blob = await downloadPprof(profileSource.QueryRequest(), queryClient, metadata);
+      const req = profileSource.QueryRequest();
+      req.groupBy = {fields: groupBy};
+      const blob = await downloadPprof(req, queryClient, metadata);
       saveAsBlob(blob, `profile.pb.gz`);
       setPprofDownloading(false);
     } catch (error) {


### PR DESCRIPTION
Add the "group by" field to the query for pprof download and pprof.me export. This makes it so the selected label set will be available in the exported data.