### PR TITLE
Optimize string matching

### DIFF
--- a/pkg/query/string_match_bench_test.go
+++ b/pkg/query/string_match_bench_test.go
@@ -19,7 +19,6 @@ import (
 	pb "github.com/parca-dev/parca/gen/proto/go/parca/query/v1alpha1"
 )
 
-// Benchmark comparing old bytes.ToLower approach vs new zero-allocation approach
 func BenchmarkStringMatching(b *testing.B) {
 	testValue := []byte("runtime.goexit")
 	testTarget := []byte("goexit")


### PR DESCRIPTION
Improves performance by ~4x or more.

```
$ benchstat old.txt new.txt
goos: darwin
goarch: arm64
pkg: github.com/parca-dev/parca/pkg/query
cpu: Apple M1 Max
                                               │   old.txt    │               new.txt                │
                                               │    sec/op    │    sec/op     vs base                │
StringMatching/equalFoldBytes-10                 58.745n ± 1%   2.923n ±  7%  -95.02% (p=0.000 n=10)
StringMatching/containsFoldBytes-10               69.07n ± 7%   18.68n ±  3%  -72.95% (p=0.000 n=10)
StringMatching/hasPrefixFoldBytes-10              62.72n ± 2%   10.06n ± 13%  -83.96% (p=0.000 n=10)
StringMatchingLongStrings/containsFoldBytes-10   203.30n ± 2%   55.16n ±  2%  -72.87% (p=0.000 n=10)
geomean                                           84.81n        13.19n        -84.44%
```