### PR TITLE
ui: Cancel previous request when a new query starts

### DIFF
--- a/ui/packages/shared/profile/src/MatchersInput/index.tsx
+++ b/ui/packages/shared/profile/src/MatchersInput/index.tsx
@@ -59,7 +59,7 @@ export const useLabelNames = (
 
   const {data, isLoading, error} = useGrpcQuery<LabelsResponse>({
     key: ['labelNames', profileType, match?.join(','), start, end],
-    queryFn: async () => {
+    queryFn: async signal => {
       const request: LabelsRequest = {match: match !== undefined ? match : []};
       if (start !== undefined && end !== undefined) {
         request.start = millisToProtoTimestamp(start);
@@ -68,7 +68,7 @@ export const useLabelNames = (
       if (profileType !== undefined) {
         request.profileType = profileType;
       }
-      const {response} = await client.labels(request, {meta: metadata});
+      const {response} = await client.labels(request, {meta: metadata, abort: signal});
       return response;
     },
     options: {
@@ -100,13 +100,13 @@ export const useLabelValues = (
 
   const {data, isLoading, error} = useGrpcQuery<string[]>({
     key: ['labelValues', labelName, profileType, start, end],
-    queryFn: async () => {
+    queryFn: async signal => {
       const request: ValuesRequest = {labelName, match: [], profileType};
       if (start !== undefined && end !== undefined) {
         request.start = millisToProtoTimestamp(start);
         request.end = millisToProtoTimestamp(end);
       }
-      const {response} = await client.values(request, {meta: metadata});
+      const {response} = await client.values(request, {meta: metadata, abort: signal});
       return sanitizeLabelValue(response.labelValues);
     },
     options: {

--- a/ui/packages/shared/profile/src/ProfileMetricsGraph/hooks/useQueryRange.ts
+++ b/ui/packages/shared/profile/src/ProfileMetricsGraph/hooks/useQueryRange.ts
@@ -68,7 +68,7 @@ export const useQueryRange = (
 
   const {data, isLoading, error} = useGrpcQuery<QueryRangeResponse | undefined>({
     key: ['query-range', queryExpression, start, end, (sumBy ?? []).join(','), stepCount, metadata],
-    queryFn: async () => {
+    queryFn: async signal => {
       const stepDuration = getStepDuration(start, end, stepCount);
       const {response} = await client.queryRange(
         {
@@ -79,7 +79,7 @@ export const useQueryRange = (
           limit: 0,
           sumBy,
         },
-        {meta: metadata}
+        {meta: metadata, abort: signal}
       );
       return response;
     },

--- a/ui/packages/shared/profile/src/useGrpcQuery/index.ts
+++ b/ui/packages/shared/profile/src/useGrpcQuery/index.ts
@@ -15,7 +15,7 @@ import {useQuery, type UseQueryResult} from '@tanstack/react-query';
 
 interface Props<IRes> {
   key: unknown[];
-  queryFn: () => Promise<IRes>;
+  queryFn: (signal?: AbortSignal) => Promise<IRes>;
   options?: {
     enabled?: boolean | undefined;
     staleTime?: number | undefined;
@@ -31,8 +31,8 @@ const useGrpcQuery = <IRes>({
 }: Props<IRes>): UseQueryResult<IRes> => {
   return useQuery<IRes>(
     key,
-    async () => {
-      return await queryFn();
+    async ({signal}) => {
+      return await queryFn(signal);
     },
     {
       enabled,

--- a/ui/packages/shared/profile/src/useQuery.tsx
+++ b/ui/packages/shared/profile/src/useQuery.tsx
@@ -66,7 +66,7 @@ export const useQuery = (
       options?.sandwichByFunction ?? '',
       protoFiltersKey,
     ],
-    queryFn: async () => {
+    queryFn: async signal => {
       const req = profileSource.QueryRequest();
       req.reportType = reportType;
       req.nodeTrimThreshold = options?.nodeTrimThreshold;
@@ -91,7 +91,7 @@ export const useQuery = (
       }
 
       try {
-        const {response} = await client.query(req, {meta: metadata});
+        const {response} = await client.query(req, {meta: metadata, abort: signal});
         return response;
       } catch (e) {
         if (options?.sourceOnly === true) {


### PR DESCRIPTION
PR uses React Query to cancel previous request if the request is exactly the same. Works for the Query, QueryRange and Labels requests.