### PR TITLE
ui: Add 'alpha' label to Sandwich view

### DIFF
--- a/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/ContextMenu.tsx
+++ b/ui/packages/shared/profile/src/ProfileIcicleGraph/IcicleGraphArrow/ContextMenu.tsx
@@ -144,7 +144,7 @@ const ContextMenu = ({
   const nonEmptyValuesToCopy = valuesToCopy.filter(({value}) => value !== '');
 
   return (
-    <Menu id={menuId} theme={isDarkMode ? 'dark' : ''}>
+    <Menu id={menuId} theme={isDarkMode ? 'dark' : ''} className="w-[250px]">
       <Item
         id="view-source-file"
         onClick={handleViewSourceFile}
@@ -187,7 +187,12 @@ const ContextMenu = ({
         >
           <div className="flex w-full items-center gap-2">
             <Icon icon="tdesign:sandwich-filled" />
-            <div>Show in sandwich</div>
+            <div className="relative">
+              Show in sandwich
+              <span className="absolute top-[-2px] text-xs lowercase text-red-500">
+                &nbsp;alpha
+              </span>
+            </div>
           </div>
         </Item>
       )}

--- a/ui/packages/shared/profile/src/ProfileView/components/ViewSelector/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileView/components/ViewSelector/index.tsx
@@ -48,7 +48,12 @@ const ViewSelector = ({profileSource}: Props): JSX.Element => {
   if (enableSandwichView === true) {
     allItems.push({
       key: 'sandwich',
-      label: 'sandwich',
+      label: (
+        <span className="relative">
+          Sandwich
+          <span className="absolute top-[-2px] text-xs lowercase text-red-500">&nbsp;alpha</span>
+        </span>
+      ),
       canBeSelected: !dashboardItems.includes('sandwich'),
     });
   }


### PR DESCRIPTION
Added a visible 'alpha' indicator next to the Sandwich view option in both the context menu and the view selector.