### PR TITLE
Flamegraph perf

### DIFF
--- a/ui/packages/shared/profile/src/ProfileFlameGraph/FlameGraphArrow/FlameGraphNodes.tsx
+++ b/ui/packages/shared/profile/src/ProfileFlameGraph/FlameGraphArrow/FlameGraphNodes.tsx
@@ -77,212 +77,226 @@ export const fadedFlameRectStyles = {
   opacity: '0.5',
 };
 
-export const FlameNode = React.memo(function FlameNodeNoMemo({
-  table,
-  row,
-  colors,
-  colorBy,
-  height,
-  totalWidth,
-  darkMode,
-  compareMode,
-  colorForSimilarNodes,
-  selectedRow,
-  onClick,
-  onContextMenu,
-  hoveringRow,
-  setHoveringRow,
-  isFlameChart,
-  profileSource,
-  isRenderedAsFlamegraph = false,
-  isInSandwichView = false,
-  maxDepth = 0,
-  effectiveDepth,
-  tooltipId = 'default',
-}: FlameNodeProps): React.JSX.Element {
-  // get the columns to read from
-  const mappingColumn = table.getChild(FIELD_MAPPING_FILE);
-  const functionNameColumn = table.getChild(FIELD_FUNCTION_NAME);
-  const cumulativeColumn = table.getChild(FIELD_CUMULATIVE);
-  const depthColumn = table.getChild(FIELD_DEPTH);
-  const diffColumn = table.getChild(FIELD_DIFF);
-  const filenameColumn = table.getChild(FIELD_FUNCTION_FILE_NAME);
-  const valueOffsetColumn = table.getChild(FIELD_VALUE_OFFSET);
-  const tsColumn = table.getChild(FIELD_TIMESTAMP);
-
-  // get the actual values from the columns
-  const binaries = useAppSelector(selectBinaries);
-
-  const mappingFile: string | null = arrowToString(mappingColumn?.get(row));
-  const functionName: string | null = arrowToString(functionNameColumn?.get(row));
-  const cumulative = cumulativeColumn?.get(row) !== null ? BigInt(cumulativeColumn?.get(row)) : 0n;
-  const diff: bigint | null = diffColumn?.get(row) !== null ? BigInt(diffColumn?.get(row)) : null;
-  const filename: string | null = arrowToString(filenameColumn?.get(row));
-  const depth: number = depthColumn?.get(row) ?? 0;
-
-  const valueOffset: bigint =
-    valueOffsetColumn?.get(row) !== null && valueOffsetColumn?.get(row) !== undefined
-      ? BigInt(valueOffsetColumn?.get(row))
-      : 0n;
-
-  const colorAttribute =
-    colorBy === 'filename' ? filename : colorBy === 'binary' ? mappingFile : null;
-
-  const colorsMap = colors;
-
-  const hoveringName =
-    hoveringRow !== undefined ? arrowToString(functionNameColumn?.get(hoveringRow)) : '';
-  const shouldBeHighlighted =
-    functionName != null && hoveringName != null && functionName === hoveringName;
-
-  const colorResult = useNodeColor({
-    isDarkMode: darkMode,
+export const FlameNode = React.memo(
+  function FlameNodeNoMemo({
+    table,
+    row,
+    colors,
+    colorBy,
+    height,
+    totalWidth,
+    darkMode,
     compareMode,
-    cumulative,
-    diff,
-    colorsMap,
-    colorAttribute,
-  });
-
-  const name = useMemo(() => {
-    return row === 0 ? 'root' : nodeLabel(table, row, binaries.length > 1);
-  }, [table, row, binaries]);
-
-  // Hide frames beyond effective depth limit
-  if (effectiveDepth !== undefined && depth > effectiveDepth) {
-    return <></>;
-  }
-
-  const selectionOffset =
-    valueOffsetColumn?.get(selectedRow) !== null &&
-    valueOffsetColumn?.get(selectedRow) !== undefined
-      ? BigInt(valueOffsetColumn?.get(selectedRow))
-      : 0n;
-  const selectionCumulative =
-    cumulativeColumn?.get(selectedRow) !== null ? BigInt(cumulativeColumn?.get(selectedRow)) : 0n;
-  if (
-    valueOffset + cumulative <= selectionOffset ||
-    valueOffset >= selectionOffset + selectionCumulative
-  ) {
-    // If the end of the node is before the selection offset or the start of the node is after the selection offset + totalWidth, we don't render it.
-    return <></>;
-  }
-
-  if (row === 0 && (isFlameChart || isInSandwichView)) {
-    // The root node is not rendered in the flame chart or sandwich view, so we return null.
-    return <></>;
-  }
-
-  // Cumulative can be larger than total when a selection is made. All parents of the selection are likely larger, but we want to only show them as 100% in the graph.
-  const tsBounds = boundsFromProfileSource(profileSource);
-  const total = cumulativeColumn?.get(selectedRow);
-  const totalRatio = cumulative > total ? 1 : Number(cumulative) / Number(total);
-  const width: number = isFlameChart
-    ? (Number(cumulative) / (Number(tsBounds[1]) - Number(tsBounds[0]))) * totalWidth
-    : totalRatio * totalWidth;
-
-  if (width <= 1) {
-    return <></>;
-  }
-
-  const selectedDepth = depthColumn?.get(selectedRow);
-  const styles =
-    selectedDepth !== undefined && selectedDepth > depth ? fadedFlameRectStyles : flameRectStyles;
-
-  const onMouseEnter = (): void => {
-    setHoveringRow(row);
-    window.dispatchEvent(
-      new CustomEvent(`flame-tooltip-update-${tooltipId}`, {
-        detail: {row},
-      })
-    );
-  };
-
-  const onMouseLeave = (): void => {
-    setHoveringRow(undefined);
-    window.dispatchEvent(
-      new CustomEvent(`flame-tooltip-update-${tooltipId}`, {
-        detail: {row: null},
-      })
-    );
-  };
-
-  const handleContextMenu = (e: React.MouseEvent): void => {
-    onContextMenu(e, row);
-  };
-
-  const ts = tsColumn !== null ? Number(tsColumn.get(row)) : 0;
-  const x =
-    isFlameChart && tsColumn !== null
-      ? ((ts - Number(tsBounds[0])) / (Number(tsBounds[1]) - Number(tsBounds[0]))) * totalWidth
-      : selectedDepth > depth
-      ? 0
-      : ((Number(valueOffset) - Number(selectionOffset)) / Number(total)) * totalWidth;
-
-  const calculateY = (
-    isRenderedAsFlamegraph: boolean,
-    isInSandwichView: boolean,
-    isFlameChart: boolean,
-    maxDepth: number,
-    depth: number,
-    height: number
-  ): number => {
-    if (isRenderedAsFlamegraph) {
-      return (maxDepth - depth) * height; // Flamegraph is inverted
-    }
-
-    if (isFlameChart || isInSandwichView) {
-      return (depth - 1) * height;
-    }
-
-    return depth * height;
-  };
-
-  const y = calculateY(
-    isRenderedAsFlamegraph,
-    isInSandwichView,
+    colorForSimilarNodes,
+    selectedRow,
+    onClick,
+    onContextMenu,
+    hoveringRow,
+    setHoveringRow,
     isFlameChart,
-    effectiveDepth ?? maxDepth,
-    depth,
-    height
-  );
+    profileSource,
+    isRenderedAsFlamegraph = false,
+    isInSandwichView = false,
+    maxDepth = 0,
+    effectiveDepth,
+    tooltipId = 'default',
+  }: FlameNodeProps): React.JSX.Element {
+    // get the columns to read from
+    const mappingColumn = table.getChild(FIELD_MAPPING_FILE);
+    const functionNameColumn = table.getChild(FIELD_FUNCTION_NAME);
+    const cumulativeColumn = table.getChild(FIELD_CUMULATIVE);
+    const depthColumn = table.getChild(FIELD_DEPTH);
+    const diffColumn = table.getChild(FIELD_DIFF);
+    const filenameColumn = table.getChild(FIELD_FUNCTION_FILE_NAME);
+    const valueOffsetColumn = table.getChild(FIELD_VALUE_OFFSET);
+    const tsColumn = table.getChild(FIELD_TIMESTAMP);
 
-  return (
-    <>
-      <g
-        id={row === 0 ? 'root-span' : undefined}
-        transform={`translate(${x + 1}, ${y + 1})`}
-        style={styles}
-        onMouseEnter={onMouseEnter}
-        onMouseLeave={onMouseLeave}
-        onClick={onClick}
-        onContextMenu={handleContextMenu}
-      >
-        <rect
-          x={0}
-          y={0}
-          width={width}
-          height={height}
-          style={{
-            fill: colorResult,
-          }}
-          className={cx(
-            shouldBeHighlighted
-              ? `${colorForSimilarNodes} stroke-[3] [stroke-dasharray:6,4] [stroke-linecap:round] [stroke-linejoin:round] h-6`
-              : 'stroke-white dark:stroke-gray-700'
+    // get the actual values from the columns
+    const binaries = useAppSelector(selectBinaries);
+
+    const mappingFile: string | null = arrowToString(mappingColumn?.get(row));
+    const functionName: string | null = arrowToString(functionNameColumn?.get(row));
+    const cumulative =
+      cumulativeColumn?.get(row) !== null ? BigInt(cumulativeColumn?.get(row)) : 0n;
+    const diff: bigint | null = diffColumn?.get(row) !== null ? BigInt(diffColumn?.get(row)) : null;
+    const filename: string | null = arrowToString(filenameColumn?.get(row));
+    const depth: number = depthColumn?.get(row) ?? 0;
+
+    const valueOffset: bigint =
+      valueOffsetColumn?.get(row) !== null && valueOffsetColumn?.get(row) !== undefined
+        ? BigInt(valueOffsetColumn?.get(row))
+        : 0n;
+
+    const colorAttribute =
+      colorBy === 'filename' ? filename : colorBy === 'binary' ? mappingFile : null;
+
+    const colorsMap = colors;
+
+    const hoveringName =
+      hoveringRow !== undefined ? arrowToString(functionNameColumn?.get(hoveringRow)) : '';
+    const shouldBeHighlighted =
+      functionName != null && hoveringName != null && functionName === hoveringName;
+
+    const colorResult = useNodeColor({
+      isDarkMode: darkMode,
+      compareMode,
+      cumulative,
+      diff,
+      colorsMap,
+      colorAttribute,
+    });
+
+    const name = useMemo(() => {
+      return row === 0 ? 'root' : nodeLabel(table, row, binaries.length > 1);
+    }, [table, row, binaries]);
+
+    // Hide frames beyond effective depth limit
+    if (effectiveDepth !== undefined && depth > effectiveDepth) {
+      return <></>;
+    }
+
+    const selectionOffset =
+      valueOffsetColumn?.get(selectedRow) !== null &&
+      valueOffsetColumn?.get(selectedRow) !== undefined
+        ? BigInt(valueOffsetColumn?.get(selectedRow))
+        : 0n;
+    const selectionCumulative =
+      cumulativeColumn?.get(selectedRow) !== null ? BigInt(cumulativeColumn?.get(selectedRow)) : 0n;
+    if (
+      valueOffset + cumulative <= selectionOffset ||
+      valueOffset >= selectionOffset + selectionCumulative
+    ) {
+      // If the end of the node is before the selection offset or the start of the node is after the selection offset + totalWidth, we don't render it.
+      return <></>;
+    }
+
+    if (row === 0 && (isFlameChart || isInSandwichView)) {
+      // The root node is not rendered in the flame chart or sandwich view, so we return null.
+      return <></>;
+    }
+
+    // Cumulative can be larger than total when a selection is made. All parents of the selection are likely larger, but we want to only show them as 100% in the graph.
+    const tsBounds = boundsFromProfileSource(profileSource);
+    const total = cumulativeColumn?.get(selectedRow);
+    const totalRatio = cumulative > total ? 1 : Number(cumulative) / Number(total);
+    const width: number = isFlameChart
+      ? (Number(cumulative) / (Number(tsBounds[1]) - Number(tsBounds[0]))) * totalWidth
+      : totalRatio * totalWidth;
+
+    if (width <= 1) {
+      return <></>;
+    }
+
+    const selectedDepth = depthColumn?.get(selectedRow);
+    const styles =
+      selectedDepth !== undefined && selectedDepth > depth ? fadedFlameRectStyles : flameRectStyles;
+
+    const onMouseEnter = (): void => {
+      setHoveringRow(row);
+      window.dispatchEvent(
+        new CustomEvent(`flame-tooltip-update-${tooltipId}`, {
+          detail: {row},
+        })
+      );
+    };
+
+    const onMouseLeave = (): void => {
+      setHoveringRow(undefined);
+      window.dispatchEvent(
+        new CustomEvent(`flame-tooltip-update-${tooltipId}`, {
+          detail: {row: null},
+        })
+      );
+    };
+
+    const handleContextMenu = (e: React.MouseEvent): void => {
+      onContextMenu(e, row);
+    };
+
+    const ts = tsColumn !== null ? Number(tsColumn.get(row)) : 0;
+    const x =
+      isFlameChart && tsColumn !== null
+        ? ((ts - Number(tsBounds[0])) / (Number(tsBounds[1]) - Number(tsBounds[0]))) * totalWidth
+        : selectedDepth > depth
+        ? 0
+        : ((Number(valueOffset) - Number(selectionOffset)) / Number(total)) * totalWidth;
+
+    const calculateY = (
+      isRenderedAsFlamegraph: boolean,
+      isInSandwichView: boolean,
+      isFlameChart: boolean,
+      maxDepth: number,
+      depth: number,
+      height: number
+    ): number => {
+      if (isRenderedAsFlamegraph) {
+        return (maxDepth - depth) * height; // Flamegraph is inverted
+      }
+
+      if (isFlameChart || isInSandwichView) {
+        return (depth - 1) * height;
+      }
+
+      return depth * height;
+    };
+
+    const y = calculateY(
+      isRenderedAsFlamegraph,
+      isInSandwichView,
+      isFlameChart,
+      effectiveDepth ?? maxDepth,
+      depth,
+      height
+    );
+
+    return (
+      <>
+        <g
+          id={row === 0 ? 'root-span' : undefined}
+          transform={`translate(${x + 1}, ${y + 1})`}
+          style={styles}
+          onMouseEnter={onMouseEnter}
+          onMouseLeave={onMouseLeave}
+          onClick={onClick}
+          onContextMenu={handleContextMenu}
+        >
+          <rect
+            x={0}
+            y={0}
+            width={width}
+            height={height}
+            style={{
+              fill: colorResult,
+            }}
+            className={cx(
+              shouldBeHighlighted
+                ? `${colorForSimilarNodes} stroke-[3] [stroke-dasharray:6,4] [stroke-linecap:round] [stroke-linejoin:round] h-6`
+                : 'stroke-white dark:stroke-gray-700'
+            )}
+          />
+          {width > 5 && (
+            <svg width={width - 5} height={height}>
+              <TextWithEllipsis
+                text={name}
+                x={5}
+                y={15}
+                width={width - 10} // Subtract padding from available width
+              />
+            </svg>
           )}
-        />
-        {width > 5 && (
-          <svg width={width - 5} height={height}>
-            <TextWithEllipsis
-              text={name}
-              x={5}
-              y={15}
-              width={width - 10} // Subtract padding from available width
-            />
-          </svg>
-        )}
-      </g>
-    </>
-  );
-});
+        </g>
+      </>
+    );
+  },
+  (prevProps, nextProps) => {
+    // Only re-render if the relevant props have changed
+    return (
+      prevProps.row === nextProps.row &&
+      prevProps.selectedRow === nextProps.selectedRow &&
+      prevProps.hoveringRow === nextProps.hoveringRow &&
+      prevProps.totalWidth === nextProps.totalWidth &&
+      prevProps.height === nextProps.height &&
+      prevProps.effectiveDepth === nextProps.effectiveDepth
+    );
+  }
+);

--- a/ui/packages/shared/profile/src/ProfileFlameGraph/FlameGraphArrow/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileFlameGraph/FlameGraphArrow/index.tsx
@@ -333,6 +333,27 @@ export const FlameGraphArrow = memo(function FlameGraphArrow({
   }
   const selectedRow = currentRow;
 
+  const VisibleNodes = useMemo(() => {
+    if (table === undefined) return [];
+
+    const visibleRows: number[] = [];
+
+    for (let row = 0; row < table.numRows; row++) {
+      const depth = table.getChild(FIELD_DEPTH)?.get(row) ?? 0;
+      const cumulative = table.getChild(FIELD_CUMULATIVE)?.get(row) ?? 0n;
+      const computedWidth = (Number(cumulative) / Number(total)) * (width ?? 1);
+
+      // Skip nodes that are too small to see or outside viewport
+      if (computedWidth <= 1 || (effectiveDepth !== undefined && depth > effectiveDepth)) {
+        continue;
+      }
+
+      visibleRows.push(row);
+    }
+
+    return visibleRows;
+  }, [table, total, width, effectiveDepth]);
+
   return (
     <TooltipProvider
       table={table}
@@ -366,7 +387,7 @@ export const FlameGraphArrow = memo(function FlameGraphArrow({
           preserveAspectRatio="xMinYMid"
           ref={svg}
         >
-          {Array.from({length: table.numRows}, (_, row) => (
+          {VisibleNodes.map((_, row) => (
             <FlameNode
               key={row}
               table={table}

--- a/ui/packages/shared/profile/src/ProfileFlameGraph/FlameGraphArrow/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileFlameGraph/FlameGraphArrow/index.tsx
@@ -39,6 +39,8 @@ import {FlameNode, RowHeight, colorByColors} from './FlameGraphNodes';
 import {MemoizedTooltip} from './MemoizedTooltip';
 import {TooltipProvider} from './TooltipContext';
 import {useFilenamesList} from './useMappingList';
+import {useScrollViewport} from './useScrollViewport';
+import {useVisibleNodes} from './useVisibleNodes';
 import {
   CurrentPathFrame,
   arrowToString,
@@ -166,34 +168,10 @@ export const FlameGraphArrow = memo(function FlameGraphArrow({
     return result;
   }, [arrow, perf]);
   const svg = useRef(null);
+  const containerRef = useRef<HTMLDivElement>(null);
   const renderStartTime = useRef<number>(0);
 
   const [svgElement, setSvgElement] = useState<SVGSVGElement | null>(null);
-
-  useEffect(() => {
-    if (perf?.markInteraction != null) {
-      renderStartTime.current = performance.now();
-    }
-  }, [table, width, curPath, perf]);
-
-  useEffect(() => {
-    if (perf?.setMeasurement != null && renderStartTime.current > 0) {
-      const measureRenderTime = (): void => {
-        const renderTime = performance.now() - renderStartTime.current;
-        if (perf?.setMeasurement != null) {
-          perf.setMeasurement('flamegraph.render_time', renderTime);
-        }
-
-        renderStartTime.current = 0;
-      };
-
-      requestAnimationFrame(measureRenderTime);
-    }
-  }, [table, width, curPath, perf]);
-
-  useEffect(() => {
-    setSvgElement(svg.current);
-  }, [tooltipId]);
 
   const {excludeBinary} = useProfileFilters();
 
@@ -304,9 +282,12 @@ export const FlameGraphArrow = memo(function FlameGraphArrow({
   // Use deferred value to prevent UI blocking when expanding frames
   const deferredEffectiveDepth = useDeferredValue(effectiveDepth);
 
-  const height = isInSandwichView
+  const totalHeight = isInSandwichView
     ? deferredEffectiveDepth * RowHeight
     : (deferredEffectiveDepth + 1) * RowHeight;
+
+  // Get the viewport of the container, this is used to determine which rows are visible.
+  const viewport = useScrollViewport(containerRef);
 
   // To find the selected row, we must walk the current path and look at which
   // children of the current frame matches the path element exactly. Until the
@@ -333,26 +314,24 @@ export const FlameGraphArrow = memo(function FlameGraphArrow({
   }
   const selectedRow = currentRow;
 
-  const VisibleNodes = useMemo(() => {
-    if (table === undefined) return [];
+  const visibleNodes = useVisibleNodes({
+    table,
+    viewport,
+    total,
+    width: width ?? 1,
+    selectedRow,
+    effectiveDepth: deferredEffectiveDepth,
+  });
 
-    const visibleRows: number[] = [];
-
-    for (let row = 0; row < table.numRows; row++) {
-      const depth = table.getChild(FIELD_DEPTH)?.get(row) ?? 0;
-      const cumulative = table.getChild(FIELD_CUMULATIVE)?.get(row) ?? 0n;
-      const computedWidth = (Number(cumulative) / Number(total)) * (width ?? 1);
-
-      // Skip nodes that are too small to see or outside viewport
-      if (computedWidth <= 1 || (effectiveDepth !== undefined && depth > effectiveDepth)) {
-        continue;
-      }
-
-      visibleRows.push(row);
+  useEffect(() => {
+    if (perf?.markInteraction != null) {
+      renderStartTime.current = performance.now();
     }
+  }, [table, width, curPath, perf]);
 
-    return visibleRows;
-  }, [table, total, width, effectiveDepth]);
+  useEffect(() => {
+    setSvgElement(svg.current);
+  }, [tooltipId]);
 
   return (
     <TooltipProvider
@@ -380,46 +359,55 @@ export const FlameGraphArrow = memo(function FlameGraphArrow({
           isInSandwichView={isInSandwichView}
         />
         <MemoizedTooltip contextElement={svgElement} dockedMetainfo={dockedMetainfo} />
-        <svg
-          className="font-robotoMono"
-          width={width}
-          height={height}
-          preserveAspectRatio="xMinYMid"
-          ref={svg}
+        <div
+          ref={containerRef}
+          className="overflow-auto scrollbar-thin scrollbar-thumb-gray-400 scrollbar-track-gray-100 dark:scrollbar-thumb-gray-600 dark:scrollbar-track-gray-800 will-change-transform scroll-smooth webkit-overflow-scrolling-touch contain"
+          style={{
+            width: width ?? '100%',
+            contain: 'layout style paint',
+          }}
         >
-          {VisibleNodes.map((_, row) => (
-            <FlameNode
-              key={row}
-              table={table}
-              row={row} // root is always row 0 in the arrow record
-              colors={colorByColors}
-              colorBy={colorByValue}
-              totalWidth={width ?? 1}
-              height={RowHeight}
-              darkMode={isDarkMode}
-              compareMode={compareMode}
-              colorForSimilarNodes={colorForSimilarNodes}
-              selectedRow={selectedRow}
-              onClick={() => {
-                if (isFlameChart) {
-                  // We don't want to expand in flame charts.
-                  return;
-                }
-                handleRowClick(row);
-              }}
-              onContextMenu={displayMenu}
-              hoveringRow={highlightSimilarStacksPreference ? hoveringRow : undefined}
-              setHoveringRow={highlightSimilarStacksPreference ? setHoveringRow : noop}
-              isFlameChart={isFlameChart}
-              profileSource={profileSource}
-              isRenderedAsFlamegraph={isRenderedAsFlamegraph}
-              isInSandwichView={isInSandwichView}
-              maxDepth={maxDepth}
-              effectiveDepth={deferredEffectiveDepth}
-              tooltipId={tooltipId}
-            />
-          ))}
-        </svg>
+          <svg
+            className="font-robotoMono"
+            width={width ?? 0}
+            height={totalHeight}
+            preserveAspectRatio="xMinYMid"
+            ref={svg}
+          >
+            {visibleNodes.map(row => (
+              <FlameNode
+                key={row}
+                table={table}
+                row={row}
+                colors={colorByColors}
+                colorBy={colorByValue}
+                totalWidth={width ?? 1}
+                height={RowHeight}
+                darkMode={isDarkMode}
+                compareMode={compareMode}
+                colorForSimilarNodes={colorForSimilarNodes}
+                selectedRow={selectedRow}
+                onClick={() => {
+                  if (isFlameChart) {
+                    // We don't want to expand in flame charts.
+                    return;
+                  }
+                  handleRowClick(row);
+                }}
+                onContextMenu={displayMenu}
+                hoveringRow={highlightSimilarStacksPreference ? hoveringRow : undefined}
+                setHoveringRow={highlightSimilarStacksPreference ? setHoveringRow : noop}
+                isFlameChart={isFlameChart}
+                profileSource={profileSource}
+                isRenderedAsFlamegraph={isRenderedAsFlamegraph}
+                isInSandwichView={isInSandwichView}
+                maxDepth={maxDepth}
+                effectiveDepth={deferredEffectiveDepth}
+                tooltipId={tooltipId}
+              />
+            ))}
+          </svg>
+        </div>
       </div>
     </TooltipProvider>
   );

--- a/ui/packages/shared/profile/src/ProfileFlameGraph/FlameGraphArrow/useScrollViewport.ts
+++ b/ui/packages/shared/profile/src/ProfileFlameGraph/FlameGraphArrow/useScrollViewport.ts
@@ -1,0 +1,89 @@
+// Copyright 2022 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {useCallback, useEffect, useRef, useState} from 'react';
+
+export interface ViewportState {
+  scrollTop: number;
+  scrollLeft: number;
+  containerHeight: number;
+  containerWidth: number;
+}
+
+export const useScrollViewport = (containerRef: React.RefObject<HTMLDivElement>): ViewportState => {
+  const [viewport, setViewport] = useState<ViewportState>({
+    scrollTop: 0,
+    scrollLeft: 0,
+    containerHeight: 0,
+    containerWidth: 0,
+  });
+
+  const throttleRef = useRef<number | null>(null);
+
+  const updateViewport = useCallback(() => {
+    if (containerRef.current !== null) {
+      const container = containerRef.current;
+
+      const newViewport = {
+        scrollTop: container.scrollTop,
+        scrollLeft: container.scrollLeft,
+        containerHeight: container.clientHeight,
+        containerWidth: container.clientWidth,
+      };
+
+      setViewport(newViewport);
+    }
+  }, [containerRef]);
+
+  // Throttling Strategy:
+  // Use requestAnimationFrame to throttle scroll events to 60fps max
+  // This ensures smooth performance while preventing excessive re-renders
+  const throttledUpdateViewport = useCallback(() => {
+    if (throttleRef.current !== null) {
+      cancelAnimationFrame(throttleRef.current);
+    }
+    throttleRef.current = requestAnimationFrame(updateViewport);
+  }, [updateViewport]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (container === null) return;
+
+    // ResizeObserver Strategy:
+    // Monitor container size changes (window resize, layout shifts)
+    // to update viewport dimensions for accurate culling calculations
+    const resizeObserver = new ResizeObserver(() => {
+      throttledUpdateViewport();
+    });
+
+    // Container Scroll Event Strategy:
+    // Use passive event listeners for better scroll performance
+    // Throttle with requestAnimationFrame to maintain 60fps target
+    container.addEventListener('scroll', throttledUpdateViewport, {passive: true});
+    resizeObserver.observe(container);
+
+    // Initialize viewport state on mount
+    updateViewport();
+
+    return () => {
+      // Cleanup: Remove event listeners and cancel pending animations
+      container.removeEventListener('scroll', throttledUpdateViewport);
+      resizeObserver.disconnect();
+      if (throttleRef.current !== null) {
+        cancelAnimationFrame(throttleRef.current);
+      }
+    };
+  }, [containerRef, throttledUpdateViewport, updateViewport]);
+
+  return viewport;
+};

--- a/ui/packages/shared/profile/src/ProfileFlameGraph/FlameGraphArrow/useVisibleNodes.ts
+++ b/ui/packages/shared/profile/src/ProfileFlameGraph/FlameGraphArrow/useVisibleNodes.ts
@@ -1,0 +1,170 @@
+// Copyright 2022 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {useMemo, useRef} from 'react';
+
+import {Table} from 'apache-arrow';
+
+import {RowHeight} from './FlameGraphNodes';
+import {FIELD_CUMULATIVE, FIELD_DEPTH, FIELD_VALUE_OFFSET} from './index';
+import {ViewportState} from './useScrollViewport';
+
+/**
+ * This function groups rows by their depth level.
+ * Instead of scanning all rows to find depth matches, we pre-compute
+ * buckets so viewport rendering only examines depth ranges that are relevant.
+ */
+const useDepthBuckets = <TRow extends Record<string, any>>(
+  table: Table<TRow> | undefined
+): number[][] => {
+  return useMemo(() => {
+    if (table === undefined) return [];
+
+    const depthColumn = table.getChild(FIELD_DEPTH);
+    if (depthColumn === null) return [];
+
+    // Find max depth
+    let maxDepth = 0;
+    for (let i = 0; i < table.numRows; i++) {
+      const depth = depthColumn.get(i) ?? 0;
+      if (depth > maxDepth) maxDepth = depth;
+    }
+
+    // Create buckets for each depth level
+    const buckets: number[][] = Array.from({length: maxDepth + 1}, () => []);
+
+    // Populate buckets with row indices
+    for (let row = 0; row < table.numRows; row++) {
+      const depth = depthColumn.get(row) ?? 0;
+      buckets[depth].push(row);
+    }
+
+    return buckets;
+  }, [table]);
+};
+
+export interface UseVisibleNodesParams {
+  table: Table<any>;
+  viewport: ViewportState;
+  total: bigint;
+  width: number;
+  selectedRow: number;
+  effectiveDepth: number;
+}
+
+/**
+ * useVisibleNodes returns row indices visible in the current viewport through multi-stage culling.
+ * Combines depth buckets, horizontal bounds checking, and size filtering to
+ * minimize rendered nodes from potentially 100K+ rows to ~hundreds.
+ *
+ * We use depth buckets to only iterate through the rows that are visible in the viewport vertically.
+ * After that we use horizontal bounds checking to only iterate through the rows that are visible in the viewport horizontally.
+ * Finally we use size filtering to only iterate through the rows that are visible in the viewport by size.
+ *
+ * Critical for maintaining 60fps performance on large flamegraphs where
+ * rendering all nodes would freeze the browser.
+ */
+export const useVisibleNodes = ({
+  table,
+  viewport,
+  total,
+  width,
+  selectedRow,
+  effectiveDepth,
+}: UseVisibleNodesParams): number[] => {
+  const depthBuckets = useDepthBuckets(table);
+  const lastResultRef = useRef<{
+    key: string;
+    result: number[];
+  }>({key: '', result: []});
+
+  return useMemo(() => {
+    // Create a stable key for memoization to prevent unnecessary recalculations
+    const memoKey = `${viewport.scrollTop}-${viewport.containerHeight}-${selectedRow}-${effectiveDepth}-${width}`;
+
+    // Return cached result if viewport hasn't meaningfully changed
+    if (lastResultRef.current.key === memoKey) {
+      return lastResultRef.current.result;
+    }
+
+    if (table === null || viewport.containerHeight === 0) return [];
+
+    const visibleRows: number[] = [];
+    const {scrollTop, containerHeight} = viewport;
+
+    // Viewport Culling Algorithm:
+    // 1. Calculate visible depth range based on scroll position and container height
+    // 2. Add 5-row buffer above/below for smooth scrolling experience
+    const startDepth = Math.max(0, Math.floor(scrollTop / RowHeight) - 5);
+    const endDepth = Math.min(
+      effectiveDepth,
+      Math.ceil((scrollTop + containerHeight) / RowHeight) + 5
+    );
+
+    const cumulativeColumn = table.getChild(FIELD_CUMULATIVE);
+    const valueOffsetColumn = table.getChild(FIELD_VALUE_OFFSET);
+
+    const selectionOffset =
+      valueOffsetColumn?.get(selectedRow) !== null &&
+      valueOffsetColumn?.get(selectedRow) !== undefined
+        ? BigInt(valueOffsetColumn?.get(selectedRow))
+        : 0n;
+    const selectionCumulative =
+      cumulativeColumn?.get(selectedRow) !== null ? BigInt(cumulativeColumn?.get(selectedRow)) : 0n;
+
+    const totalNumber = Number(total);
+    const selectionOffsetNumber = Number(selectionOffset);
+    const selectionCumulativeNumber = Number(selectionCumulative);
+
+    // Iterate only through visible depth range instead of all rows
+    for (let depth = startDepth; depth <= endDepth && depth < depthBuckets.length; depth++) {
+      // Skip if depth is beyond effective depth limit
+      if (effectiveDepth !== undefined && depth > effectiveDepth) {
+        continue;
+      }
+
+      const rowsAtDepth = depthBuckets[depth];
+
+      for (const row of rowsAtDepth) {
+        const cumulative =
+          cumulativeColumn?.get(row) !== null ? Number(cumulativeColumn?.get(row)) : 0;
+
+        const valueOffset =
+          valueOffsetColumn?.get(row) !== null && valueOffsetColumn?.get(row) !== undefined
+            ? Number(valueOffsetColumn?.get(row))
+            : 0;
+
+        // Horizontal culling: Skip nodes outside selection bounds
+        if (
+          valueOffset + cumulative <= selectionOffsetNumber ||
+          valueOffset >= selectionOffsetNumber + selectionCumulativeNumber
+        ) {
+          continue;
+        }
+
+        // Size culling: Skip nodes too small to be visible (< 1px width)
+        const computedWidth = (cumulative / totalNumber) * width;
+        if (computedWidth <= 1) {
+          continue;
+        }
+
+        visibleRows.push(row);
+      }
+    }
+
+    // Cache the result with the current key
+    lastResultRef.current = {key: memoKey, result: visibleRows};
+
+    return visibleRows;
+  }, [depthBuckets, viewport, total, width, selectedRow, effectiveDepth, table]);
+};

--- a/ui/packages/shared/utilities/src/index.ts
+++ b/ui/packages/shared/utilities/src/index.ts
@@ -198,7 +198,8 @@ export const parseParams = (
       key === 'profileType' ||
       key === 'cur_path' ||
       key === 'time_selection_a' ||
-      key === 'time_selection_b'
+      key === 'time_selection_b' ||
+      key === 'sandwich_function_name'
     ) {
       values = values.map((value): string => {
         // First, decode multiple levels if present


### PR DESCRIPTION
This PR implements a couple of performance improvements to our flame graph rendering.

We do viewport culling where the idea here is to not render rows that are not visible to users so as to speed up rendering. We do this on multiple levels i.e. vertically and horizontally.

We cull vertically and efficiently by grouping the rows (by their depth level) into buckets and this is done by pre-computing buckets i.e. we don't scan all rows, which results in much faster lookups.

Horizontal culling is done by checking horizontal bounds and only iterating through rows visible horizontally in the viewport.

Before
[Link to Profiler](https://share.firefox.dev/44Z8WfE)
<img width="1784" height="709" alt="image" src="https://github.com/user-attachments/assets/c74e4e9c-a9fa-404a-85f7-6ab8aa226363" />

After
[Link to Profiler](https://share.firefox.dev/46Yi4Ua)
<img width="1786" height="711" alt="image" src="https://github.com/user-attachments/assets/7aceb2b3-ce13-4798-8656-ef8d64e1dda4" />

As seen in the profiles shared above, the flame graph rendering time reduced from 8 seconds to 91ms by culling from 7,951 rendered nodes to just 91 visible nodes.