### PR TITLE
Move the data fetching for the Sandwich view to be in the ProfileView

### DIFF
--- a/ui/packages/shared/profile/src/ProfileView/components/ColorStackLegend.tsx
+++ b/ui/packages/shared/profile/src/ProfileView/components/ColorStackLegend.tsx
@@ -50,8 +50,6 @@ const ColorStackLegend = ({mappings, compareMode = false, loading}: Props): Reac
       .map(f => f.value);
   }, [appliedFilters]);
 
-  console.log('currentBinaryFilters', currentBinaryFilters);
-
   const mappingsList = useMappingList(mappings);
 
   const mappingColors = useMemo(() => {

--- a/ui/packages/shared/profile/src/ProfileView/components/DashboardItems/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileView/components/DashboardItems/index.tsx
@@ -24,6 +24,7 @@ import {SourceView} from '../../../SourceView';
 import {Table} from '../../../Table';
 import type {
   FlamegraphData,
+  SandwichData,
   SourceData,
   TopTableData,
   VisualizationType,
@@ -36,6 +37,7 @@ interface GetDashboardItemProps {
   flamegraphData: FlamegraphData;
   flamechartData: FlamegraphData;
   topTableData?: TopTableData;
+  sandwichData: SandwichData;
   sourceData?: SourceData;
   profileSource: ProfileSource;
   total: bigint;
@@ -58,13 +60,13 @@ export const getDashboardItem = ({
   flamechartData,
   topTableData,
   sourceData,
+  sandwichData,
   profileSource,
   total,
   filtered,
   curPathArrow,
   setNewCurPathArrow,
   perf,
-  queryClient,
 }: GetDashboardItemProps): JSX.Element => {
   switch (type) {
     case 'flamegraph':
@@ -142,17 +144,7 @@ export const getDashboardItem = ({
       );
     case 'sandwich':
       return topTableData != null ? (
-        <Sandwich
-          total={total}
-          filtered={filtered}
-          loading={topTableData.loading}
-          data={topTableData.arrow?.record}
-          unit={topTableData.unit}
-          profileType={profileSource?.ProfileType()}
-          metadataMappingFiles={flamegraphData.metadataMappingFiles}
-          profileSource={profileSource}
-          queryClient={queryClient}
-        />
+        <Sandwich profileSource={profileSource} sandwichData={sandwichData} />
       ) : (
         <></>
       );

--- a/ui/packages/shared/profile/src/ProfileView/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileView/index.tsx
@@ -44,6 +44,7 @@ export const ProfileView = ({
   pprofDownloading,
   compare,
   showVisualizationSelector,
+  sandwichData,
 }: ProfileViewProps): JSX.Element => {
   const {
     timezone,
@@ -88,6 +89,7 @@ export const ProfileView = ({
     isHalfScreen: boolean;
   }): JSX.Element => {
     return getDashboardItem({
+      sandwichData,
       type,
       isHalfScreen,
       dimensions,

--- a/ui/packages/shared/profile/src/ProfileView/types/visualization.ts
+++ b/ui/packages/shared/profile/src/ProfileView/types/visualization.ts
@@ -11,20 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {
-  Callgraph as CallgraphType,
-  Flamegraph,
-  FlamegraphArrow,
-  QueryServiceClient,
-  Source,
-  TableArrow,
-} from '@parca/client';
+import {FlamegraphArrow, QueryServiceClient, Source, TableArrow} from '@parca/client';
 
 import {ProfileSource} from '../../ProfileSource';
 
 export interface FlamegraphData {
   loading: boolean;
-  data?: Flamegraph;
   arrow?: FlamegraphArrow;
   total?: bigint;
   filtered?: bigint;
@@ -43,18 +35,15 @@ export interface TopTableData {
   unit?: string;
 }
 
-export interface CallgraphData {
-  loading: boolean;
-  data?: CallgraphType;
-  total?: bigint;
-  filtered?: bigint;
-  error?: any;
-}
-
 export interface SourceData {
   loading: boolean;
   data?: Source;
   error?: any;
+}
+
+export interface SandwichData {
+  callees: FlamegraphData;
+  callers: FlamegraphData;
 }
 
 export type VisualizationType =
@@ -70,8 +59,8 @@ export interface ProfileViewProps {
   filtered: bigint;
   flamegraphData: FlamegraphData;
   flamechartData: FlamegraphData;
+  sandwichData: SandwichData;
   topTableData?: TopTableData;
-  callgraphData?: CallgraphData;
   sourceData?: SourceData;
   profileSource: ProfileSource;
   queryClient?: QueryServiceClient;

--- a/ui/packages/shared/profile/src/Sandwich/components/CalleesSection.tsx
+++ b/ui/packages/shared/profile/src/Sandwich/components/CalleesSection.tsx
@@ -13,24 +13,14 @@
 
 import React from 'react';
 
-import {type FlamegraphArrow} from '@parca/client';
-
 import ProfileFlameGraph from '../../ProfileFlameGraph';
 import {type CurrentPathFrame} from '../../ProfileFlameGraph/FlameGraphArrow/utils';
 import {type ProfileSource} from '../../ProfileSource';
+import {FlamegraphData} from '../../ProfileView/types/visualization';
 
 interface CalleesSectionProps {
   calleesRef: React.RefObject<HTMLDivElement>;
-  calleesFlamegraphResponse?: {
-    report: {
-      oneofKind: string;
-      flamegraphArrow?: FlamegraphArrow;
-    };
-    total?: string;
-  };
-  calleesFlamegraphLoading: boolean;
-  calleesFlamegraphError: any;
-  filtered: bigint;
+  calleesFlamegraphData: FlamegraphData;
   profileSource: ProfileSource;
   curPathArrow: CurrentPathFrame[];
   setCurPathArrow: (path: CurrentPathFrame[]) => void;
@@ -39,14 +29,10 @@ interface CalleesSectionProps {
 
 export function CalleesSection({
   calleesRef,
-  calleesFlamegraphResponse,
-  calleesFlamegraphLoading,
-  calleesFlamegraphError,
-  filtered,
+  calleesFlamegraphData,
   profileSource,
   curPathArrow,
   setCurPathArrow,
-  metadataMappingFiles,
 }: CalleesSectionProps): JSX.Element {
   return (
     <div className="flex relative items-start flex-row" ref={calleesRef}>
@@ -54,22 +40,18 @@ export function CalleesSection({
         {'<-'} Callees
       </div>
       <ProfileFlameGraph
-        arrow={
-          calleesFlamegraphResponse?.report.oneofKind === 'flamegraphArrow'
-            ? calleesFlamegraphResponse?.report?.flamegraphArrow
-            : undefined
-        }
-        total={BigInt(calleesFlamegraphResponse?.total ?? '0')}
-        filtered={filtered}
+        arrow={calleesFlamegraphData?.arrow}
+        total={calleesFlamegraphData.total ?? BigInt(0)}
+        filtered={calleesFlamegraphData.filtered ?? BigInt(0)}
         profileType={profileSource?.ProfileType()}
-        loading={calleesFlamegraphLoading}
-        error={calleesFlamegraphError}
+        loading={calleesFlamegraphData.loading}
+        error={calleesFlamegraphData.error}
         isHalfScreen={true}
         width={
           calleesRef.current != null ? calleesRef.current.getBoundingClientRect().width - 25 : 0
         }
-        metadataMappingFiles={metadataMappingFiles}
-        metadataLoading={false}
+        metadataMappingFiles={calleesFlamegraphData.metadataMappingFiles}
+        metadataLoading={calleesFlamegraphData.metadataLoading}
         isInSandwichView={true}
         curPathArrow={curPathArrow}
         setNewCurPathArrow={setCurPathArrow}

--- a/ui/packages/shared/profile/src/Sandwich/index.tsx
+++ b/ui/packages/shared/profile/src/Sandwich/index.tsx
@@ -11,59 +11,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import React, {useEffect, useMemo, useRef, useState} from 'react';
+import React, {useMemo, useRef, useState} from 'react';
 
-import {type Row as TableRow} from '@tanstack/table-core';
-import {tableFromIPC} from 'apache-arrow';
 import {AnimatePresence, motion} from 'framer-motion';
 
-import {QueryRequest_ReportType, QueryServiceClient} from '@parca/client';
-import {useParcaContext, useURLState} from '@parca/components';
-import {useCurrentColorProfile} from '@parca/hooks';
-import {ProfileType} from '@parca/parser';
+import {useURLState} from '@parca/components';
 
-import useMappingList, {
-  useFilenamesList,
-} from '../ProfileFlameGraph/FlameGraphArrow/useMappingList';
 import {ProfileSource} from '../ProfileSource';
-import {useProfileFilters} from '../ProfileView/components/ProfileFilters/useProfileFilters';
 import {useDashboard} from '../ProfileView/context/DashboardContext';
 import {useVisualizationState} from '../ProfileView/hooks/useVisualizationState';
-import {FIELD_FUNCTION_NAME, Row} from '../Table';
-import {useColorManagement} from '../Table/hooks/useColorManagement';
-import {useQuery} from '../useQuery';
+import {SandwichData} from '../ProfileView/types/visualization';
 import {CalleesSection} from './components/CalleesSection';
 import {CallersSection} from './components/CallersSection';
-import {processRowData} from './utils/processRowData';
 
 interface Props {
-  data?: Uint8Array;
-  total: bigint;
-  filtered: bigint;
-  profileType?: ProfileType;
-  loading: boolean;
-  unit?: string;
-  metadataMappingFiles?: string[];
-  queryClient?: QueryServiceClient;
   profileSource: ProfileSource;
+  sandwichData: SandwichData;
 }
 
 const Sandwich = React.memo(function Sandwich({
-  data,
-  filtered,
-  profileType,
-  loading,
-  unit,
-  metadataMappingFiles,
-  queryClient,
+  sandwichData,
   profileSource,
 }: Props): React.JSX.Element {
-  const currentColorProfile = useCurrentColorProfile();
   const {dashboardItems} = useDashboard();
   const [sandwichFunctionName] = useURLState<string | undefined>('sandwich_function_name');
 
-  const {isDarkMode} = useParcaContext();
-  const [selectedRow, setSelectedRow] = useState<TableRow<Row> | null>(null);
   const callersRef = React.useRef<HTMLDivElement | null>(null);
   const calleesRef = React.useRef<HTMLDivElement | null>(null);
   const [isExpanded, setIsExpanded] = useState(false);
@@ -71,113 +43,10 @@ const Sandwich = React.memo(function Sandwich({
 
   const callersCalleesContainerRef = useRef<HTMLDivElement | null>(null);
 
-  const {colorBy, setColorBy, curPathArrow, setCurPathArrow} = useVisualizationState();
+  const {curPathArrow, setCurPathArrow} = useVisualizationState();
 
-  const nodeTrimThreshold = useMemo(() => {
-    let width =
-      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-      window.innerWidth || document.documentElement.clientWidth || document.body.clientWidth;
-    // subtract the padding
-    width = width - 12 - 16 - 12;
-    return (1 / width) * 100;
-  }, []);
-
-  const {protoFilters} = useProfileFilters();
-
-  const {
-    isLoading: callersFlamegraphLoading,
-    response: callersFlamegraphResponse,
-    error: callersFlamegraphError,
-  } = useQuery(
-    queryClient as QueryServiceClient,
-    profileSource,
-    QueryRequest_ReportType.FLAMEGRAPH_ARROW,
-    {
-      nodeTrimThreshold,
-      groupBy: [FIELD_FUNCTION_NAME],
-      invertCallStack: true,
-      sandwichByFunction: sandwichFunctionName,
-      skip: sandwichFunctionName === undefined,
-      protoFilters,
-    }
-  );
-
-  const {
-    isLoading: calleesFlamegraphLoading,
-    response: calleesFlamegraphResponse,
-    error: calleesFlamegraphError,
-  } = useQuery(
-    queryClient as QueryServiceClient,
-    profileSource,
-    QueryRequest_ReportType.FLAMEGRAPH_ARROW,
-    {
-      nodeTrimThreshold,
-      groupBy: [FIELD_FUNCTION_NAME],
-      invertCallStack: false,
-      sandwichByFunction: sandwichFunctionName,
-      skip: sandwichFunctionName === undefined,
-      protoFilters,
-    }
-  );
-
-  const table = useMemo(() => {
-    if (loading || data == null) {
-      return null;
-    }
-
-    return tableFromIPC(data);
-  }, [data, loading]);
-
-  const mappingsList = useMappingList(metadataMappingFiles);
-  const filenamesList = useFilenamesList(table);
-
-  const mappingsListCount = useMemo(
-    () => mappingsList.filter(m => m !== '').length,
-    [mappingsList]
-  );
-
-  // If there is only one mapping file, we want to color by filename by default.
-  useEffect(() => {
-    if (mappingsListCount === 1 && colorBy !== 'filename') {
-      setColorBy('filename');
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mappingsListCount]);
-
-  const {colorByColors, colorByValue} = useColorManagement({
-    isDarkMode,
-    currentColorProfile,
-    mappingsList,
-    filenamesList,
-    colorBy,
-  });
-
-  unit = useMemo(() => unit ?? profileType?.sampleUnit ?? '', [unit, profileType?.sampleUnit]);
-
-  const rows = useMemo(() => {
-    if (table == null || table.numRows === 0) {
-      return [];
-    }
-
-    return processRowData({
-      table,
-      colorByColors,
-      colorBy: colorByValue,
-    });
-  }, [table, colorByColors, colorByValue]);
-
-  useEffect(() => {
-    if (sandwichFunctionName !== undefined && selectedRow == null) {
-      // find the row with the sandwichFunctionName
-      const row = rows.find(row => {
-        return row.name.trim() === sandwichFunctionName.trim();
-      });
-
-      if (row != null) {
-        setSelectedRow(row as unknown as TableRow<Row>);
-      }
-    }
-  }, [sandwichFunctionName, rows, selectedRow]);
+  const callersFlamegraphData = useMemo(() => sandwichData.callers, [sandwichData.callers]);
+  const calleesFlamegraphData = useMemo(() => sandwichData.callees, [sandwichData.callees]);
 
   return (
     <section className="flex flex-row h-full w-full">
@@ -194,24 +63,10 @@ const Sandwich = React.memo(function Sandwich({
               <div className="w-full flex flex-col" ref={callersCalleesContainerRef}>
                 <CallersSection
                   callersRef={callersRef}
-                  callersFlamegraphResponse={
-                    callersFlamegraphResponse?.report.oneofKind === 'flamegraphArrow'
-                      ? {
-                          report: {
-                            oneofKind: 'flamegraphArrow',
-                            flamegraphArrow: callersFlamegraphResponse.report.flamegraphArrow,
-                          },
-                          total: callersFlamegraphResponse.total?.toString() ?? '0',
-                        }
-                      : undefined
-                  }
-                  callersFlamegraphLoading={callersFlamegraphLoading}
-                  callersFlamegraphError={callersFlamegraphError}
-                  filtered={filtered}
+                  callersFlamegraphData={callersFlamegraphData}
                   profileSource={profileSource}
                   curPathArrow={curPathArrow}
                   setCurPathArrow={setCurPathArrow}
-                  metadataMappingFiles={metadataMappingFiles}
                   isExpanded={isExpanded}
                   setIsExpanded={setIsExpanded}
                   defaultMaxFrames={defaultMaxFrames}
@@ -219,24 +74,10 @@ const Sandwich = React.memo(function Sandwich({
                 <div className="h-4" />
                 <CalleesSection
                   calleesRef={calleesRef}
-                  calleesFlamegraphResponse={
-                    calleesFlamegraphResponse?.report.oneofKind === 'flamegraphArrow'
-                      ? {
-                          report: {
-                            oneofKind: 'flamegraphArrow',
-                            flamegraphArrow: calleesFlamegraphResponse.report.flamegraphArrow,
-                          },
-                          total: calleesFlamegraphResponse.total?.toString() ?? '0',
-                        }
-                      : undefined
-                  }
-                  calleesFlamegraphLoading={calleesFlamegraphLoading}
-                  calleesFlamegraphError={calleesFlamegraphError}
-                  filtered={filtered}
+                  calleesFlamegraphData={calleesFlamegraphData}
                   profileSource={profileSource}
                   curPathArrow={curPathArrow}
                   setCurPathArrow={setCurPathArrow}
-                  metadataMappingFiles={metadataMappingFiles}
                 />
               </div>
             ) : (

--- a/ui/packages/shared/utilities/src/index.ts
+++ b/ui/packages/shared/utilities/src/index.ts
@@ -198,7 +198,8 @@ export const parseParams = (
       key === 'profileType' ||
       key === 'cur_path' ||
       key === 'time_selection_a' ||
-      key === 'time_selection_b'
+      key === 'time_selection_b' ||
+      key === 'sandwich_function_name'
     ) {
       values = values.map((value): string => {
         // First, decode multiple levels if present


### PR DESCRIPTION
I previously wrote the sandwich flame graphs’ data fetching logic in the `Sandwich` component itself, which is problematic upstream in [pprof.me](http://pprof.me/). We get a “cannot read properties of undefined reading “query” because it’s expecting a queryClient.

<img width="764" height="494" alt="Pasted Graphic 4 copy" src="https://github.com/user-attachments/assets/bf656da9-8c89-4161-928e-ad5857bb3fd3" />

This PR moves the data fetching logic back to the `ProfileViewWithData` component which already is responsible for data fetching for our other visualisations.