### PR TITLE
ui: Refactor Flame Graph color mapping logic

### DIFF
--- a/ui/packages/shared/profile/src/ProfileFlameGraph/FlameGraphArrow/FlameGraphNodes.tsx
+++ b/ui/packages/shared/profile/src/ProfileFlameGraph/FlameGraphArrow/FlameGraphNodes.tsx
@@ -130,8 +130,6 @@ export const FlameNode = React.memo(
     const colorAttribute =
       colorBy === 'filename' ? filename : colorBy === 'binary' ? mappingFile : null;
 
-    const colorsMap = colors;
-
     const hoveringName =
       hoveringRow !== undefined ? arrowToString(functionNameColumn?.get(hoveringRow)) : '';
     const shouldBeHighlighted =
@@ -142,7 +140,7 @@ export const FlameNode = React.memo(
       compareMode,
       cumulative,
       diff,
-      colorsMap,
+      colorsMap: colors,
       colorAttribute,
     });
 
@@ -296,7 +294,9 @@ export const FlameNode = React.memo(
       prevProps.hoveringRow === nextProps.hoveringRow &&
       prevProps.totalWidth === nextProps.totalWidth &&
       prevProps.height === nextProps.height &&
-      prevProps.effectiveDepth === nextProps.effectiveDepth
+      prevProps.effectiveDepth === nextProps.effectiveDepth &&
+      prevProps.colorBy === nextProps.colorBy &&
+      prevProps.colors === nextProps.colors
     );
   }
 );


### PR DESCRIPTION
There was an opportunity to consolidate how the mapping files and filenames are used to derive the colors to be used for the Flame Graph. 

This PR helps to ensure we're not repeating logic in different components by using the `useProfileMetadata` and `useVisualizationState` hooks to get all the coloring data needed and passing it down as props to the components that needs them.

It also fixes a bug where if you switch the coloring by from filename to binary and vice versa, the Flame Graph is not immediately re-rendered with the new colors.