### PR TITLE
ui: Query validation for icicle chart visualization

### DIFF
--- a/ui/packages/shared/profile/src/ProfileIcicleGraph/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph/index.tsx
@@ -21,7 +21,7 @@ import {IcicleGraphSkeleton, useParcaContext, useURLState} from '@parca/componen
 import {ProfileType} from '@parca/parser';
 import {capitalizeOnlyFirstLetter, divide} from '@parca/utilities';
 
-import { MergedProfileSource, ProfileSource } from '../ProfileSource';
+import {MergedProfileSource, ProfileSource} from '../ProfileSource';
 import DiffLegend from '../ProfileView/components/DiffLegend';
 import {useProfileViewContext} from '../ProfileView/context/ProfileViewContext';
 import {TimelineGuide} from '../TimelineGuide';
@@ -62,8 +62,8 @@ const ErrorContent = ({errorMessage}: {errorMessage: string}): JSX.Element => {
 export const validateIcicleChartQuery = (profileSource: MergedProfileSource) => {
   const isNonDelta = profileSource.ProfileType().delta !== true;
   const isDurationTooLong = profileSource.mergeTo - profileSource.mergeFrom > 10000;
-  return { isValid: !isNonDelta && !isDurationTooLong, isNonDelta, isDurationTooLong };
-}
+  return {isValid: !isNonDelta && !isDurationTooLong, isNonDelta, isDurationTooLong};
+};
 
 const ProfileIcicleGraph = function ProfileIcicleGraphNonMemo({
   graph,
@@ -155,7 +155,11 @@ const ProfileIcicleGraph = function ProfileIcicleGraphNonMemo({
   }, [loadingState]);
 
   const icicleGraph = useMemo(() => {
-    const { isValid: isIcicleChartValid, isNonDelta, isDurationTooLong } = validateIcicleChartQuery(profileSource as MergedProfileSource);
+    const {
+      isValid: isIcicleChartValid,
+      isNonDelta,
+      isDurationTooLong,
+    } = validateIcicleChartQuery(profileSource as MergedProfileSource);
     const isInvalidIcicleChartQuery = isIcicleChart && isIcicleChartValid === false;
     if (isLoading && !isInvalidIcicleChartQuery) {
       return (
@@ -174,9 +178,7 @@ const ProfileIcicleGraph = function ProfileIcicleGraphNonMemo({
           <ErrorContent errorMessage="Icicle chart is not available for queries with a duration longer than 10 seconds, select a point in the metrics graph to continue." />
         );
       } else {
-        return (
-          <ErrorContent errorMessage="Icicle chart is not available for this query." />
-        );
+        return <ErrorContent errorMessage="Icicle chart is not available for this query." />;
       }
     }
 

--- a/ui/packages/shared/profile/src/ProfileIcicleGraph/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph/index.tsx
@@ -59,9 +59,9 @@ const ErrorContent = ({errorMessage}: {errorMessage: string}): JSX.Element => {
   return <div className="flex justify-center p-10">{errorMessage}</div>;
 };
 
-export const validateIcicleChartQuery = (profileSource: MergedProfileSource) => {
-  const isNonDelta = profileSource.ProfileType().delta !== true;
-  const isDurationTooLong = profileSource.mergeTo - profileSource.mergeFrom > 10000;
+export const validateIcicleChartQuery = (profileSource: MergedProfileSource): { isValid: boolean; isNonDelta: boolean; isDurationTooLong: boolean } => {
+  const isNonDelta = !profileSource.ProfileType().delta;
+  const isDurationTooLong = profileSource.mergeTo - profileSource.mergeFrom > 60000;
   return {isValid: !isNonDelta && !isDurationTooLong, isNonDelta, isDurationTooLong};
 };
 
@@ -160,7 +160,7 @@ const ProfileIcicleGraph = function ProfileIcicleGraphNonMemo({
       isNonDelta,
       isDurationTooLong,
     } = validateIcicleChartQuery(profileSource as MergedProfileSource);
-    const isInvalidIcicleChartQuery = isIcicleChart && isIcicleChartValid === false;
+    const isInvalidIcicleChartQuery = isIcicleChart && isIcicleChartValid;
     if (isLoading && !isInvalidIcicleChartQuery) {
       return (
         <div className="h-auto overflow-clip">
@@ -175,7 +175,7 @@ const ProfileIcicleGraph = function ProfileIcicleGraphNonMemo({
         return <ErrorContent errorMessage="Icicle chart is only available for delta profiles." />;
       } else if (isDurationTooLong) {
         return (
-          <ErrorContent errorMessage="Icicle chart is not available for queries with a duration longer than 10 seconds, select a point in the metrics graph to continue." />
+          <ErrorContent errorMessage="Icicle chart is not available for queries with a duration longer than a minute, select a point in the metrics graph to continue." />
         );
       } else {
         return <ErrorContent errorMessage="Icicle chart is not available for this query." />;

--- a/ui/packages/shared/profile/src/ProfileIcicleGraph/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph/index.tsx
@@ -21,7 +21,7 @@ import {IcicleGraphSkeleton, useParcaContext, useURLState} from '@parca/componen
 import {ProfileType} from '@parca/parser';
 import {capitalizeOnlyFirstLetter, divide} from '@parca/utilities';
 
-import {ProfileSource} from '../ProfileSource';
+import { MergedProfileSource, ProfileSource } from '../ProfileSource';
 import DiffLegend from '../ProfileView/components/DiffLegend';
 import {useProfileViewContext} from '../ProfileView/context/ProfileViewContext';
 import {TimelineGuide} from '../TimelineGuide';
@@ -58,6 +58,12 @@ interface ProfileIcicleGraphProps {
 const ErrorContent = ({errorMessage}: {errorMessage: string}): JSX.Element => {
   return <div className="flex justify-center p-10">{errorMessage}</div>;
 };
+
+export const validateIcicleChartQuery = (profileSource: MergedProfileSource) => {
+  const isNonDelta = profileSource.ProfileType().delta !== true;
+  const isDurationTooLong = profileSource.mergeTo - profileSource.mergeFrom > 10000;
+  return { isValid: !isNonDelta && !isDurationTooLong, isNonDelta, isDurationTooLong };
+}
 
 const ProfileIcicleGraph = function ProfileIcicleGraphNonMemo({
   graph,
@@ -149,12 +155,29 @@ const ProfileIcicleGraph = function ProfileIcicleGraphNonMemo({
   }, [loadingState]);
 
   const icicleGraph = useMemo(() => {
-    if (isLoading) {
+    const { isValid: isIcicleChartValid, isNonDelta, isDurationTooLong } = validateIcicleChartQuery(profileSource as MergedProfileSource);
+    const isInvalidIcicleChartQuery = isIcicleChart && isIcicleChartValid === false;
+    if (isLoading && !isInvalidIcicleChartQuery) {
       return (
         <div className="h-auto overflow-clip">
           <IcicleGraphSkeleton isHalfScreen={isHalfScreen} isDarkMode={isDarkMode} />
         </div>
       );
+    }
+
+    // Do necessary checks to ensure that icicle chart can be rendered for this query.
+    if (isInvalidIcicleChartQuery) {
+      if (isNonDelta) {
+        return <ErrorContent errorMessage="Icicle chart is only available for delta profiles." />;
+      } else if (isDurationTooLong) {
+        return (
+          <ErrorContent errorMessage="Icicle chart is not available for queries with a duration longer than 10 seconds, select a point in the metrics graph to continue." />
+        );
+      } else {
+        return (
+          <ErrorContent errorMessage="Icicle chart is not available for this query." />
+        );
+      }
     }
 
     if (graph === undefined && arrow === undefined)

--- a/ui/packages/shared/profile/src/ProfileIcicleGraph/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph/index.tsx
@@ -161,7 +161,9 @@ const ProfileIcicleGraph = function ProfileIcicleGraphNonMemo({
       isValid: isIcicleChartValid,
       isNonDelta,
       isDurationTooLong,
-    } = isIcicleChart ? validateIcicleChartQuery(profileSource as MergedProfileSource) : { isValid: true, isNonDelta: false, isDurationTooLong: false };
+    } = isIcicleChart
+      ? validateIcicleChartQuery(profileSource as MergedProfileSource)
+      : {isValid: true, isNonDelta: false, isDurationTooLong: false};
     const isInvalidIcicleChartQuery = isIcicleChart && !isIcicleChartValid;
     if (isLoading && !isInvalidIcicleChartQuery) {
       return (

--- a/ui/packages/shared/profile/src/ProfileIcicleGraph/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph/index.tsx
@@ -159,8 +159,8 @@ const ProfileIcicleGraph = function ProfileIcicleGraphNonMemo({
       isValid: isIcicleChartValid,
       isNonDelta,
       isDurationTooLong,
-    } = validateIcicleChartQuery(profileSource as MergedProfileSource);
-    const isInvalidIcicleChartQuery = isIcicleChart && isIcicleChartValid;
+    } = isIcicleChart ? validateIcicleChartQuery(profileSource as MergedProfileSource) : { isValid: true, isNonDelta: false, isDurationTooLong: false };
+    const isInvalidIcicleChartQuery = isIcicleChart && !isIcicleChartValid;
     if (isLoading && !isInvalidIcicleChartQuery) {
       return (
         <div className="h-auto overflow-clip">

--- a/ui/packages/shared/profile/src/ProfileViewWithData.tsx
+++ b/ui/packages/shared/profile/src/ProfileViewWithData.tsx
@@ -17,12 +17,12 @@ import {QueryRequest_ReportType, QueryServiceClient} from '@parca/client';
 import {useGrpcMetadata, useParcaContext, useURLState} from '@parca/components';
 import {saveAsBlob} from '@parca/utilities';
 
+import {validateIcicleChartQuery} from './ProfileIcicleGraph';
 import {FIELD_FUNCTION_NAME} from './ProfileIcicleGraph/IcicleGraphArrow';
-import { MergedProfileSource, ProfileSource } from './ProfileSource';
+import {MergedProfileSource, ProfileSource} from './ProfileSource';
 import {ProfileView} from './ProfileView';
 import {useQuery} from './useQuery';
 import {downloadPprof} from './utils';
-import { validateIcicleChartQuery } from './ProfileIcicleGraph';
 
 interface ProfileViewWithDataProps {
   queryClient: QueryServiceClient;
@@ -67,7 +67,6 @@ export const ProfileViewWithData = ({
     return (1 / width) * 100;
   }, []);
 
-
   const {
     isLoading: flamegraphLoading,
     response: flamegraphResponse,
@@ -85,7 +84,10 @@ export const ProfileViewWithData = ({
     response: flamechartResponse,
     error: flamechartError,
   } = useQuery(queryClient, profileSource, QueryRequest_ReportType.FLAMECHART, {
-    skip: !(dashboardItems.includes('iciclechart') && validateIcicleChartQuery(profileSource as MergedProfileSource).isValid),
+    skip: !(
+      dashboardItems.includes('iciclechart') &&
+      validateIcicleChartQuery(profileSource as MergedProfileSource).isValid
+    ),
     nodeTrimThreshold,
     groupBy,
     invertCallStack,

--- a/ui/packages/shared/profile/src/ProfileViewWithData.tsx
+++ b/ui/packages/shared/profile/src/ProfileViewWithData.tsx
@@ -18,10 +18,11 @@ import {useGrpcMetadata, useParcaContext, useURLState} from '@parca/components';
 import {saveAsBlob} from '@parca/utilities';
 
 import {FIELD_FUNCTION_NAME} from './ProfileIcicleGraph/IcicleGraphArrow';
-import {ProfileSource} from './ProfileSource';
+import { MergedProfileSource, ProfileSource } from './ProfileSource';
 import {ProfileView} from './ProfileView';
 import {useQuery} from './useQuery';
 import {downloadPprof} from './utils';
+import { validateIcicleChartQuery } from './ProfileIcicleGraph';
 
 interface ProfileViewWithDataProps {
   queryClient: QueryServiceClient;
@@ -66,6 +67,7 @@ export const ProfileViewWithData = ({
     return (1 / width) * 100;
   }, []);
 
+
   const {
     isLoading: flamegraphLoading,
     response: flamegraphResponse,
@@ -83,7 +85,7 @@ export const ProfileViewWithData = ({
     response: flamechartResponse,
     error: flamechartError,
   } = useQuery(queryClient, profileSource, QueryRequest_ReportType.FLAMECHART, {
-    skip: !dashboardItems.includes('iciclechart'),
+    skip: !(dashboardItems.includes('iciclechart') && validateIcicleChartQuery(profileSource as MergedProfileSource).isValid),
     nodeTrimThreshold,
     groupBy,
     invertCallStack,


### PR DESCRIPTION
This PR adds some validations on the query before querying for flamecharts and renders appropriate error message in the UI. 

Screenshots:
Valid Query:
<img width="1317" alt="Screenshot 2025-05-06 at 3 26 19 PM" src="https://github.com/user-attachments/assets/169a6a8a-fc5b-44f8-a4e5-0e335d5dca48" />

Invalid Queries:

<img width="1296" alt="Screenshot 2025-05-06 at 3 23 18 PM" src="https://github.com/user-attachments/assets/b1946cc3-32b0-4b38-89e4-42a468f7e55e" />

<img width="1296" alt="Screenshot 2025-05-06 at 3 24 42 PM" src="https://github.com/user-attachments/assets/c87f27af-b347-4a1c-92bb-cd3a60823cdf" />
