### PR TITLE
ui: remove overflow for MatchersInput component

### DIFF
--- a/ui/packages/shared/profile/src/MatchersInput/SuggestionsList.tsx
+++ b/ui/packages/shared/profile/src/MatchersInput/SuggestionsList.tsx
@@ -75,7 +75,7 @@ interface RefreshButtonProps {
 
 const RefreshButton = ({onClick, disabled, title, testId}: RefreshButtonProps): JSX.Element => {
   return (
-    <div className="sticky bottom-0 w-full flex items-center justify-center px-3 py-2 bg-gray-50 dark:bg-gray-900 border-t border-gray-200 dark:border-gray-700 z-20">
+    <div className="w-full flex items-center justify-center px-3 py-2 bg-gray-50 dark:bg-gray-900 border-t border-gray-200 dark:border-gray-700">
       <button
         onClick={e => {
           e.preventDefault();
@@ -303,9 +303,9 @@ const SuggestionsList = ({
           >
             <div
               style={{width: inputRef?.offsetWidth}}
-              className="absolute z-10 mt-1 max-h-[400px] overflow-auto rounded-md bg-gray-50 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none dark:bg-gray-900 sm:text-sm flex flex-col"
+              className="absolute z-10 mt-1 max-h-[400px] rounded-md bg-gray-50 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none dark:bg-gray-900 sm:text-sm flex flex-col"
             >
-              <div className="flex-1 min-h-0">
+              <div className="flex-1 overflow-auto min-h-0">
                 {isLabelNamesLoading ? (
                   <LoadingSpinner />
                 ) : suggestions.literals.length === 0 && suggestions.labelValues.length === 0 ? (


### PR DESCRIPTION
Fixes the positon of the refresh results button on the `SuggestionsList` component to the bottom.

_Before_
<img width="916" height="477" alt="image" src="https://github.com/user-attachments/assets/0b02ecfd-da75-41ea-92e2-b1633f9e326f" />

_After_
<img width="906" height="494" alt="image" src="https://github.com/user-attachments/assets/89baaf8c-ba07-4884-861f-8d86879a1583" />
