### PR TITLE
Add test IDs for Invert Call Stack button

### DIFF
--- a/ui/packages/shared/profile/src/ProfileView/components/InvertCallStack/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileView/components/InvertCallStack/index.tsx
@@ -14,6 +14,7 @@
 import {Icon} from '@iconify/react';
 
 import {Button, useURLState} from '@parca/components';
+import {TEST_IDS, testId} from '@parca/test-utils';
 
 import {useResetFlameGraphState} from '../../hooks/useResetFlameGraphState';
 
@@ -36,6 +37,7 @@ const InvertCallStack = (): JSX.Element => {
         className="flex items-center gap-2 whitespace-nowrap"
         onClick={() => handleSetInvert(!isInvert)}
         id="h-invert-call-stack"
+        {...testId(TEST_IDS.INVERT_CALL_STACK_BUTTON)}
       >
         <Icon icon={isInvert ? 'ph:sort-ascending' : 'ph:sort-descending'} className="h-4 w-4" />
         {isInvert ? 'Original' : 'Invert'} Call Stack

--- a/ui/packages/shared/profile/src/ProfileView/hooks/useVisualizationState.ts
+++ b/ui/packages/shared/profile/src/ProfileView/hooks/useVisualizationState.ts
@@ -89,8 +89,10 @@ export const useVisualizationState = (): {
   const setGroupByLabels = useCallback(
     (labels: string[]): void => {
       setGroupBy(groupBy.filter(l => !l.startsWith(`${FIELD_LABELS}.`)).concat(labels));
+
+      resetFlameGraphState();
     },
-    [groupBy, setGroupBy]
+    [groupBy, setGroupBy, resetFlameGraphState]
   );
 
   const resetSandwichFunctionName = useCallback((): void => {

--- a/ui/packages/shared/test-utils/src/test-ids.ts
+++ b/ui/packages/shared/test-utils/src/test-ids.ts
@@ -113,6 +113,9 @@ export const TEST_IDS = {
   GROUP_BY_LABEL: 'group-by-label',
   GROUP_BY_SELECT_FLYOUT: 'group-by-select-flyout',
 
+  // Invert Call Stack
+  INVERT_CALL_STACK_BUTTON: 'invert-call-stack-button',
+
   // Compare Mode
   COMPARE_CONTAINER: 'compare-container',
   COMPARE_SIDE_A: 'compare-side-a',


### PR DESCRIPTION
Also ensures flame graph state resets when group by labels are updated. (This is an actual bug detected by the E2E tests)