### PR TITLE
ui: Properly handle multiple encodings for query expressions

### DIFF
--- a/ui/packages/shared/utilities/src/decodeMultipleEncodings.test.ts
+++ b/ui/packages/shared/utilities/src/decodeMultipleEncodings.test.ts
@@ -1,0 +1,68 @@
+// Copyright 2022 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {expect, test} from 'vitest';
+
+import {decodeMultipleEncodings} from './index';
+
+test('decodeMultipleEncodings - should handle single encoding', () => {
+  const input = 'parca_agent%3Asamples%3Acount%3Acpu%3Ananoseconds%3Adelta';
+  const expected = 'parca_agent:samples:count:cpu:nanoseconds:delta';
+  expect(decodeMultipleEncodings(input)).toBe(expected);
+});
+
+test('decodeMultipleEncodings - should handle double encoding', () => {
+  const input = 'parca_agent%253Asamples%253Acount%253Acpu%253Ananoseconds%253Adelta';
+  const expected = 'parca_agent:samples:count:cpu:nanoseconds:delta';
+  expect(decodeMultipleEncodings(input)).toBe(expected);
+});
+
+test('decodeMultipleEncodings - should handle triple encoding', () => {
+  const input = 'parca_agent%25253Asamples%25253Acount%25253Acpu%25253Ananoseconds%25253Adelta';
+  const expected = 'parca_agent:samples:count:cpu:nanoseconds:delta';
+  expect(decodeMultipleEncodings(input)).toBe(expected);
+});
+
+test('decodeMultipleEncodings - should handle the exact case from the bug report', () => {
+  const input =
+    'parca_agent%2525252525253Asamples%2525252525253Acount%2525252525253Acpu%2525252525253Ananoseconds%2525252525253Adelta%2525252525257Bnamespace%2525252525253D%25252525252522environment-1c86a3b5-9073-4ba5-9f3f-daf63532ad0a-0%25252525252522%2525252525257D';
+  const expected =
+    'parca_agent:samples:count:cpu:nanoseconds:delta{namespace="environment-1c86a3b5-9073-4ba5-9f3f-daf63532ad0a-0"}';
+  expect(decodeMultipleEncodings(input)).toBe(expected);
+});
+
+test('decodeMultipleEncodings - should handle unencoded strings', () => {
+  const input = 'parca_agent:samples:count:cpu:nanoseconds:delta';
+  expect(decodeMultipleEncodings(input)).toBe(input);
+});
+
+test('decodeMultipleEncodings - should handle empty strings', () => {
+  expect(decodeMultipleEncodings('')).toBe('');
+});
+
+test('decodeMultipleEncodings - should handle null/undefined gracefully', () => {
+  expect(decodeMultipleEncodings(null as any)).toBe(null);
+  expect(decodeMultipleEncodings(undefined as any)).toBe(undefined);
+});
+
+test('decodeMultipleEncodings - should handle invalid encoding gracefully', () => {
+  const input = 'invalid%ZZencoding';
+  expect(decodeMultipleEncodings(input)).toBe(input);
+});
+
+test('decodeMultipleEncodings - should prevent infinite loops with malformed input', () => {
+  const input = '%25%25%25%25%25%25%25%25%25%25%25%25%25%25%25%25';
+  const result = decodeMultipleEncodings(input);
+  // Should return something and not hang
+  expect(typeof result).toBe('string');
+});

--- a/ui/packages/shared/utilities/src/decodeMultipleEncodings.test.ts
+++ b/ui/packages/shared/utilities/src/decodeMultipleEncodings.test.ts
@@ -51,8 +51,8 @@ test('decodeMultipleEncodings - should handle empty strings', () => {
 });
 
 test('decodeMultipleEncodings - should handle null/undefined gracefully', () => {
-  expect(decodeMultipleEncodings(null as any)).toBe(null);
-  expect(decodeMultipleEncodings(undefined as any)).toBe(undefined);
+  expect(decodeMultipleEncodings(null)).toBe(null);
+  expect(decodeMultipleEncodings(undefined)).toBe(undefined);
 });
 
 test('decodeMultipleEncodings - should handle invalid encoding gracefully', () => {

--- a/ui/packages/shared/utilities/src/index.ts
+++ b/ui/packages/shared/utilities/src/index.ts
@@ -434,8 +434,10 @@ export const isUrlEncoded = (str: string): boolean => {
 };
 
 // Safely decode a string that might have multiple levels of URL encoding
-export const decodeMultipleEncodings = (str: string): string => {
-  if (str === undefined || str === '') return str;
+export const decodeMultipleEncodings = (
+  str: string | null | undefined
+): string | null | undefined => {
+  if (str == null) return str;
 
   let decoded = str;
   let previousDecoded = '';

--- a/ui/packages/shared/utilities/src/index.ts
+++ b/ui/packages/shared/utilities/src/index.ts
@@ -187,7 +187,7 @@ export const parseParams = (
 
   const obj: Record<string, string | string[]> = {};
   for (const key of Array.from(params.keys())) {
-    let values = params.getAll(key);
+    let values = params.getAll(key).filter((v): v is string => v != null);
 
     // Handle expression parameters that might have multiple levels of encoding
     if (
@@ -196,15 +196,19 @@ export const parseParams = (
       key === 'selection_a' ||
       key === 'selection_b'
     ) {
-      values = values.map(value => {
+      values = values.map((value): string => {
         // First, decode multiple levels if present
         const decoded = decodeMultipleEncodings(value);
         // Then, if encodeValues is true, ensure it's encoded once
         if (encodeValues === true) {
-          return isUrlEncoded(decoded) ? decoded : encodeURIComponent(decoded);
+          return decoded != null
+            ? isUrlEncoded(decoded)
+              ? decoded
+              : encodeURIComponent(decoded)
+            : '';
         }
         // Otherwise return the fully decoded value
-        return decoded;
+        return decoded ?? '';
       });
     }
 


### PR DESCRIPTION
This PR helps to handle query expressions that have been encoded multiple times and now breaking the app. It  safely decodes strings that may have multiple levels of URL encoding with the `decodeMultipleEncodings` function.

I've also added safegaurds to ensure that we're not unnecessarily encoding query expressions multiple times by doing all the encoding for query expressions in the `filterSuffix` function.