### PR TITLE
feat: improve error handling for overlapping data in icicle charts

### DIFF
--- a/ui/packages/shared/profile/src/ProfileIcicleGraph/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph/index.tsx
@@ -280,6 +280,33 @@ const ProfileIcicleGraph = function ProfileIcicleGraphNonMemo({
       return <ErrorContent errorMessage={authenticationErrorMessage} />;
     }
 
+    // Check for specific merge errors
+    const errorMessageLower = error.message?.toLowerCase() ?? '';
+    const isMergeError: boolean = errorMessageLower.includes('failed to merge flame chart records');
+    const isTimestampError: boolean = errorMessageLower.includes('multiple samples for the same timestamp is not allowed');
+
+    if (isMergeError || isTimestampError) {
+      return (
+        <ErrorContent
+          errorMessage={
+            <>
+              <span className="font-semibold">Unable to display overlapping data</span>
+              <span className="text-gray-600 dark:text-gray-400">
+                The selected data contains overlapping samples from multiple nodes or threads that cannot be merged.
+              </span>
+              <span className="text-gray-600 dark:text-gray-400">
+                To view this data, please apply more specific filters:
+              </span>
+              <ul className="list-disc list-inside text-left max-w-md mx-auto text-gray-600 dark:text-gray-400">
+                <li>Select a specific node from the node selector</li>
+                <li>Filter by either CPU or thread</li>
+              </ul>
+            </>
+          }
+        />
+      );
+    }
+
     return (
       <ErrorContent
         errorMessage={

--- a/ui/packages/shared/profile/src/ProfileIcicleGraph/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph/index.tsx
@@ -283,7 +283,9 @@ const ProfileIcicleGraph = function ProfileIcicleGraphNonMemo({
     // Check for specific merge errors
     const errorMessageLower = error.message?.toLowerCase() ?? '';
     const isMergeError: boolean = errorMessageLower.includes('failed to merge flame chart records');
-    const isTimestampError: boolean = errorMessageLower.includes('multiple samples for the same timestamp is not allowed');
+    const isTimestampError: boolean = errorMessageLower.includes(
+      'multiple samples for the same timestamp is not allowed'
+    );
 
     if (isMergeError || isTimestampError) {
       return (
@@ -292,7 +294,8 @@ const ProfileIcicleGraph = function ProfileIcicleGraphNonMemo({
             <>
               <span className="font-semibold">Unable to display overlapping data</span>
               <span className="text-gray-600 dark:text-gray-400">
-                The selected data contains overlapping samples from multiple nodes or threads that cannot be merged.
+                The selected data contains overlapping samples from multiple nodes or threads that
+                cannot be merged.
               </span>
               <span className="text-gray-600 dark:text-gray-400">
                 To view this data, please apply more specific filters:


### PR DESCRIPTION
## Summary
- Add user-friendly error messages for icicle chart merge conflicts
- Handle "Failed to merge flame chart records" and "Multiple samples for the same timestamp" errors
- Display clear filtering instructions to resolve overlapping data issues

![image](https://github.com/user-attachments/assets/30bbb12b-9a10-4cd8-88c8-c1918d4137c7)
