### PR TITLE
Fix: Add URL encoding for starts_with and not_starts_with filters

### DIFF
--- a/ui/packages/shared/profile/src/ProfileView/components/ProfileFilters/useProfileFiltersUrlState.ts
+++ b/ui/packages/shared/profile/src/ProfileView/components/ProfileFilters/useProfileFiltersUrlState.ts
@@ -39,6 +39,8 @@ const MATCH_MAP: Record<string, string> = {
   not_equal: '!=',
   contains: '~',
   not_contains: '!~',
+  starts_with: '^',
+  not_starts_with: '!^',
 };
 
 // Reverse mappings for decoding


### PR DESCRIPTION
The MATCH_MAP was missing entries for the new filter types, causing 'undefined' to appear in the URL when these filters were applied.

Added mappings:
- starts_with: '^' (regex-style start anchor)
- not_starts_with: '!^' (negated start anchor)