### PR TITLE
feat(parcacol): use distinct for label discovery to reduce rows returned

### DIFF
--- a/pkg/parcacol/querier.go
+++ b/pkg/parcacol/querier.go
@@ -118,7 +118,7 @@ func (q *Querier) Labels(
 
 	err := q.engine.ScanTable(q.tableName).
 		Filter(logicalplan.And(filterExpr...)).
-		Project(logicalplan.DynCol(profile.ColumnLabels)).
+		Distinct(logicalplan.DynCol(profile.ColumnLabels)).
 		Execute(ctx, func(ctx context.Context, r arrow.Record) error {
 			r.Retain()
 			for i := 0; i < int(r.NumCols()); i++ {


### PR DESCRIPTION
Replace `Project` with `Distinct` in Querier.Labels. This emits only unique label columns, significantly reducing the number of rows materialized and returned.

In my cluster, the query of "Labels" returns more than 100 million rows from the underlying database. This PR reduced it to less than 50,000.
