### PR TITLE
Add purged state for debuginfo cleanup

### DIFF
--- a/gen/proto/go/parca/debuginfo/v1alpha1/debuginfo.pb.go
+++ b/gen/proto/go/parca/debuginfo/v1alpha1/debuginfo.pb.go
@@ -1282,7 +1282,7 @@ const file_parca_debuginfo_v1alpha1_debuginfo_proto_rawDesc = "" +
 	"\x06Source\x12\x1e\n" +
 	"\x1aSOURCE_UNKNOWN_UNSPECIFIED\x10\x00\x12\x11\n" +
 	"\rSOURCE_UPLOAD\x10\x01\x12\x15\n" +
-	"\x11SOURCE_DEBUGINFOD\x10\x02\"\xc5\x02\n" +
+	"\x11SOURCE_DEBUGINFOD\x10\x02\"\xd7\x02\n" +
 	"\x0fDebuginfoUpload\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04hash\x18\x02 \x01(\tR\x04hash\x12E\n" +
@@ -1290,11 +1290,12 @@ const file_parca_debuginfo_v1alpha1_debuginfo_proto_rawDesc = "" +
 	"\n" +
 	"started_at\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\tstartedAt\x12;\n" +
 	"\vfinished_at\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
-	"finishedAt\"O\n" +
+	"finishedAt\"a\n" +
 	"\x05State\x12\x1d\n" +
 	"\x19STATE_UNKNOWN_UNSPECIFIED\x10\x00\x12\x13\n" +
 	"\x0fSTATE_UPLOADING\x10\x01\x12\x12\n" +
-	"\x0eSTATE_UPLOADED\x10\x02\"\xb7\x01\n" +
+	"\x0eSTATE_UPLOADED\x10\x02\x12\x10\n" +
+	"\fSTATE_PURGED\x10\x03\"\xb7\x01\n" +
 	"\x10DebuginfoQuality\x12\"\n" +
 	"\rnot_valid_elf\x18\x01 \x01(\bR\vnotValidElf\x12\x1b\n" +
 	"\thas_dwarf\x18\x02 \x01(\bR\bhasDwarf\x12$\n" +

--- a/gen/proto/go/parca/debuginfo/v1alpha1/debuginfo.pb.go
+++ b/gen/proto/go/parca/debuginfo/v1alpha1/debuginfo.pb.go
@@ -253,6 +253,8 @@ const (
 	DebuginfoUpload_STATE_UPLOADING DebuginfoUpload_State = 1
 	// The debuginfo has been uploaded successfully.
 	DebuginfoUpload_STATE_UPLOADED DebuginfoUpload_State = 2
+	// The debuginfo has been purged/cleaned up from storage.
+	DebuginfoUpload_STATE_PURGED DebuginfoUpload_State = 3
 )
 
 // Enum value maps for DebuginfoUpload_State.
@@ -261,11 +263,13 @@ var (
 		0: "STATE_UNKNOWN_UNSPECIFIED",
 		1: "STATE_UPLOADING",
 		2: "STATE_UPLOADED",
+		3: "STATE_PURGED",
 	}
 	DebuginfoUpload_State_value = map[string]int32{
 		"STATE_UNKNOWN_UNSPECIFIED": 0,
 		"STATE_UPLOADING":           1,
 		"STATE_UPLOADED":            2,
+		"STATE_PURGED":              3,
 	}
 )
 

