### PR TITLE
Fix cumulative value calculation for recursive functions in Table view

### DIFF
--- a/pkg/query/table.go
+++ b/pkg/query/table.go
@@ -135,6 +135,10 @@ func generateTableArrowRecord(
 
 		for sampleRow := 0; sampleRow < int(r.Record.NumRows()); sampleRow++ {
 			previousTableRow := -1
+			// Track which table rows have been counted for this sample to avoid
+			// double-counting cumulative values for recursive functions.
+			seenInSample := make(map[int]struct{})
+
 			lOffsetStart, lOffsetEnd := r.Locations.ValueOffsets(sampleRow)
 			for locationRow := int(lOffsetStart); locationRow < int(lOffsetEnd); locationRow++ {
 				if r.Locations.ListValues().IsNull(locationRow) {
@@ -164,10 +168,17 @@ func generateTableArrowRecord(
 						} else {
 							tb.addresses[string(buildID)][addr] = tableRow
 						}
+						seenInSample[tableRow] = struct{}{}
 						previousTableRow = tableRow
 						tableRow++
 					} else {
-						tb.mergeRow(r, cr, sampleRow, locationRow, -1, tb.addresses[unsafeString(buildID)][addr], previousTableRow, isLeaf)
+						// Only add to cumulative if this is the first occurrence in this sample
+						_, alreadySeen := seenInSample[cr]
+						addCumulative := !alreadySeen
+						if addCumulative {
+							seenInSample[cr] = struct{}{}
+						}
+						tb.mergeRow(r, cr, sampleRow, locationRow, -1, tb.addresses[unsafeString(buildID)][addr], previousTableRow, isLeaf, addCumulative)
 						previousTableRow = tb.addresses[unsafeString(buildID)][addr]
 					}
 				} else {
@@ -184,10 +195,17 @@ func generateTableArrowRecord(
 									return nil, 0, err
 								}
 								tb.functions[string(fn)] = tableRow
+								seenInSample[tableRow] = struct{}{}
 								previousTableRow = tableRow
 								tableRow++
 							} else {
-								tb.mergeRow(r, cr, sampleRow, locationRow, lineRow, tb.functions[unsafeString(fn)], previousTableRow, isLeaf)
+								// Only add to cumulative if this is the first occurrence in this sample
+								_, alreadySeen := seenInSample[cr]
+								addCumulative := !alreadySeen
+								if addCumulative {
+									seenInSample[cr] = struct{}{}
+								}
+								tb.mergeRow(r, cr, sampleRow, locationRow, lineRow, tb.functions[unsafeString(fn)], previousTableRow, isLeaf, addCumulative)
 								previousTableRow = tb.functions[unsafeString(fn)]
 							}
 						}
@@ -432,10 +450,15 @@ func (tb *tableBuilder) appendRow(
 	return nil
 }
 
-func (tb *tableBuilder) mergeRow(r *profile.RecordReader, mergeRow, sampleRow, _, lineRow, currentTableRow, previousTableRow int, isLeaf bool) {
-	tb.builderCumulative.Add(mergeRow, r.Value.Value(sampleRow))
-	if r.Diff.Value(sampleRow) != 0 {
-		tb.builderCumulativeDiff.Add(mergeRow, r.Diff.Value(sampleRow))
+// mergeRow merges sample data into an existing table row.
+// If addCumulative is false, only caller/callee relationships and flat values (if leaf) are updated.
+// This is used to avoid double-counting cumulative values for recursive functions.
+func (tb *tableBuilder) mergeRow(r *profile.RecordReader, mergeRow, sampleRow, _, lineRow, currentTableRow, previousTableRow int, isLeaf, addCumulative bool) {
+	if addCumulative {
+		tb.builderCumulative.Add(mergeRow, r.Value.Value(sampleRow))
+		if r.Diff.Value(sampleRow) != 0 {
+			tb.builderCumulativeDiff.Add(mergeRow, r.Diff.Value(sampleRow))
+		}
 	}
 
 	if isLeaf {


### PR DESCRIPTION
## Problem

In the Table view, recursive functions (functions that appear multiple times in the same call stack) may display Cumulative (%) values greater than 100%. For example (tested with parca 0.25.0):

<img width="1580" height="246" alt="image" src="https://github.com/user-attachments/assets/429cdcd8-8285-45cc-aeb2-ad8aeb6ca9b3" />

## Root Cause

When building the table, the code iterates through each frame in a stacktrace and adds the sample value to that function's cumulative. When a function appears multiple times in the same stacktrace (due to recursion), its cumulative value gets counted multiple times.

Example:

```
Stacktrace: [A → B → A → D], value = 50

Before fix:
  Frame A: cumulative += 50  → 50
  Frame B: cumulative += 50  → 50
  Frame A: cumulative += 50  → 100  // Counted twice!
  Frame D: cumulative += 50  → 50

Function A Cumulative (%) = 100/50 = 200%  // Exceeds 100%
```

## Solution

Track which table rows have been counted for each sample using a `seenInSample` map. Only add to cumulative for the first occurrence of a function in each sample, while still maintaining caller/callee relationships for all occurrences.

```
After fix:
  Frame A: first seen, +50     → cumulative = 50
  Frame B: first seen, +50     → cumulative = 50
  Frame A: already seen, SKIP  → cumulative = 50 (unchanged)
  Frame D: first seen, +50     → cumulative = 50

Function A Cumulative (%) = 50/50 = 100% 
```
