### PR TITLE
ui: Reset visualisation state on selection of series point

### DIFF
--- a/ui/packages/shared/profile/src/ProfileSelector/MetricsGraphSection.tsx
+++ b/ui/packages/shared/profile/src/ProfileSelector/MetricsGraphSection.tsx
@@ -21,6 +21,7 @@ import {MergedProfileSelection, ProfileSelection} from '..';
 import UtilizationMetricsGraph from '../MetricsGraph/UtilizationMetrics';
 import AreaChart from '../MetricsGraph/UtilizationMetrics/Throughput';
 import ProfileMetricsGraph, {ProfileMetricsEmptyState} from '../ProfileMetricsGraph';
+import {useResetStateOnSeriesChange} from '../ProfileView/hooks/useResetStateOnSeriesChange';
 import {QuerySelection, type UtilizationMetrics as UtilizationMetricsType} from './index';
 
 interface MetricsGraphSectionProps {
@@ -69,6 +70,7 @@ export function MetricsGraphSection({
   utilizationMetricsLoading,
   onUtilizationSeriesSelect,
 }: MetricsGraphSectionProps): JSX.Element {
+  const resetStateOnSeriesChange = useResetStateOnSeriesChange();
   const handleTimeRangeChange = (range: DateTimeRange): void => {
     const from = range.getFromMs();
     const to = range.getToMs();
@@ -137,6 +139,8 @@ export function MetricsGraphSection({
     const durationInMilliseconds = duration / 1000000; // duration is in nanoseconds
     const mergeFrom = timestamp;
     const mergeTo = query.profileType().delta ? mergeFrom + durationInMilliseconds : mergeFrom;
+
+    resetStateOnSeriesChange(); // reset some state when a new series is selected
     selectProfile(new MergedProfileSelection(mergeFrom, mergeTo, query));
   };
 

--- a/ui/packages/shared/profile/src/ProfileView/hooks/useResetStateOnSeriesChange.ts
+++ b/ui/packages/shared/profile/src/ProfileView/hooks/useResetStateOnSeriesChange.ts
@@ -13,28 +13,12 @@
 
 import {useURLState} from '@parca/components';
 
-export const useResetStateOnProfileTypeChange = (): (() => void) => {
-  const [groupBy, setGroupBy] = useURLState('group_by');
-  const [filterByFunction, setFilterByFunction] = useURLState('filter_by_function');
-  const [excludeFunction, setExcludeFunction] = useURLState('exclude_function');
-  const [searchString, setSearchString] = useURLState('search_string');
+export const useResetStateOnSeriesChange = (): (() => void) => {
   const [curPath, setCurPath] = useURLState('cur_path');
   const [sandwichFunctionName, setSandwichFunctionName] = useURLState('sandwich_function_name');
 
   return () => {
     setTimeout(() => {
-      if (groupBy !== undefined) {
-        setGroupBy(undefined);
-      }
-      if (filterByFunction !== undefined) {
-        setFilterByFunction(undefined);
-      }
-      if (excludeFunction !== undefined) {
-        setExcludeFunction(undefined);
-      }
-      if (searchString !== undefined) {
-        setSearchString(undefined);
-      }
       if (curPath !== undefined) {
         setCurPath(undefined);
       }

--- a/ui/packages/shared/profile/src/Sandwich/components/TableSection.tsx
+++ b/ui/packages/shared/profile/src/Sandwich/components/TableSection.tsx
@@ -43,7 +43,6 @@ export function TableSection({
   height,
   sandwichFunctionName,
 }: TableSectionProps): JSX.Element {
-  console.log(height);
   return (
     <div
       style={{height: height !== undefined ? `${height}px` : '80vh'}}


### PR DESCRIPTION
For now, we reset the `sandwich_function_name` and `cur_path` URL state whenever a new point in the Metrics Graph series is selected. Thew newly added `ui/packages/shared/profile/src/ProfileView/hooks/useResetStateOnSeriesChange.ts` is responsible for this,