### PR TITLE
ui: Hide context menu after sandwich action

### DIFF
--- a/ui/packages/shared/profile/src/ProfileFlameGraph/FlameGraphArrow/ContextMenu.tsx
+++ b/ui/packages/shared/profile/src/ProfileFlameGraph/FlameGraphArrow/ContextMenu.tsx
@@ -194,11 +194,13 @@ const ContextMenu = ({
 
             if (dashboardItems.includes('sandwich')) {
               setSandwichFunctionName(functionName);
+              hideMenu();
               return;
             }
 
             setSandwichFunctionName(functionName);
             setDashboardItems([...dashboardItems, 'sandwich']);
+            hideMenu();
           }}
           disabled={functionName === '' || functionName == null}
         >


### PR DESCRIPTION
Added calls to hideMenu() after setting the sandwich function name, ensuring the context menu closes immediately when the sandwich action is triggered.