### PR TITLE
ui: Change "Show function name from left side" preference to be icicle graph option

### DIFF
--- a/ui/packages/shared/components/src/UserPreferences/index.tsx
+++ b/ui/packages/shared/components/src/UserPreferences/index.tsx
@@ -71,10 +71,6 @@ const UserPreferences = ({modal}: {modal?: boolean}): JSX.Element => {
           userPreferenceDetails={USER_PREFERENCES.HIGHLIGHT_SIMILAR_STACKS}
         />
         <UserPreferenceItem
-          id="h-show-function-name-from-left"
-          userPreferenceDetails={USER_PREFERENCES.SHOW_FUNCTION_NAME_FROM_LEFT}
-        />
-        <UserPreferenceItem
           id="h-enable-iciclechart"
           userPreferenceDetails={USER_PREFERENCES.ENABLE_ICICLECHARTS}
         />

--- a/ui/packages/shared/hooks/src/useUserPreference/index.ts
+++ b/ui/packages/shared/hooks/src/useUserPreference/index.ts
@@ -64,14 +64,6 @@ export const USER_PREFERENCES: {[key: string]: UserPreferenceDetails} = {
     description:
       "When enabled, this option automatically highlights stacks that are similar to the one you're currently hovering over in the Icicle graph.",
   },
-  SHOW_FUNCTION_NAME_FROM_LEFT: {
-    name: 'Show function name from left side',
-    key: 'SHOW_FUNCTION_NAME_FROM_LEFT',
-    type: 'boolean',
-    default: true,
-    description:
-      'When enabled, function names in the graph will be shown starting from the left side. When disabled, names will be shown from the right side, which can be more useful for languages where the most distinctive part of the function name appears at the end.',
-  },
   ENABLE_ICICLECHARTS: {
     name: 'Enable Icicle charts',
     key: 'ENABLE_ICICLECHARTS',

--- a/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/TextWithEllipsis.tsx
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/TextWithEllipsis.tsx
@@ -13,7 +13,7 @@
 
 import {useEffect, useRef, useState} from 'react';
 
-import {USER_PREFERENCES, useUserPreference} from '@parca/hooks';
+import {useURLState} from '@parca/components';
 
 interface Props {
   text: string;
@@ -66,9 +66,9 @@ function calculateTruncatedText(
 function TextWithEllipsis({text, x, y, width}: Props): JSX.Element {
   const textRef = useRef<SVGTextElement>(null);
   const [displayText, setDisplayText] = useState(text);
-  const [showFunctionNameFromLeft] = useUserPreference<boolean>(
-    USER_PREFERENCES.SHOW_FUNCTION_NAME_FROM_LEFT.key
-  );
+  const [alignFunctionName] = useURLState('align_function_name');
+
+  const showFunctionNameFromLeft = alignFunctionName === 'left' || alignFunctionName === undefined;
 
   useEffect(() => {
     const textElement = textRef.current;

--- a/ui/packages/shared/profile/src/ProfileView/components/Toolbars/MultiLevelDropdown.tsx
+++ b/ui/packages/shared/profile/src/ProfileView/components/Toolbars/MultiLevelDropdown.tsx
@@ -167,6 +167,9 @@ const MultiLevelDropdown: React.FC<MultiLevelDropdownProps> = ({onSelect, profil
   const isInvert = invertStack === 'true';
   const isColorStackLegendEnabled = colorStackLegend === 'true';
 
+  const [alignFunctionName, setAlignFunctionName] = useURLState('align_function_name');
+  const isLeftAligned = alignFunctionName === 'left' || alignFunctionName === undefined;
+
   // By default, we want delta profiles (CPU) to be relatively compared.
   // For non-delta profiles, like goroutines or memory, we want the profiles to be compared absolutely.
   const compareAbsoluteDefault = profileType?.delta === false ? 'true' : 'false';
@@ -226,6 +229,15 @@ const MultiLevelDropdown: React.FC<MultiLevelDropdownProps> = ({onSelect, profil
       icon: isInvert ? 'ph:sort-ascending' : 'ph:sort-descending',
     },
     {
+      label: isLeftAligned ? 'Right-align function names' : 'Left-align function names',
+      onclick: () => setAlignFunctionName(isLeftAligned ? 'right' : 'left'),
+      id: 'h-align-function-names',
+      hide: false,
+      icon: isLeftAligned
+        ? 'ic:outline-align-horizontal-right'
+        : 'ic:outline-align-horizontal-left',
+    },
+    {
       label: isCompareAbsolute ? 'Compare Relative' : 'Compare Absolute',
       onclick: () => setCompareAbsolute(isCompareAbsolute ? 'false' : 'true'),
       hide: !compareMode,
@@ -275,7 +287,7 @@ const MultiLevelDropdown: React.FC<MultiLevelDropdownProps> = ({onSelect, profil
               </span>
             </Menu.Button>
             {open && (
-              <Menu.Items className="absolute z-30 left-0 w-56 mt-2 py-2 origin-top-right bg-white rounded-md shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none border dark:bg-gray-900 dark:border-gray-600">
+              <Menu.Items className="absolute z-30 left-0 w-64 mt-2 py-2 origin-top-right bg-white rounded-md shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none border dark:bg-gray-900 dark:border-gray-600">
                 <span className="text-xs text-gray-400 capitalize px-4 py-3">actions</span>
                 {menuItems
                   .filter(item => item.hide !== undefined && !item.hide)


### PR DESCRIPTION
This moves the option of showing function names from lef/right side away from the user preferences settings to be an Icicle graph action.

<img width="472" alt="image" src="https://github.com/user-attachments/assets/133dfbed-17c4-4a03-aa84-62d42290b628" />
