### PR TITLE
Query parser: Allow hyphen in profile type

### DIFF
--- a/ui/packages/shared/parser/package.json
+++ b/ui/packages/shared/parser/package.json
@@ -4,7 +4,7 @@
   "description": "JavaScript parser implementation for the continuous profiling language",
   "main": "dist/index.js",
   "scripts": {
-    "test": "jest --coverage --config ../../../jest.config.cjs ./src/*",
+    "test": "vitest run",
     "gen": "nearleyc -g -o ./src/selector.js ./src/selector.ne",
     "watch": "tsc-watch",
     "build": "tsc"

--- a/ui/packages/shared/parser/src/index.test.ts
+++ b/ui/packages/shared/parser/src/index.test.ts
@@ -49,6 +49,12 @@ test('Query.toString With Comma', () => {
   );
 });
 
+test('Query.toString With hyphen', () => {
+  expect(Query.parse('query-memory:inuse_space:bytes:space:bytes{}').toString()).toBe(
+    'query-memory:inuse_space:bytes:space:bytes{}'
+  );
+});
+
 test('Partial Parsing ProfileName and rest', () => {
   [
     {

--- a/ui/packages/shared/parser/src/selector.js
+++ b/ui/packages/shared/parser/src/selector.js
@@ -20,7 +20,7 @@ export let grammar;
     main: {
       strstart: {match: '"', push: 'lit'},
       space: {match: /\s+/, lineBreaks: true},
-      ident: /(?:[a-zA-Z_:][a-zA-Z0-9_:.]*)/,
+      ident: /(?:[a-zA-Z_:][a-zA-Z0-9_:\-.]*)/,
       matcherType: ['=', '!=', '=~', '!~'],
       '{': '{',
       '}': '}',

--- a/ui/packages/shared/parser/src/selector.ne
+++ b/ui/packages/shared/parser/src/selector.ne
@@ -6,7 +6,7 @@ let lexer = moo.states({
   main: {
     strstart: {match: '"', push: 'lit'},
     space: {match: /\s+/, lineBreaks: true},
-    ident: /(?:[a-zA-Z_:][a-zA-Z0-9_:.]*)/,
+    ident: /(?:[a-zA-Z_:][a-zA-Z0-9_:\-.]*)/,
     matcherType: ['=', '!=', '=~', '!~'],
     '{': '{',
     '}': '}',

--- a/ui/packages/shared/parser/test-setup.ts
+++ b/ui/packages/shared/parser/test-setup.ts
@@ -1,0 +1,14 @@
+// Copyright 2022 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import '@testing-library/jest-dom';


### PR DESCRIPTION
Allow profile types like: `query-memory:inuse_space:bytes:space:bytes{}` 