### PR TITLE
Fix labels not appearing in SimpleMatchers after adding via context menu

### DIFF
--- a/ui/packages/shared/profile/src/ProfileSelector/QueryControls.tsx
+++ b/ui/packages/shared/profile/src/ProfileSelector/QueryControls.tsx
@@ -159,6 +159,7 @@ export function QueryControls({
           />
         ) : (
           <SimpleMatchers
+            key={query.toString()}
             setMatchersString={setMatchersString}
             runQuery={setQueryExpression}
             currentQuery={query}

--- a/ui/packages/shared/profile/src/SimpleMatchers/index.tsx
+++ b/ui/packages/shared/profile/src/SimpleMatchers/index.tsx
@@ -198,8 +198,18 @@ const SimpleMatchers = ({
 
   useEffect(() => {
     if (currentMatchers === '') {
+      const defaultRow = {
+        labelName: '',
+        operator: '=',
+        labelValue: '',
+        labelValues: [],
+        isLoading: false,
+      };
+      setQueryRows([defaultRow]);
       return;
     }
+
+    let isCancelled = false;
 
     const fetchAndSetQueryRows = async (): Promise<void> => {
       const newRows = await Promise.all(
@@ -222,17 +232,23 @@ const SimpleMatchers = ({
             operator,
             labelValue: sanitizedLabelValue,
             labelValues,
+            isLoading: false,
           };
         })
       );
 
-      const filteredRows = newRows.filter((row): row is QueryRow => row !== null);
-      setQueryRows(filteredRows);
-      updateMatchersString(filteredRows);
+      if (!isCancelled) {
+        const filteredRows = newRows.filter((row): row is QueryRow => row !== null);
+        setQueryRows(filteredRows);
+      }
     };
 
     void fetchAndSetQueryRows();
-  }, [currentMatchers, fetchLabelValuesUnified, updateMatchersString]);
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [currentMatchers, fetchLabelValuesUnified]);
 
   const updateRow = useCallback(
     async (index: number, field: keyof QueryRow, value: string): Promise<void> => {


### PR DESCRIPTION
When using the "add to query" button from the metrics graph context menu, the first label would appear correctly in the SimpleMatchers component, but subsequent labels would only update the URL without reflecting in the UI until page reload.

Fixed by:
- Adding `key` prop to SimpleMatchers component to force re-render when query changes
- Improving useEffect in SimpleMatchers with proper async cleanup to prevent race conditions