### PR TITLE
Dynamically adjust the method name area in the flame graph tooltip

### DIFF
--- a/ui/packages/shared/profile/src/GraphTooltipArrow/Content.tsx
+++ b/ui/packages/shared/profile/src/GraphTooltipArrow/Content.tsx
@@ -77,10 +77,10 @@ const GraphTooltipArrowContent = ({
   return (
     <div className={`flex text-sm ${isFixed ? 'w-full' : ''}`}>
       <div className={`m-auto w-full ${isFixed ? 'w-full' : ''}`}>
-        <div className="min-h-52 flex w-[500px] flex-col justify-between rounded-lg border border-gray-300 bg-gray-50 p-3 shadow-lg dark:border-gray-500 dark:bg-gray-900">
+        <div className="flex w-auto max-w-[600px] min-w-[300px] flex-col justify-start rounded-lg border border-gray-300 bg-gray-50 p-3 shadow-lg dark:border-gray-500 dark:bg-gray-900">
           <div className="flex flex-row">
             <div className="mx-2">
-              <div className="flex h-10 items-start justify-between gap-4 break-all font-semibold">
+              <div className="flex min-h-10 items-start justify-between gap-4 break-all font-semibold mb-2">
                 {row === 0 ? (
                   <p>root</p>
                 ) : (


### PR DESCRIPTION
The function name is too long and may cover the content below.
<img width="505" height="257" alt="image" src="https://github.com/user-attachments/assets/7837f2df-adbe-47af-90f0-035d3a78067c" />

The effect after modification is as follows.
<img width="621" height="310" alt="image" src="https://github.com/user-attachments/assets/7679a429-36c3-4fdb-a3ad-6d84c576ac17" />
