### PR TITLE
ui: Remove the "X" button in the Sum by component

### DIFF
--- a/ui/packages/shared/profile/src/ProfileSelector/QueryControls.tsx
+++ b/ui/packages/shared/profile/src/ProfileSelector/QueryControls.tsx
@@ -179,6 +179,7 @@ export function QueryControls({
             id="h-sum-by-selector"
             defaultValue={[]}
             isMulti
+            isClearable={false}
             name="colors"
             options={labels.map(label => ({label, value: label}))}
             className="parca-select-container text-sm w-full max-w-80"


### PR DESCRIPTION
It's too easy to accidentally hit and each label already has its own "X".