### PR TITLE
feat: use Distinct instead of Project for profile metadata queries

### DIFF
--- a/pkg/parcacol/querier.go
+++ b/pkg/parcacol/querier.go
@@ -1567,7 +1567,7 @@ func (q *Querier) GetProfileMetadataMappings(
 	records := make(map[string]struct{})
 	err = q.engine.ScanTable(q.tableName).
 		Filter(filterExpr).
-		Project(logicalplan.Col("stacktrace")).
+		Distinct(logicalplan.Col("stacktrace")).
 		Execute(ctx, func(ctx context.Context, r arrow.Record) error {
 			r.Retain()
 
@@ -1632,7 +1632,7 @@ func (q *Querier) GetProfileMetadataLabels(
 
 	err = q.engine.ScanTable(q.tableName).
 		Filter(filterExpr).
-		Project(logicalplan.DynCol("labels")).
+		Distinct(logicalplan.DynCol("labels")).
 		Execute(ctx, func(ctx context.Context, ar arrow.Record) error {
 			for i, field := range ar.Schema().Fields() {
 				nulls := ar.Column(i).NullN()


### PR DESCRIPTION
Replace `Project()` with `Distinct()` in `GetProfileMetadataMappings` and 
`GetProfileMetadataLabels` methods to ensure unique results and improve 
query performance by eliminating duplicate stacktrace and label entries.

This change will not affect correctness as GetProfileMetadataMappings
and GetProfileMetadataLabels also have deduplicate logic.

This change helps reduce 100+ million rows from the underlying database, just like #5921