### PR TITLE
feat(debuginfo): implement ObjectSizer interface for UploadReader

### DIFF
--- a/pkg/debuginfo/reader.go
+++ b/pkg/debuginfo/reader.go
@@ -91,3 +91,9 @@ func contextError(ctx context.Context) error {
 		return nil
 	}
 }
+
+// ObjectSize implements the objstore.ObjectSizer interface to provide the total size of bytes read so far.
+// This is used by objstore.TryToGetSize to optimize multipart uploads by pre-allocating the correct buffer size.
+func (r *UploadReader) ObjectSize() (int64, error) {
+	return int64(r.size), nil
+}


### PR DESCRIPTION
Implement `objstore.ObjectSizer` interface on UploadReader to support optimized multipart uploads. This allows `objstore.TryToGetSize` to determine the total size of the upload stream, enabling proper buffer pre-allocation and improving upload performance.

The implementation tracks the running total of bytes read in the size field and returns it via `ObjectSize()`, resolving the below warning when using a S3 storage for `debuginfo`.

```
level=warn ... msg="could not guess file size for multipart upload; upload might be not optimized" name=debuginfo/8201aa879bcc815d4abc232049bb1c2a/debuginfo err="unsupported type of io.Reader: *debuginfo.UploadReader"
```