### PR TITLE
feat: ui: Add support for dashed lines for limit metrics in graphs

### DIFF
--- a/ui/packages/shared/profile/src/MetricsGraph/UtilizationMetrics/index.tsx
+++ b/ui/packages/shared/profile/src/MetricsGraph/UtilizationMetrics/index.tsx
@@ -481,6 +481,10 @@ const RawUtilizationMetrics = ({
                   });
                 }
 
+                const isLimit = s.metric
+                  .findIndex(m => m.name === '__type__' && m.value === 'limit') > -1;
+                const strokeDasharray = isLimit ? '8 4' : '';
+
                 return (
                   <g key={i} className="line cursor-pointer">
                     <MetricsSeries
@@ -494,6 +498,7 @@ const RawUtilizationMetrics = ({
                           ? lineStrokeHover
                           : lineStroke
                       }
+                      strokeDasharray={strokeDasharray}
                       xScale={xScale}
                       yScale={yScale}
                       onClick={() => {

--- a/ui/packages/shared/profile/src/MetricsGraph/UtilizationMetrics/index.tsx
+++ b/ui/packages/shared/profile/src/MetricsGraph/UtilizationMetrics/index.tsx
@@ -481,8 +481,8 @@ const RawUtilizationMetrics = ({
                   });
                 }
 
-                const isLimit = s.metric
-                  .findIndex(m => m.name === '__type__' && m.value === 'limit') > -1;
+                const isLimit =
+                  s.metric.findIndex(m => m.name === '__type__' && m.value === 'limit') > -1;
                 const strokeDasharray = isLimit ? '8 4' : '';
 
                 return (

--- a/ui/packages/shared/profile/src/MetricsGraph/utils/colorMapping.ts
+++ b/ui/packages/shared/profile/src/MetricsGraph/utils/colorMapping.ts
@@ -25,6 +25,7 @@ const colorScale = d3.scaleOrdinal(d3.schemeCategory10);
 export function getSeriesColor(labels: Array<{name: string; value: string}>): string {
   // Create a key from all labels to ensure unique identification
   const key = labels
+    .filter(l => l.name !== '__type__' && l.name !== 'limit') // ignore injected virtual labels
     .map(l => `${l.name}=${l.value}`)
     .sort()
     .join(',');

--- a/ui/packages/shared/profile/src/MetricsSeries/index.tsx
+++ b/ui/packages/shared/profile/src/MetricsSeries/index.tsx
@@ -18,6 +18,7 @@ interface MetricsSeriesProps {
   line: d3.Line<[number, number]>;
   color: string;
   strokeWidth: string;
+  strokeDasharray?: string;
   xScale: (input: number) => number;
   yScale: (input: number) => number;
   onClick?: () => void;
@@ -28,6 +29,7 @@ const MetricsSeries = ({
   line,
   color,
   strokeWidth,
+  strokeDasharray = '',
   onClick,
 }: MetricsSeriesProps): JSX.Element => (
   <g className="line-group">
@@ -37,6 +39,7 @@ const MetricsSeries = ({
       style={{
         stroke: color,
         strokeWidth,
+        strokeDasharray,
       }}
       onClick={onClick}
     />

--- a/ui/packages/shared/profile/src/ProfileSelector/MetricsGraphSection.tsx
+++ b/ui/packages/shared/profile/src/ProfileSelector/MetricsGraphSection.tsx
@@ -153,7 +153,7 @@ export function MetricsGraphSection({
         metric.name === 'gpu_pcie_throughput_receive_bytes'
     );
 
-    if (utilizationMetrics === undefined || utilizationMetrics.length === 0) {
+    if (utilizationMetrics.length === 0) {
       return <></>;
     }
 


### PR DESCRIPTION
Filtered out virtual labels for unique key generation in colors. Introduced a `strokeDasharray` prop to allow dashed lines, applied to limit metrics for visual distinction.
