### PR TITLE
Improve GroupByLabelsDropdown menu styling

### DIFF
--- a/ui/packages/shared/profile/src/ProfileView/components/GroupByLabelsDropdown/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileView/components/GroupByLabelsDropdown/index.tsx
@@ -30,7 +30,7 @@ interface Props {
 
 const GroupByLabelsDropdown = ({labels, groupBy, setGroupByLabels}: Props): JSX.Element => {
   return (
-    <div className="flex flex-col" {...testId('GROUP_BY_CONTAINER')}>
+    <div className="flex flex-col relative" {...testId('GROUP_BY_CONTAINER')}>
       <div className="flex items-center justify-between">
         <label className="text-sm" {...testId('GROUP_BY_LABEL')}>
           Group by
@@ -45,11 +45,16 @@ const GroupByLabelsDropdown = ({labels, groupBy, setGroupByLabels}: Props): JSX.
         options={labels.map(label => ({label, value: `${FIELD_LABELS}.${label}`}))}
         className="parca-select-container text-sm rounded-md bg-white"
         classNamePrefix="parca-select"
-        menuPortalTarget={document.body}
         components={{
           // eslint-disable-next-line react/prop-types
           MenuList: ({children, innerProps}) => (
-            <div {...testId('GROUP_BY_SELECT_FLYOUT')} {...innerProps}>
+            <div
+              className="overflow-y-auto"
+              {...testId('GROUP_BY_SELECT_FLYOUT')}
+              {...innerProps}
+              // eslint-disable-next-line react/prop-types
+              style={{...innerProps.style, height: '332px', maxHeight: '332px', fontSize: '14px'}}
+            >
               {children}
             </div>
           ),
@@ -65,10 +70,11 @@ const GroupByLabelsDropdown = ({labels, groupBy, setGroupByLabels}: Props): JSX.
           menu: provided => ({
             ...provided,
             marginBottom: 0,
-            boxShadow: 'none',
-            marginTop: 0,
+            boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)',
+            marginTop: 10,
             zIndex: 1000,
             minWidth: '320px',
+            position: 'absolute',
           }),
           control: provided => ({
             ...provided,


### PR DESCRIPTION
The usage of `menuPortalTarget ` was causing a bug where the select dropdown was on top of the actual flame graph. Also added the default select dropdown styles back.


**Before**
<img width="1498" height="647" alt="image" src="https://github.com/user-attachments/assets/9dc72e59-f064-4a73-8f71-392c557ad537" />

**After**
<img width="1517" height="377" alt="image" src="https://github.com/user-attachments/assets/76403663-1aae-4100-bc47-371be1ec877a" />
