### PR TITLE
Update GoReleaser commands to use new skip option

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -100,7 +100,7 @@ jobs:
         with:
           distribution: goreleaser
           version: ${{ env.GORELEASER_VERSION }}
-          args: build --clean --skip-validate --snapshot --debug --timeout=60m
+          args: build --clean --skip=validate --snapshot --debug --timeout=60m
         env:
           GORELEASER_CURRENT_TAG: "${{ env.goreleaser_current_tag }}"
 

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -121,7 +121,7 @@ jobs:
         with:
           distribution: goreleaser
           version: ${{ env.GORELEASER_VERSION }}
-          args: release --clean --skip-validate --skip-publish --timeout=60m
+          args: release --clean --skip=validate --skip-publish --timeout=60m
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: "${{ env.goreleaser_current_tag }}"

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -124,7 +124,7 @@ jobs:
         with:
           distribution: goreleaser
           version: ${{ env.GORELEASER_VERSION }}
-          args: release --clean --skip-validate --skip-publish --timeout=60m
+          args: release --clean --skip=validate --skip-publish --timeout=60m
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: "${{ env.goreleaser_current_tag }}"

--- a/Makefile
+++ b/Makefile
@@ -213,8 +213,8 @@ README.md: embedmd tmp/help.txt
 
 .PHONY: release-dry-run
 release-dry-run:
-	goreleaser release --clean --auto-snapshot --skip-validate --skip-publish --debug
+	goreleaser release --clean --auto-snapshot --skip=validate --skip-publish --debug
 
 .PHONY: release-build
 release-build:
-	goreleaser build --clean --skip-validate --snapshot --debug
+	goreleaser build --clean --skip=validate --snapshot --debug


### PR DESCRIPTION
## PR Summary
This small PR updates all uses of the deprecated `--skip-validate` flag in the GoReleaser CLI to the new syntax `--skip=validate`, as per [GoReleaser deprecation guidelines](https://goreleaser.com/deprecations#-skip). The changes affect both the `Makefile` and GitHub Actions workflows (`container.yml`, `release-dry-run.yml`, and `snap.yml`). This resolves warnings like the following, which are currently visible in the [CI logs](https://github.com/parca-dev/parca/actions/runs/16092547709/job/45411169934#step:9:26):
```
DEPRECATED: --skip-validate was deprecated in favor of --skip=validate, check https://goreleaser.com/deprecations#-skip for more details
````