### PR TITLE
Add agent IP address to panic reporting log

### DIFF
--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -16,9 +16,11 @@ package telemetry
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"google.golang.org/grpc/peer"
 
 	pb "github.com/parca-dev/parca/gen/proto/go/parca/telemetry/v1alpha1"
 )
@@ -38,6 +40,28 @@ func NewTelemetry(logger log.Logger) *TelemetryAPI {
 // ReportPanic reports a panic experienced by Agents. Just now it just logs the last
 // few KBs of stderr and the metadata.
 func (t *TelemetryAPI) ReportPanic(ctx context.Context, req *pb.ReportPanicRequest) (*pb.ReportPanicResponse, error) {
-	level.Info(t.logger).Log("msg", "agent panic'ed with", "stderr", req.Stderr, "metadata", fmt.Sprintf("%v", req.Metadata))
+	ip, err := extractIPFromContext(ctx)
+	if err != nil {
+		ip = "unknown"
+	}
+	level.Info(t.logger).Log(
+		"msg", "agent panic'ed with",
+		"stderr", req.Stderr,
+		"metadata", fmt.Sprintf("%v", req.Metadata),
+		"agent_ip", ip,
+	)
 	return &pb.ReportPanicResponse{}, nil
+}
+
+// extractIPFromContext extracts the IP address of the agent from the context.
+func extractIPFromContext(ctx context.Context) (string, error) {
+	var ip string
+	if p, ok := peer.FromContext(ctx); ok {
+		ipPort := p.Addr.String()
+		if colon := strings.LastIndex(ipPort, ":"); colon != -1 {
+			ip = ipPort[:colon]
+		}
+		return ip, nil
+	}
+	return "", fmt.Errorf("failed to extract IP from context")
 }


### PR DESCRIPTION
### Summary

This PR enhances the panic reporting functionality by including the agent's IP address in the log entry when an agent panic is reported. This additional context will help operators and developers more easily identify which agent instance experienced a panic, improving troubleshooting and incident response.

### Details

- The `ReportPanic` method in the Telemetry API now attempts to extract the agent's IP address from the gRPC context using `peer.FromContext`.
- The extracted IP address is added to the log entry under the `agent_ip` field.
- If the IP address cannot be determined, the value will be set to `"unknown"`.

### Motivation

Previously, when an agent panic was reported, the log entry included only the stderr output and metadata. In environments with multiple agents, it was difficult to determine which specific agent instance encountered the issue. By logging the agent's IP address, we make it easier to correlate panics with specific agents, aiding in debugging and operational monitoring.