### PR TITLE
ui: Fixed metrics graph alignment to the grid

### DIFF
--- a/ui/packages/shared/profile/src/MetricsGraph/UtilizationMetrics/index.tsx
+++ b/ui/packages/shared/profile/src/MetricsGraph/UtilizationMetrics/index.tsx
@@ -129,7 +129,11 @@ const RawUtilizationMetrics = ({
   const lineStrokeHover = '2px';
   const lineStrokeSelected = '3px';
 
-  const graphWidth = width - margin * 1.5 - margin / 2;
+  const graphWidth = useMemo(() => (width - margin * 1.5 - margin / 2), [width, margin]);
+  const graphTransform = useMemo(() => {
+    // Adds 10px padding which aligns the graph on the grid
+    return `translate(10, 0) scale(${(graphWidth - 10) / graphWidth}, 1)`;
+  }, [graphWidth]);
 
   const paddedFrom = from;
   const paddedTo = to;
@@ -461,7 +465,7 @@ const RawUtilizationMetrics = ({
                 </text>
               </g>
             </g>
-            <g className="lines fill-transparent">
+            <g className="lines fill-transparent" transform={graphTransform}>
               {series.map((s, i) => {
                 const isLimit =
                   s.metric.findIndex(m => m.name === '__type__' && m.value === 'limit') > -1;

--- a/ui/packages/shared/profile/src/MetricsGraph/UtilizationMetrics/index.tsx
+++ b/ui/packages/shared/profile/src/MetricsGraph/UtilizationMetrics/index.tsx
@@ -129,7 +129,7 @@ const RawUtilizationMetrics = ({
   const lineStrokeHover = '2px';
   const lineStrokeSelected = '3px';
 
-  const graphWidth = useMemo(() => (width - margin * 1.5 - margin / 2), [width, margin]);
+  const graphWidth = useMemo(() => width - margin * 1.5 - margin / 2, [width, margin]);
   const graphTransform = useMemo(() => {
     // Adds 10px padding which aligns the graph on the grid
     return `translate(10, 0) scale(${(graphWidth - 10) / graphWidth}, 1)`;

--- a/ui/packages/shared/profile/src/MetricsGraph/index.tsx
+++ b/ui/packages/shared/profile/src/MetricsGraph/index.tsx
@@ -158,7 +158,11 @@ export const RawMetricsGraph = ({
     width = 0;
   }
 
-  const graphWidth = width - margin * 1.5 - margin / 2;
+  const graphWidth = useMemo(() => (width - (margin * 1.5) - (margin / 2)), [width, margin]);
+  const graphTransform = useMemo(() => {
+    // Adds 6px padding which aligns the graph on the grid
+    return `translate(6, 0) scale(${(graphWidth - 6) / graphWidth}, 1)`;
+  }, [graphWidth]);
 
   const series: Series[] = data.reduce<Series[]>(function (agg: Series[], s: MetricsSeriesPb) {
     if (s.labelset !== undefined) {
@@ -595,7 +599,7 @@ export const RawMetricsGraph = ({
                 </text>
               </g>
             </g>
-            <g className="lines fill-transparent">
+            <g className="lines fill-transparent" transform={graphTransform} width={graphWidth - 100}>
               {series.map((s, i) => (
                 <g key={i} className="line">
                   <MetricsSeries
@@ -618,6 +622,7 @@ export const RawMetricsGraph = ({
                 className="circle-group"
                 ref={metricPointRef}
                 style={{fill: color(highlighted.seriesIndex.toString())}}
+                transform={graphTransform}
               >
                 <MetricsCircle cx={highlighted.x} cy={highlighted.y} />
               </g>
@@ -630,6 +635,7 @@ export const RawMetricsGraph = ({
                     ? {fill: color(selected.seriesIndex.toString())}
                     : {}
                 }
+                transform={graphTransform}
               >
                 <MetricsCircle cx={selected.x} cy={selected.y} radius={5} />
               </g>

--- a/ui/packages/shared/profile/src/MetricsGraph/index.tsx
+++ b/ui/packages/shared/profile/src/MetricsGraph/index.tsx
@@ -158,7 +158,7 @@ export const RawMetricsGraph = ({
     width = 0;
   }
 
-  const graphWidth = useMemo(() => (width - (margin * 1.5) - (margin / 2)), [width, margin]);
+  const graphWidth = useMemo(() => width - margin * 1.5 - margin / 2, [width, margin]);
   const graphTransform = useMemo(() => {
     // Adds 6px padding which aligns the graph on the grid
     return `translate(6, 0) scale(${(graphWidth - 6) / graphWidth}, 1)`;
@@ -599,7 +599,11 @@ export const RawMetricsGraph = ({
                 </text>
               </g>
             </g>
-            <g className="lines fill-transparent" transform={graphTransform} width={graphWidth - 100}>
+            <g
+              className="lines fill-transparent"
+              transform={graphTransform}
+              width={graphWidth - 100}
+            >
               {series.map((s, i) => (
                 <g key={i} className="line">
                   <MetricsSeries

--- a/ui/packages/shared/profile/src/MetricsSeries/index.tsx
+++ b/ui/packages/shared/profile/src/MetricsSeries/index.tsx
@@ -19,6 +19,7 @@ interface MetricsSeriesProps {
   color: string;
   strokeWidth: string;
   strokeDasharray?: string;
+  strokeLinecap?: React.CSSProperties['strokeLinecap'];
   xScale: (input: number) => number;
   yScale: (input: number) => number;
   onClick?: () => void;
@@ -30,6 +31,7 @@ const MetricsSeries = ({
   color,
   strokeWidth,
   strokeDasharray = '',
+  strokeLinecap = 'round',
   onClick,
 }: MetricsSeriesProps): JSX.Element => (
   <g className="line-group">
@@ -40,6 +42,7 @@ const MetricsSeries = ({
         stroke: color,
         strokeWidth,
         strokeDasharray,
+        strokeLinecap,
       }}
       onClick={onClick}
     />


### PR DESCRIPTION
The metrics graph needed some padding to align it to the grid scale which in turn fixed the overflows on either side.