### PR TITLE
Fix depth crash

### DIFF
--- a/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/IcicleGraphNodes.tsx
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/IcicleGraphNodes.tsx
@@ -114,7 +114,9 @@ export const IcicleNode = React.memo(function IcicleNodeNoMemo({
   const filename: string | null = arrowToString(filenameColumn?.get(row));
   const depth: number = depthColumn?.get(row) ?? 0;
   const valueOffset: bigint =
-    valueOffsetColumn?.get(row) !== null ? BigInt(valueOffsetColumn?.get(row)) : 0n;
+    valueOffsetColumn?.get(row) !== null && valueOffsetColumn?.get(row) !== undefined
+      ? BigInt(valueOffsetColumn?.get(row))
+      : 0n;
 
   const colorAttribute =
     colorBy === 'filename' ? filename : colorBy === 'binary' ? mappingFile : null;
@@ -147,7 +149,10 @@ export const IcicleNode = React.memo(function IcicleNodeNoMemo({
   }, [searchString, name]);
 
   const selectionOffset =
-    valueOffsetColumn?.get(selectedRow) !== null ? BigInt(valueOffsetColumn?.get(selectedRow)) : 0n;
+    valueOffsetColumn?.get(selectedRow) !== null &&
+    valueOffsetColumn?.get(selectedRow) !== undefined
+      ? BigInt(valueOffsetColumn?.get(selectedRow))
+      : 0n;
   const selectionCumulative =
     cumulativeColumn?.get(selectedRow) !== null ? BigInt(cumulativeColumn?.get(selectedRow)) : 0n;
   if (

--- a/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/index.tsx
@@ -106,6 +106,17 @@ export const getFilenameColors = (
 
 const noop = (): void => {};
 
+function getMaxDepth(depthColumn: Vector<any> | null): number {
+  if (depthColumn === null) return 0;
+
+  let max = 0;
+  for (const val of depthColumn) {
+    const numVal = Number(val);
+    if (numVal > max) max = numVal;
+  }
+  return max;
+}
+
 export const IcicleGraphArrow = memo(function IcicleGraphArrow({
   arrow,
   total,
@@ -237,16 +248,7 @@ export const IcicleGraphArrow = memo(function IcicleGraphArrow({
   };
 
   const depthColumn = table.getChild(FIELD_DEPTH);
-  const maxDepth =
-    depthColumn === null
-      ? 0
-      : (() => {
-          let max = 0;
-          for (const val of depthColumn) {
-            max = Math.max(max, val);
-          }
-          return max;
-        })();
+  const maxDepth = getMaxDepth(depthColumn);
   const height = maxDepth * RowHeight;
 
   // To find the selected row, we must walk the current path and look at which

--- a/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/index.tsx
@@ -237,7 +237,16 @@ export const IcicleGraphArrow = memo(function IcicleGraphArrow({
   };
 
   const depthColumn = table.getChild(FIELD_DEPTH);
-  const maxDepth = depthColumn === null ? 0 : Math.max(...depthColumn.toArray());
+  const maxDepth =
+    depthColumn === null
+      ? 0
+      : (() => {
+          let max = 0;
+          for (const val of depthColumn) {
+            max = Math.max(max, val);
+          }
+          return max;
+        })();
   const height = maxDepth * RowHeight;
 
   // To find the selected row, we must walk the current path and look at which


### PR DESCRIPTION
This PR adds null/undefined checks and introduces a helper function for calculating maximum depth.

* Updated the `valueOffset` and `selectionOffset` calculations in `IcicleNode` to include explicit checks for both `null` and `undefined` values, ensuring safer handling of potential edge cases. 

* Added a new helper function `getMaxDepth` to encapsulate the logic for determining the maximum depth from a `depthColumn`, improving readability and reusability. 