### PR TITLE
ui: Fixed the time-range selection bug during the click-n-drag interaction

### DIFF
--- a/ui/packages/shared/profile/src/ProfileSelector/MetricsGraphSection.tsx
+++ b/ui/packages/shared/profile/src/ProfileSelector/MetricsGraphSection.tsx
@@ -76,7 +76,7 @@ export function MetricsGraphSection({
     const to = range.getToMs();
     let mergedProfileParams = {};
     if (query.profileType().delta) {
-      mergedProfileParams = { mergeFrom: from * 1_000_000, mergeTo: to * 1_000_000 };
+      mergedProfileParams = {mergeFrom: from * 1_000_000, mergeTo: to * 1_000_000};
     }
     setTimeRangeSelection(range);
     selectQuery({


### PR DESCRIPTION
The latest nanoseconds migration missed handling this one, the click and drag on metrics graph was setting the merged_from and merged_to in milliseconds which made the flame graph query to return "Profile has no samples" error. 