### PR TITLE
ui: Removed the token based publishing in the favour of OIDC trusted publishing

### DIFF
--- a/.github/workflows/ui-publish-components.yml
+++ b/.github/workflows/ui-publish-components.yml
@@ -67,13 +67,6 @@ jobs:
           cache: 'pnpm'
           cache-dependency-path: ui/pnpm-lock.yaml
 
-      - name: Ensure access
-        working-directory: ui
-        run: |
-          npm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"
-        env:
-          NPM_TOKEN: ${{ secrets.NPMTOKEN }}
-
       - name: Config git user
         run: |
           git config --global user.name "${{ github.actor }}"

--- a/ui/packages/shared/client/README.md
+++ b/ui/packages/shared/client/README.md
@@ -1,1 +1,1 @@
-# Parca API Client
+## Parca API Client

--- a/ui/packages/shared/components/README.md
+++ b/ui/packages/shared/components/README.md
@@ -1,3 +1,3 @@
-## Parca Component Library
+# Parca Component Library
 
 A package with all react components that are used in Parca.

--- a/ui/packages/shared/dynamicsize/README.md
+++ b/ui/packages/shared/dynamicsize/README.md
@@ -1,3 +1,3 @@
-# Dynamically resize Parca components
+## Dynamically resize Parca components
 
 Library all around dynamically sizing components.

--- a/ui/packages/shared/hooks/README.md
+++ b/ui/packages/shared/hooks/README.md
@@ -1,3 +1,3 @@
-# Parca Hooks
+## Parca Hooks
 
 A library containing React hooks used in the Parca UI

--- a/ui/packages/shared/icons/README.md
+++ b/ui/packages/shared/icons/README.md
@@ -1,3 +1,3 @@
-# Parca Icons
+## Parca Icons
 
 These are some of the commonly used icons in the Parca project.

--- a/ui/packages/shared/parser/README.md
+++ b/ui/packages/shared/parser/README.md
@@ -1,1 +1,1 @@
-# JS Parser for continuous profiling language
+## JS Parser for continuous profiling language

--- a/ui/packages/shared/profile/README.md
+++ b/ui/packages/shared/profile/README.md
@@ -1,1 +1,1 @@
-# Parca Profile Libraries
+## Parca Profile Libraries

--- a/ui/packages/shared/store/README.md
+++ b/ui/packages/shared/store/README.md
@@ -1,3 +1,3 @@
-# Parca Store
+## Parca Store
 
 State management for the Parca UI

--- a/ui/packages/shared/utilities/README.md
+++ b/ui/packages/shared/utilities/README.md
@@ -1,1 +1,1 @@
-# Parca Shared Functions
+## Parca Shared Functions


### PR DESCRIPTION
This change removes the token based npm publishing and I have configured the GitHub actions as a trusted oidc publisher on npmjs.com for these packages. 