### PR TITLE
Add filter preset for Rust futures infrastructure

### DIFF
--- a/ui/packages/shared/profile/src/ProfileView/components/ProfileFilters/filterPresets.ts
+++ b/ui/packages/shared/profile/src/ProfileView/components/ProfileFilters/filterPresets.ts
@@ -194,6 +194,37 @@ export const filterPresets: FilterPreset[] = [
     ],
   },
   {
+    key: 'hide_rust_futures',
+    name: 'Hide Rust Futures Infrastructure',
+    description: 'Excludes Rust futures infrastructure frames from the profile',
+    filters: [
+      {
+        type: 'frame',
+        field: 'function_name',
+        matchType: 'not_starts_with',
+        value: 'future',
+      },
+      {
+        type: 'frame',
+        field: 'function_name',
+        matchType: 'not_starts_with',
+        value: '<future',
+      },
+      {
+        type: 'frame',
+        field: 'function_name',
+        matchType: 'not_contains',
+        value: 'futures_core',
+      },
+      {
+        type: 'frame',
+        field: 'function_name',
+        matchType: 'not_contains',
+        value: 'core::future::future::Future',
+      },
+    ],
+  },
+  {
     key: 'hide_rust_panic_backtrace',
     name: 'Hide Rust Panic Backtrace Infrastructure',
     description: 'Excludes Rust panic and backtrace infrastructure frames from the profile',


### PR DESCRIPTION
Adds a new filter preset to hide Rust futures infrastructure frames from profiling views. The preset filters out:
- Functions starting with "future"
- Functions starting with "<future"
- Functions containing "futures_core"
- Functions containing "core::future::future::Future"

This helps reduce noise in profiles by hiding low-level futures implementation details.