### PR TITLE
Revert "feat(debuginfo): implement ObjectSizer interface for UploadReader"

### DIFF
--- a/pkg/debuginfo/reader.go
+++ b/pkg/debuginfo/reader.go
@@ -91,9 +91,3 @@ func contextError(ctx context.Context) error {
 		return nil
 	}
 }
-
-// ObjectSize implements the objstore.ObjectSizer interface to provide the total size of bytes read so far.
-// This is used by objstore.TryToGetSize to optimize multipart uploads by pre-allocating the correct buffer size.
-func (r *UploadReader) ObjectSize() (int64, error) {
-	return int64(r.size), nil
-}


### PR DESCRIPTION
This reverts commit b86663df0f51de0a54d726ac4acc94e34315f5d0.

#5641 uses "UploadReader.size" as "ObjectSize()", but "size" is not set when initializing, so "ObjectSize()" returns "0". Then it causes the uploaded "debuginfo" file to be size zero.

It seems currently the warning "could not guess file size for multipart upload; upload might be not optimized" has to be left.