### PR TITLE
Migrate from arrow.Record to arrow.RecordBatch

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -22,11 +22,11 @@ import (
 )
 
 type Ingester interface {
-	Ingest(ctx context.Context, record arrow.Record) error
+	Ingest(ctx context.Context, record arrow.RecordBatch) error
 }
 
 type Table interface {
-	InsertRecord(context.Context, arrow.Record) (tx uint64, err error)
+	InsertRecord(context.Context, arrow.RecordBatch) (tx uint64, err error)
 }
 
 type TableIngester struct {
@@ -44,7 +44,7 @@ func NewIngester(
 	}
 }
 
-func (ing TableIngester) Ingest(ctx context.Context, record arrow.Record) error {
+func (ing TableIngester) Ingest(ctx context.Context, record arrow.RecordBatch) error {
 	if record.NumRows() == 0 {
 		return nil
 	}

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -47,14 +47,14 @@ func MustReadAllGzip(t require.TestingT, filename string) []byte {
 type fakeTable struct {
 	schema *dynparquet.Schema
 
-	inserts []arrow.Record
+	inserts []arrow.RecordBatch
 }
 
 func (t *fakeTable) Schema() *dynparquet.Schema {
 	return t.schema
 }
 
-func (t *fakeTable) InsertRecord(ctx context.Context, record arrow.Record) (uint64, error) {
+func (t *fakeTable) InsertRecord(ctx context.Context, record arrow.RecordBatch) (uint64, error) {
 	record.Retain()
 	t.inserts = append(t.inserts, record)
 	return 0, nil

--- a/pkg/normalizer/arrow.go
+++ b/pkg/normalizer/arrow.go
@@ -95,7 +95,7 @@ func (c *arrowToInternalConverter) HasUnknownStacktraceIDs() (bool, error) {
 	return true, nil
 }
 
-func (c *arrowToInternalConverter) UnknownStacktraceIDsRecord() (arrow.Record, error) {
+func (c *arrowToInternalConverter) UnknownStacktraceIDsRecord() (arrow.RecordBatch, error) {
 	m := arrow.NewMetadata(
 		[]string{MetadataSchemaVersion},
 		[]string{MetadataSchemaVersionV1},
@@ -106,7 +106,7 @@ func (c *arrowToInternalConverter) UnknownStacktraceIDsRecord() (arrow.Record, e
 		return nil, fmt.Errorf("expected stacktrace IDs column to be of type Binary, got %T", c.b.StacktraceIDs.Dictionary())
 	}
 
-	return array.NewRecord(
+	return array.NewRecordBatch(
 		arrow.NewSchema([]arrow.Field{{
 			Name: "stacktrace_id",
 			Type: arrow.BinaryTypes.Binary,
@@ -118,7 +118,7 @@ func (c *arrowToInternalConverter) UnknownStacktraceIDsRecord() (arrow.Record, e
 
 func (c *arrowToInternalConverter) AddLocationsRecord(
 	ctx context.Context,
-	rec arrow.Record,
+	rec arrow.RecordBatch,
 ) error {
 	value, ok := rec.Schema().Metadata().GetValue(MetadataSchemaVersion)
 	if !ok {
@@ -135,7 +135,7 @@ func (c *arrowToInternalConverter) AddLocationsRecord(
 
 func (c *arrowToInternalConverter) AddSampleRecord(
 	ctx context.Context,
-	rec arrow.Record,
+	rec arrow.RecordBatch,
 ) error {
 	value, ok := rec.Schema().Metadata().GetValue(MetadataSchemaVersion)
 	if !ok {
@@ -375,8 +375,8 @@ func (r *InternalRecordBuilderV1) validate() error {
 	return nil
 }
 
-func (c *arrowToInternalConverter) NewRecord(ctx context.Context) (arrow.Record, error) {
-	newRecord := array.NewRecord(
+func (c *arrowToInternalConverter) NewRecord(ctx context.Context) (arrow.RecordBatch, error) {
+	newRecord := array.NewRecordBatch(
 		arrow.NewSchema(append(c.b.LabelFields, []arrow.Field{{
 			Name: profile.ColumnName,
 			Type: &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Uint32, ValueType: arrow.BinaryTypes.Binary},
@@ -488,7 +488,7 @@ func (c *arrowToInternalConverter) NewRecord(ctx context.Context) (arrow.Record,
 
 func (c *arrowToInternalConverter) AddLocationsRecordV1(
 	ctx context.Context,
-	rec arrow.Record,
+	rec arrow.RecordBatch,
 ) error {
 	schema := rec.Schema()
 	if schema.NumFields() != 3 {
@@ -632,7 +632,7 @@ func unsafeString(b []byte) string {
 
 func (c *arrowToInternalConverter) AddSampleRecordV1(
 	ctx context.Context,
-	rec arrow.Record,
+	rec arrow.RecordBatch,
 ) error {
 	var (
 		ok  bool

--- a/pkg/normalizer/normalizer.go
+++ b/pkg/normalizer/normalizer.go
@@ -120,7 +120,7 @@ func WriteRawRequestToArrowRecord(
 	mem memory.Allocator,
 	req *profilestorepb.WriteRawRequest,
 	schema *dynparquet.Schema,
-) (arrow.Record, error) {
+) (arrow.RecordBatch, error) {
 	normalizedRequest, err := NormalizeWriteRawRequest(
 		ctx,
 		req,
@@ -325,7 +325,7 @@ func WriteRawRequestToArrowRecord(
 		}
 	}
 
-	record := b.NewRecord()
+	record := b.NewRecordBatch()
 	if record.NumRows() == 0 {
 		// If there are no rows in the record we simply return early.
 		record.Release()

--- a/pkg/normalizer/otel.go
+++ b/pkg/normalizer/otel.go
@@ -40,7 +40,7 @@ func OtlpRequestToArrowRecord(
 	req *otelgrpcprofilingpb.ExportProfilesServiceRequest,
 	schema *dynparquet.Schema,
 	mem memory.Allocator,
-) (arrow.Record, error) {
+) (arrow.RecordBatch, error) {
 	if err := ValidateOtelExportProfilesServiceRequest(req); err != nil {
 		return nil, fmt.Errorf("invalid request: %w", err)
 	}
@@ -290,7 +290,7 @@ func (w *profileWriter) writeResourceProfiles(
 	return nil
 }
 
-func (w *profileWriter) ArrowRecord(ctx context.Context) (arrow.Record, error) {
+func (w *profileWriter) ArrowRecord(ctx context.Context) (arrow.RecordBatch, error) {
 	if w.buffer.NumRows() == 0 {
 		// If there are no rows in the buffer we simply return early
 		return nil, nil

--- a/pkg/parcacol/arrow.go
+++ b/pkg/parcacol/arrow.go
@@ -217,7 +217,7 @@ func (c *ArrowToProfileConverter) Convert(
 	}, nil
 }
 
-func BuildArrowLocations(allocator memory.Allocator, stacktraces []*pb.Stacktrace, resolvedLocations []*profile.Location, locationIndex map[string]int) (arrow.Record, error) {
+func BuildArrowLocations(allocator memory.Allocator, stacktraces []*pb.Stacktrace, resolvedLocations []*profile.Location, locationIndex map[string]int) (arrow.RecordBatch, error) {
 	w := profile.NewLocationsWriter(allocator)
 	defer w.RecordBuilder.Release()
 
@@ -316,7 +316,7 @@ func BuildArrowLocations(allocator memory.Allocator, stacktraces []*pb.Stacktrac
 		}
 	}
 
-	return w.RecordBuilder.NewRecord(), nil
+	return w.RecordBuilder.NewRecordBatch(), nil
 }
 
 func stringToBytes(s string) []byte {

--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -140,7 +140,7 @@ type NormalizedSample struct {
 }
 
 type Profile struct {
-	Samples []arrow.Record
+	Samples []arrow.RecordBatch
 	Meta    Meta
 }
 

--- a/pkg/profile/reader.go
+++ b/pkg/profile/reader.go
@@ -31,7 +31,7 @@ type Reader struct {
 }
 
 type RecordReader struct {
-	Record arrow.Record
+	Record arrow.RecordBatch
 
 	LabelFields  []arrow.Field
 	LabelColumns []LabelColumn
@@ -74,7 +74,7 @@ func NewReader(p Profile) Reader {
 	return r
 }
 
-func NewRecordReader(ar arrow.Record) *RecordReader {
+func NewRecordReader(ar arrow.RecordBatch) *RecordReader {
 	schema := ar.Schema()
 
 	labelFields := make([]arrow.Field, 0, schema.NumFields())

--- a/pkg/profilestore/profilecolumnstore.go
+++ b/pkg/profilestore/profilecolumnstore.go
@@ -216,7 +216,7 @@ func (s *ProfileColumnStore) write(ctx context.Context, server profilestorepb.Pr
 	)
 	defer c.Release()
 
-	if err := c.AddSampleRecord(ctx, r.Record()); err != nil {
+	if err := c.AddSampleRecord(ctx, r.RecordBatch()); err != nil {
 		return status.Error(codes.InvalidArgument, "failed to add sample record")
 	}
 
@@ -267,7 +267,7 @@ func (s *ProfileColumnStore) write(ctx context.Context, server profilestorepb.Pr
 			return status.Errorf(codes.InvalidArgument, "failed to read record: %v", r.Err())
 		}
 
-		if err := c.AddLocationsRecord(ctx, r.Record()); err != nil {
+		if err := c.AddLocationsRecord(ctx, r.RecordBatch()); err != nil {
 			return status.Errorf(codes.InvalidArgument, "failed to add locations record: %v", err)
 		}
 	}

--- a/pkg/query/columnquery_test.go
+++ b/pkg/query/columnquery_test.go
@@ -1310,7 +1310,7 @@ func PprofToSymbolizedProfile(meta profile.Meta, prof *pprofprofile.Profile, ind
 
 	return profile.Profile{
 		Meta:    meta,
-		Samples: []arrow.Record{w.RecordBuilder.NewRecord()},
+		Samples: []arrow.RecordBatch{w.RecordBuilder.NewRecordBatch()},
 	}, nil
 }
 
@@ -1370,12 +1370,12 @@ func TestFilterData(t *testing.T) {
 	w.TimeNanos.Append(1)
 	w.Period.Append(1)
 
-	originalRecord := w.RecordBuilder.NewRecord()
+	originalRecord := w.RecordBuilder.NewRecordBatch()
 	recs, _, err := FilterProfileData(
 		context.Background(),
 		noop.NewTracerProvider().Tracer(""),
 		mem,
-		[]arrow.Record{originalRecord},
+		[]arrow.RecordBatch{originalRecord},
 		[]*pb.Filter{
 			{
 				Filter: &pb.Filter_FrameFilter{
@@ -1432,12 +1432,12 @@ func TestFilterUnsymbolized(t *testing.T) {
 	w.TimeNanos.Append(1)
 	w.Period.Append(1)
 
-	originalRecord := w.RecordBuilder.NewRecord()
+	originalRecord := w.RecordBuilder.NewRecordBatch()
 	recs, _, err := FilterProfileData(
 		context.Background(),
 		noop.NewTracerProvider().Tracer(""),
 		mem,
-		[]arrow.Record{originalRecord},
+		[]arrow.RecordBatch{originalRecord},
 		[]*pb.Filter{
 			{
 				Filter: &pb.Filter_FrameFilter{
@@ -1529,12 +1529,12 @@ func TestFilterDataWithPath(t *testing.T) {
 	w.TimeNanos.Append(1)
 	w.Period.Append(1)
 
-	originalRecord := w.RecordBuilder.NewRecord()
+	originalRecord := w.RecordBuilder.NewRecordBatch()
 	recs, _, err := FilterProfileData(
 		context.Background(),
 		noop.NewTracerProvider().Tracer(""),
 		mem,
-		[]arrow.Record{originalRecord},
+		[]arrow.RecordBatch{originalRecord},
 		[]*pb.Filter{
 			{
 				Filter: &pb.Filter_FrameFilter{
@@ -1631,12 +1631,12 @@ func TestFilterDataFrameFilter(t *testing.T) {
 	w.TimeNanos.Append(1)
 	w.Period.Append(1)
 
-	originalRecord := w.RecordBuilder.NewRecord()
+	originalRecord := w.RecordBuilder.NewRecordBatch()
 	recs, _, err := FilterProfileData(
 		context.Background(),
 		noop.NewTracerProvider().Tracer(""),
 		mem,
-		[]arrow.Record{originalRecord},
+		[]arrow.RecordBatch{originalRecord},
 		[]*pb.Filter{
 			{
 				Filter: &pb.Filter_FrameFilter{
@@ -1730,7 +1730,7 @@ func BenchmarkFilterData(t *testing.B) {
 		w.Period.Append(1)
 	}
 
-	originalRecord := w.RecordBuilder.NewRecord()
+	originalRecord := w.RecordBuilder.NewRecordBatch()
 	defer originalRecord.Release()
 	for i := 0; i < t.N; i++ {
 		originalRecord.Retain() // retain each time since FilterProfileData will release it
@@ -1738,7 +1738,7 @@ func BenchmarkFilterData(t *testing.B) {
 			context.Background(),
 			noop.NewTracerProvider().Tracer(""),
 			mem,
-			[]arrow.Record{originalRecord},
+			[]arrow.RecordBatch{originalRecord},
 			[]*pb.Filter{
 				{
 					Filter: &pb.Filter_FrameFilter{
@@ -1916,7 +1916,7 @@ func TestFilterDataExclude(t *testing.T) {
 	w.TimeNanos.Append(3)
 	w.Period.Append(1)
 
-	originalRecord := w.RecordBuilder.NewRecord()
+	originalRecord := w.RecordBuilder.NewRecordBatch()
 	defer originalRecord.Release()
 
 	t.Run("exclude=false filters to only samples with foo", func(t *testing.T) {
@@ -1925,7 +1925,7 @@ func TestFilterDataExclude(t *testing.T) {
 			ctx,
 			tracer,
 			mem,
-			[]arrow.Record{originalRecord},
+			[]arrow.RecordBatch{originalRecord},
 			[]*pb.Filter{
 				{
 					Filter: &pb.Filter_StackFilter{
@@ -1973,7 +1973,7 @@ func TestFilterDataExclude(t *testing.T) {
 			ctx,
 			tracer,
 			mem,
-			[]arrow.Record{originalRecord},
+			[]arrow.RecordBatch{originalRecord},
 			[]*pb.Filter{
 				{
 					Filter: &pb.Filter_StackFilter{
@@ -2012,7 +2012,7 @@ func TestFilterDataExclude(t *testing.T) {
 			ctx,
 			tracer,
 			mem,
-			[]arrow.Record{originalRecord},
+			[]arrow.RecordBatch{originalRecord},
 			[]*pb.Filter{}, // no filters
 		)
 		require.NoError(t, err)
@@ -2037,7 +2037,7 @@ func TestFilterDataExclude(t *testing.T) {
 			ctx,
 			tracer,
 			mem,
-			[]arrow.Record{originalRecord},
+			[]arrow.RecordBatch{originalRecord},
 			[]*pb.Filter{}, // no filters
 		)
 		require.NoError(t, err)
@@ -2063,7 +2063,7 @@ func TestFilterDataExclude(t *testing.T) {
 			ctx,
 			tracer,
 			mem,
-			[]arrow.Record{originalRecord},
+			[]arrow.RecordBatch{originalRecord},
 			[]*pb.Filter{
 				{
 					Filter: &pb.Filter_StackFilter{

--- a/pkg/query/flamegraph_arrow.go
+++ b/pkg/query/flamegraph_arrow.go
@@ -108,7 +108,7 @@ func GenerateFlamegraphArrow(
 	}, cumulative, nil
 }
 
-func generateFlamegraphArrowRecord(ctx context.Context, mem memory.Allocator, tracer trace.Tracer, p profile.Profile, groupBy []string, trimFraction float32) (arrow.Record, int64, int32, int64, error) {
+func generateFlamegraphArrowRecord(ctx context.Context, mem memory.Allocator, tracer trace.Tracer, p profile.Profile, groupBy []string, trimFraction float32) (arrow.RecordBatch, int64, int32, int64, error) {
 	ctx, span := tracer.Start(ctx, "generateFlamegraphArrowRecord")
 	defer span.End()
 
@@ -1154,7 +1154,7 @@ func (fb *flamegraphBuilder) prepareNewRecord() error {
 // NewRecord returns a new record from the builders.
 // It adds the children to the children column and the labels intersection to the labels column.
 // Finally, it assembles all columns from the builders into an arrow record.
-func (fb *flamegraphBuilder) NewRecord() (arrow.Record, error) {
+func (fb *flamegraphBuilder) NewRecord() (arrow.RecordBatch, error) {
 	fields := []arrow.Field{
 		// Location
 		{Name: FlamegraphFieldLabelsOnly, Type: arrow.FixedWidthTypes.Boolean},
@@ -1253,7 +1253,7 @@ func (fb *flamegraphBuilder) NewRecord() (arrow.Record, error) {
 		arrays[numCols+i] = fb.labels[i]
 	}
 
-	return array.NewRecord(
+	return array.NewRecordBatch(
 		arrow.NewSchema(fields, nil),
 		arrays,
 		int64(numRows),
@@ -2117,7 +2117,7 @@ func release(releasers ...compactDictionary.Releasable) {
 	}
 }
 
-func recordStats(r arrow.Record) string {
+func recordStats(r arrow.RecordBatch) string {
 	var totalBytes int
 	type fieldStat struct {
 		valueBytes  int

--- a/pkg/query/multiple_filters_test.go
+++ b/pkg/query/multiple_filters_test.go
@@ -30,8 +30,8 @@ import (
 // createTestProfileData creates multiple test profile records with meaningful function names
 // that can be reused across multiple filtering tests. This simulates real-world scenarios
 // where profile data comes in multiple batches/records.
-func createTestProfileData(mem memory.Allocator) ([]arrow.Record, func()) {
-	records := []arrow.Record{}
+func createTestProfileData(mem memory.Allocator) ([]arrow.RecordBatch, func()) {
+	records := []arrow.RecordBatch{}
 	writers := []*profile.Writer{}
 
 	// Record 1: Contains multiple samples
@@ -150,7 +150,7 @@ func createTestProfileData(mem memory.Allocator) ([]arrow.Record, func()) {
 	w1.TimeNanos.Append(2)
 	w1.Period.Append(1)
 
-	record1 := w1.RecordBuilder.NewRecord()
+	record1 := w1.RecordBuilder.NewRecordBatch()
 	records = append(records, record1)
 
 	// Record 2: Contains a single sample (utils.helper -> database.connect)
@@ -197,7 +197,7 @@ func createTestProfileData(mem memory.Allocator) ([]arrow.Record, func()) {
 	w2.TimeNanos.Append(3)
 	w2.Period.Append(1)
 
-	record2 := w2.RecordBuilder.NewRecord()
+	record2 := w2.RecordBuilder.NewRecordBatch()
 	records = append(records, record2)
 
 	// Record 3: Contains multiple samples
@@ -300,7 +300,7 @@ func createTestProfileData(mem memory.Allocator) ([]arrow.Record, func()) {
 	w3.TimeNanos.Append(5)
 	w3.Period.Append(1)
 
-	record3 := w3.RecordBuilder.NewRecord()
+	record3 := w3.RecordBuilder.NewRecordBatch()
 	records = append(records, record3)
 
 	cleanup := func() {

--- a/pkg/query/pprof.go
+++ b/pkg/query/pprof.go
@@ -141,7 +141,7 @@ func (w *PprofWriter) getBuf(capacity int) []byte {
 	return w.buf[:capacity]
 }
 
-func (w *PprofWriter) WriteRecord(rec arrow.Record) {
+func (w *PprofWriter) WriteRecord(rec arrow.RecordBatch) {
 	r := parcaprofile.NewRecordReader(rec)
 	t := w.transpose(r)
 

--- a/pkg/query/sources.go
+++ b/pkg/query/sources.go
@@ -72,7 +72,7 @@ func generateSourceReportRecord(
 	p profile.Profile,
 	ref *pb.SourceReference,
 	source string,
-) (arrow.Record, int64) {
+) (arrow.RecordBatch, int64) {
 	b := newSourceReportBuilder(pool, ref, int64(strings.Count(source, "\n")))
 	for _, record := range p.Samples {
 		b.addRecord(record)
@@ -112,7 +112,7 @@ func newSourceReportBuilder(
 	}
 }
 
-func (b *sourceReportBuilder) finish() (arrow.Record, int64) {
+func (b *sourceReportBuilder) finish() (arrow.RecordBatch, int64) {
 	flat := array.NewInt64Builder(b.pool)
 	defer flat.Release()
 	cumu := array.NewInt64Builder(b.pool)
@@ -126,7 +126,7 @@ func (b *sourceReportBuilder) finish() (arrow.Record, int64) {
 	flatarr := flat.NewInt64Array()
 	defer flatarr.Release()
 
-	return array.NewRecord(
+	return array.NewRecordBatch(
 		arrow.NewSchema(
 			[]arrow.Field{
 				{Name: "cumulative", Type: arrow.PrimitiveTypes.Int64},
@@ -142,7 +142,7 @@ func (b *sourceReportBuilder) finish() (arrow.Record, int64) {
 	), b.cumulative
 }
 
-func (b *sourceReportBuilder) addRecord(rec arrow.Record) {
+func (b *sourceReportBuilder) addRecord(rec arrow.RecordBatch) {
 	r := profile.NewRecordReader(rec)
 	b.cumulative += math.Int64.Sum(r.Value)
 

--- a/pkg/query/table.go
+++ b/pkg/query/table.go
@@ -116,7 +116,7 @@ func generateTableArrowRecord(
 	mem memory.Allocator,
 	tracer trace.Tracer,
 	p profile.Profile,
-) (arrow.Record, int64, error) {
+) (arrow.RecordBatch, int64, error) {
 	_, span := tracer.Start(ctx, "generateTableArrowRecord")
 	defer span.End()
 
@@ -310,7 +310,7 @@ func (tb *tableBuilder) populateCallerAndCalleeData() {
 }
 
 // NewRecord returns a new record from the builders.
-func (tb *tableBuilder) NewRecord() (arrow.Record, error) {
+func (tb *tableBuilder) NewRecord() (arrow.RecordBatch, error) {
 	tb.populateCallerAndCalleeData()
 	return tb.rb.NewRecord(), nil
 }

--- a/pkg/query/table_test.go
+++ b/pkg/query/table_test.go
@@ -285,7 +285,7 @@ type tableColumns struct {
 	flatDiff           []int64
 }
 
-func tableRecordToColumns(t *testing.T, r arrow.Record) tableColumns {
+func tableRecordToColumns(t *testing.T, r arrow.RecordBatch) tableColumns {
 	return tableColumns{
 		mappingFile:        extractColumn(t, r, TableFieldMappingFile).([]string),
 		mappingBuildID:     extractColumn(t, r, TableFieldMappingBuildID).([]string),


### PR DESCRIPTION
Updated the codebase to replace all usages of `arrow.Record` with `arrow.RecordBatch` to make golang-lint happy again.

https://github.com/apache/arrow-go/pull/466 broke our golangci-lint with Arrow v18.4.1
