### PR TITLE
Fixes copy failure when accessing Parca UI via IP address

### DIFF
--- a/ui/packages/shared/profile/src/ProfileFlameGraph/FlameGraphArrow/ContextMenu.tsx
+++ b/ui/packages/shared/profile/src/ProfileFlameGraph/FlameGraphArrow/ContextMenu.tsx
@@ -136,7 +136,11 @@ const ContextMenu = ({
     }
 
     if (!successful) {
-      alert('Copy failed. Please copy manually: ' + text.substring(0, 100) + (text.length > 100 ? '...' : ''));
+      alert(
+        'Copy failed. Please copy manually: ' +
+          text.substring(0, 100) +
+          (text.length > 100 ? '...' : '')
+      );
     }
   };
 


### PR DESCRIPTION
Copying failed when accessing the UI using an IP address.

<img width="1980" height="750" alt="image" src="https://github.com/user-attachments/assets/8a1a85e6-85b5-42ef-ba28-d8a83688956c" />

