### PR TITLE
fix address for interpreter and kernel

### DIFF
--- a/pkg/profile/decode.go
+++ b/pkg/profile/decode.go
@@ -182,6 +182,7 @@ func DecodeInto(lw LocationsWriter, data []byte) (DecodeResult, error) {
 
 		return DecodeResult{
 			WroteLines: true,
+			Addr:       addr,
 		}, nil
 	} else {
 		return DecodeResult{


### PR DESCRIPTION
Address is not shown for interpreter and kernel. Fix it by adding address when lines > 0.