### PR TITLE
ui: Add group_by param to default explorer values

### DIFF
--- a/ui/packages/shared/profile/src/index.tsx
+++ b/ui/packages/shared/profile/src/index.tsx
@@ -52,6 +52,9 @@ export const DEFAULT_PROFILE_EXPLORER_PARAM_VALUES: ParamPreferences = {
     defaultValue: 'flamegraph',
     splitOnCommas: true, // This param should split on commas for array values
   },
+  group_by: {
+    splitOnCommas: true,
+  },
 };
 
 export {


### PR DESCRIPTION
This ensures that when the flame graph is grouped by custom labels and there's a page reload, we no longer get the error below. 

<img width="1537" height="308" alt="image" src="https://github.com/user-attachments/assets/3aeadc6e-a6c1-48d8-a8bb-2dcf1b84d333" />

The change simply ensures that the `group_by` param is treated as an array and not a string.