### PR TITLE
ui: Potential fix for the occasional time range validation error: End: start timestamp must be before end.

### DIFF
--- a/ui/packages/shared/components/src/DateTimeRangePicker/RelativeDatePicker/index.tsx
+++ b/ui/packages/shared/components/src/DateTimeRangePicker/RelativeDatePicker/index.tsx
@@ -19,10 +19,10 @@ import {Button} from '../../Button';
 import {
   AbsoluteDate,
   DateTimeRange,
-  NOW,
   RelativeDate,
   UNITS,
   UNIT_TYPE,
+  createNow,
   formatRange,
   getHistoricalDate,
   getRelativeTimeRangeBetweenDates,
@@ -79,7 +79,7 @@ export const RelativeDatePickerForPanel = ({
   // absolute date range is converted to a relative date range and we then use the `onChange` prop to
   // update the range in the `RelativeDatePicker` component below.
   useEffect(() => {
-    onChange(new RelativeDate(unit, value), NOW);
+    onChange(new RelativeDate(unit, value), createNow());
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [unit, value]);
 
@@ -98,7 +98,7 @@ export const RelativeDatePickerForPanel = ({
         <Button
           key={`${value}-${unit}`}
           onClick={() => {
-            onChange(new RelativeDate(unit, value), NOW);
+            onChange(new RelativeDate(unit, value), createNow());
             hidePopoverMenu();
           }}
           className="min-w-[142px]"
@@ -142,7 +142,7 @@ const RelativeDatePicker = ({
   useEffect(() => {
     const formattedRange = formatRange(validRange.value, validRange.unit);
     setRangeInputString(formattedRange);
-    onChange(new RelativeDate(validRange.unit, validRange.value), NOW);
+    onChange(new RelativeDate(validRange.unit, validRange.value), createNow());
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [validRange]);
 

--- a/ui/packages/shared/components/src/DateTimeRangePicker/utils.ts
+++ b/ui/packages/shared/components/src/DateTimeRangePicker/utils.ts
@@ -465,4 +465,4 @@ export const formatRange = (value: number, unit: UNIT_TYPE): string => {
   return parts.join('');
 };
 
-export const NOW = new RelativeDate(UNITS.MINUTE, 0);
+export const createNow = (): RelativeDate => new RelativeDate(UNITS.MINUTE, 0);


### PR DESCRIPTION
The theory being the older `NOW`(already evaluated) instance being used in place of `to` in these `onChange` callbacks leading to a `to` that is older than the `from` which is evaluated freshly. 

We'll have to observe over time and see if this really fixes this bug scenario. 