### PR TITLE
Fix objstore operation duration metrics by upgrading thanos-io/objstore

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/prometheus/common v0.65.0
 	github.com/prometheus/prometheus v0.55.1
 	github.com/stretchr/testify v1.10.0
-	github.com/thanos-io/objstore v0.0.0-20240913165201-fd105025a2e5
+	github.com/thanos-io/objstore v0.0.0-20241028145108-31c0873d5266
 	github.com/zeebo/xxh3 v1.0.2
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.62.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.62.0

--- a/go.sum
+++ b/go.sum
@@ -850,8 +850,8 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.194/go.mod 
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/kms v1.0.194/go.mod h1:yrBKWhChnDqNz1xuXdSbWXG56XawEq0G5j1lg4VwBD4=
 github.com/tencentyun/cos-go-sdk-v5 v0.7.40 h1:W6vDGKCHe4wBACI1d2UgE6+50sJFhRWU4O8IB2ozzxM=
 github.com/tencentyun/cos-go-sdk-v5 v0.7.40/go.mod h1:4dCEtLHGh8QPxHEkgq+nFaky7yZxQuYwgSJM87icDaw=
-github.com/thanos-io/objstore v0.0.0-20240913165201-fd105025a2e5 h1:sb2s6y+T5+iaNElATi4bpzw2lGMcd5YjAUvxQp9ePtw=
-github.com/thanos-io/objstore v0.0.0-20240913165201-fd105025a2e5/go.mod h1:A5Rlc/vdyENE5D0as6+6kp4kxWO72b4R0Q1ay/1d230=
+github.com/thanos-io/objstore v0.0.0-20241028145108-31c0873d5266 h1:WOrWkm6NYFTK/P4v2ortRm1ucuKBfPYAvSbQiQiqLxc=
+github.com/thanos-io/objstore v0.0.0-20241028145108-31c0873d5266/go.mod h1:/ZMUxFcp/nT6oYV5WslH9k07NU/+86+aibgZRmMMr/4=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=

--- a/pkg/debuginfo/metadata_test.go
+++ b/pkg/debuginfo/metadata_test.go
@@ -51,7 +51,7 @@ func TestMetadata(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	bucket, err := client.NewBucket(logger, cfg, "parca/store")
+	bucket, err := client.NewBucket(logger, cfg, "parca/store", nil)
 	require.NoError(t, err)
 
 	store, err := NewStore(

--- a/pkg/parca/parca.go
+++ b/pkg/parca/parca.go
@@ -240,7 +240,7 @@ func Run(ctx context.Context, logger log.Logger, reg *prometheus.Registry, flags
 		return err
 	}
 
-	bucket, err := client.NewBucket(logger, bucketCfg, "parca")
+	bucket, err := client.NewBucket(logger, bucketCfg, "parca", nil)
 	if err != nil {
 		level.Error(logger).Log("msg", "failed to initialize object storage bucket", "err", err)
 		return err

--- a/pkg/symbolizer/symbolizer_test.go
+++ b/pkg/symbolizer/symbolizer_test.go
@@ -55,7 +55,7 @@ func TestSymbolizer(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	bucket, err := client.NewBucket(logger, cfg, "parca/store")
+	bucket, err := client.NewBucket(logger, cfg, "parca/store", nil)
 	require.NoError(t, err)
 
 	metadata := debuginfo.NewObjectStoreMetadata(logger, bucket)


### PR DESCRIPTION
### Problem

The `objstore_bucket_operation_duration_seconds` metric was reporting extremely high and incorrect values, indicating severe performance issues that don't reflect actual operation times.

Before the fix:

```
objstore_bucket_operation_duration_seconds_sum{bucket="xxx",operation="get"} 1.0440258375572279e+10
objstore_bucket_operation_duration_seconds_count{bucket="xxx",operation="get"} 2068
```
- Average operation time: ~5,048,480 seconds (~58 days per operation)
- This clearly incorrect metric made it impossible to monitor actual object storage performance

### Root Cause

The issue was caused by a bug in the `github.com/thanos-io/objstore` library's metrics collection logic, where operation durations were being incorrectly calculated or accumulated.

### Solution

Updated `github.com/thanos-io/objstore` dependency from `v0.0.0-20240913165201-fd105025a2e5` to `v0.0.0-20241028145108-31c0873d5266` to include the fix from [objstore commit 31c0873d](https://github.com/thanos-io/objstore/commit/31c0873d5266a6c58fe8fb5d6de01b66dcd50f5f).

Code changes required:
- Updated dependency version in `go.mod` and `go.sum`
- Updated `client.NewBucket()` calls to accommodate API changes by adding the new fourth parameter (set to `nil`)

### Verification

After the fix:

```
objstore_bucket_operation_duration_seconds_sum{bucket="xxx",operation="get"} 318.43996360699987
objstore_bucket_operation_duration_seconds_count{bucket="xxx",operation="get"} 541
```
- Average operation time: ~0.59 seconds per operation
- Metrics now accurately reflect actual object storage performance