--- a/pkg/debuginfo/fetcher.go
+++ b/pkg/debuginfo/fetcher.go
@@ -26,6 +26,7 @@ import (
 var (
 	ErrUnknownDebuginfoSource = errors.New("unknown debuginfo source")
 	ErrNotUploadedYet         = errors.New("debuginfo not uploaded yet")
+	ErrDebuginfoPurged        = errors.New("debuginfo has been purged")
 )
 
 type Fetcher struct {

--- a/pkg/debuginfo/metadata.go
+++ b/pkg/debuginfo/metadata.go
@@ -105,6 +105,21 @@ func (m *ObjectStoreMetadata) MarkAsUploaded(ctx context.Context, buildID, uploa
 	return m.write(ctx, dbginfo)
 }
 
+func (m *ObjectStoreMetadata) MarkAsPurged(ctx context.Context, buildID string, typ debuginfopb.DebuginfoType) error {
+	dbginfo, err := m.Fetch(ctx, buildID, typ)
+	if err != nil {
+		return err
+	}
+
+	if dbginfo.Upload == nil {
+		return ErrUploadMetadataNotFound
+	}
+
+	dbginfo.Upload.State = debuginfopb.DebuginfoUpload_STATE_PURGED
+
+	return m.write(ctx, dbginfo)
+}
+
 func (m *ObjectStoreMetadata) Fetch(ctx context.Context, buildID string, typ debuginfopb.DebuginfoType) (*debuginfopb.Debuginfo, error) {
 	path := metadataObjectPath(buildID, typ)
 	r, err := m.bucket.Get(ctx, path)

--- a/pkg/debuginfo/store.go
+++ b/pkg/debuginfo/store.go
@@ -126,6 +126,7 @@ const (
 	ReasonDebuginfoInvalid                = "Debuginfo already exists but is marked as invalid, therefore a new upload is needed. Hash the debuginfo and initiate the upload."
 	ReasonDebuginfoEqual                  = "Debuginfo already exists and is marked as invalid, but the proposed hash is the same as the one already available, therefore the upload is not accepted as it would result in the same invalid debuginfos."
 	ReasonDebuginfoNotEqual               = "Debuginfo already exists but is marked as invalid, therefore a new upload will be accepted."
+	ReasonDebuginfoPurged                 = "Debuginfo was previously uploaded but has been purged/cleaned up, therefore a new upload is needed."
 	ReasonDebuginfodSource                = "Debuginfo is available from debuginfod already and not marked as invalid, therefore no new upload is needed."
 	ReasonDebuginfodInvalid               = "Debuginfo is available from debuginfod already but is marked as invalid, therefore a new upload is needed."
 )
@@ -236,6 +237,12 @@ func (s *Store) ShouldInitiateUpload(ctx context.Context, req *debuginfopb.Shoul
 				return &debuginfopb.ShouldInitiateUploadResponse{
 					ShouldInitiateUpload: true,
 					Reason:               ReasonDebuginfoNotEqual,
+				}, nil
+			case debuginfopb.DebuginfoUpload_STATE_PURGED:
+				// Debuginfo was purged, allow re-uploading
+				return &debuginfopb.ShouldInitiateUploadResponse{
+					ShouldInitiateUpload: true,
+					Reason:               ReasonDebuginfoPurged,
 				}, nil
 			default:
 				return nil, status.Error(codes.Internal, "metadata inconsistency: unknown upload state")

--- a/pkg/symbolizer/symbolizer.go
+++ b/pkg/symbolizer/symbolizer.go
@@ -202,7 +202,12 @@ func (s *Symbolizer) getDebuginfo(ctx context.Context, buildID string) (string, 
 
 	switch dbginfo.Source {
 	case debuginfopb.Debuginfo_SOURCE_UPLOAD:
-		if dbginfo.Upload.State != debuginfopb.DebuginfoUpload_STATE_UPLOADED {
+		switch dbginfo.Upload.State {
+		case debuginfopb.DebuginfoUpload_STATE_UPLOADED:
+			// Good to proceed
+		case debuginfopb.DebuginfoUpload_STATE_PURGED:
+			return "", nil, nil, debuginfo.ErrDebuginfoPurged
+		default:
 			return "", nil, nil, debuginfo.ErrNotUploadedYet
 		}
 	case debuginfopb.Debuginfo_SOURCE_DEBUGINFOD:

--- a/proto/parca/debuginfo/v1alpha1/debuginfo.proto
+++ b/proto/parca/debuginfo/v1alpha1/debuginfo.proto
@@ -230,6 +230,8 @@ message DebuginfoUpload {
     STATE_UPLOADING = 1;
     // The debuginfo has been uploaded successfully.
     STATE_UPLOADED = 2;
+    // The debuginfo has been purged/cleaned up from storage.
+    STATE_PURGED = 3;
   }
 
   // State is the current state of the debuginfo upload.

--- a/ui/packages/shared/client/src/parca/debuginfo/v1alpha1/debuginfo.ts
+++ b/ui/packages/shared/client/src/parca/debuginfo/v1alpha1/debuginfo.ts
@@ -423,7 +423,13 @@ export enum DebuginfoUpload_State {
      *
      * @generated from protobuf enum value: STATE_UPLOADED = 2;
      */
-    UPLOADED = 2
+    UPLOADED = 2,
+    /**
+     * The debuginfo has been purged/cleaned up from storage.
+     *
+     * @generated from protobuf enum value: STATE_PURGED = 3;
+     */
+    PURGED = 3
 }
 /**
  * DebuginfoQuality is the quality of the debuginfo.


### PR DESCRIPTION
This commit introduces a new STATE_PURGED state to track debuginfo that has been cleaned up from storage. This allows the system to:

1. Signal to users that debuginfo existed but was purged/cleaned up
2. Allow re-uploading of purged debuginfo
3. Prevent symbolization attempts with purged debuginfo

Changes:
- Add STATE_PURGED enum value to proto definition
- Update generated Go and TypeScript code
- Add MarkAsPurged method to ObjectStoreMetadata
- Handle purged state in ShouldInitiateUpload (allows re-upload)
- Handle purged state in symbolizer (returns ErrDebuginfoPurged)
- Add ErrDebuginfoPurged error definition