### PR TITLE
Add "not starts with libcublas" frame filter

### DIFF
--- a/ui/packages/shared/profile/src/ProfileView/components/ProfileFilters/filterPresets.ts
+++ b/ui/packages/shared/profile/src/ProfileView/components/ProfileFilters/filterPresets.ts
@@ -134,6 +134,12 @@ export const filterPresets: FilterPreset[] = [
         matchType: 'not_contains',
         value: 'libparcagpucupti.so',
       },
+      {
+        type: 'frame',
+        field: 'binary',
+        matchType: 'not_starts_with',
+        value: 'libcublas',
+      },
     ],
   },
   {


### PR DESCRIPTION
Add a "not starts with libcublas" frame filter to the hide_cuda_internals preset to exclude CUDA BLAS library frames from profiles.