### PR TITLE
chore: Update copyright year to 2026

### DIFF
--- a/cmd/parca/main.go
+++ b/cmd/parca/main.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/env-jsonnet.sh
+++ b/env-jsonnet.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2023-2025 The Parca Authors
+# Copyright 2023-2026 The Parca Authors
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/env-local-test.sh
+++ b/env-local-test.sh
@@ -1,5 +1,5 @@
 #! /usr/bin/env bash
-# Copyright 2023-2025 The Parca Authors
+# Copyright 2023-2026 The Parca Authors
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/env-proto.sh
+++ b/env-proto.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2023-2025 The Parca Authors
+# Copyright 2023-2026 The Parca Authors
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/env.sh
+++ b/env.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2023-2025 The Parca Authors
+# Copyright 2023-2026 The Parca Authors
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/gen/proto/go/parca/query/v1alpha1/validate.go
+++ b/gen/proto/go/parca/query/v1alpha1/validate.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/badgerlogger/badgerlogger.go
+++ b/pkg/badgerlogger/badgerlogger.go
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 The Parca Authors
+// Copyright 2024-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 The Parca Authors
+// Copyright 2023-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 The Parca Authors
+// Copyright 2023-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/cache/cache_with_eviction.go
+++ b/pkg/cache/cache_with_eviction.go
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 The Parca Authors
+// Copyright 2023-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/cache/cache_with_ttl.go
+++ b/pkg/cache/cache_with_ttl.go
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 The Parca Authors
+// Copyright 2023-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/cache/loading.go
+++ b/pkg/cache/loading.go
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 The Parca Authors
+// Copyright 2023-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/cache/loading_test.go
+++ b/pkg/cache/loading_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 The Parca Authors
+// Copyright 2023-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/cache/lru/lru.go
+++ b/pkg/cache/lru/lru.go
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 The Parca Authors
+// Copyright 2023-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/cache/lru/lru_test.go
+++ b/pkg/cache/lru/lru_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 The Parca Authors
+// Copyright 2023-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/cache/lru/lru_with_eviction_test.go
+++ b/pkg/cache/lru/lru_with_eviction_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 The Parca Authors
+// Copyright 2023-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/cache/lru/metrics.go
+++ b/pkg/cache/lru/metrics.go
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 The Parca Authors
+// Copyright 2023-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/cache/lru/options.go
+++ b/pkg/cache/lru/options.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/cache/noop.go
+++ b/pkg/cache/noop.go
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 The Parca Authors
+// Copyright 2023-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/compactdictionary/compactdictionary.go
+++ b/pkg/compactdictionary/compactdictionary.go
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 The Parca Authors
+// Copyright 2024-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/config/reloader.go
+++ b/pkg/config/reloader.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/config/reloader_test.go
+++ b/pkg/config/reloader_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/config/secret.go
+++ b/pkg/config/secret.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/debuginfo/client.go
+++ b/pkg/debuginfo/client.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/debuginfo/debuginfod.go
+++ b/pkg/debuginfo/debuginfod.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/debuginfo/debuginfod_test.go
+++ b/pkg/debuginfo/debuginfod_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/debuginfo/fetcher.go
+++ b/pkg/debuginfo/fetcher.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/debuginfo/forwarder.go
+++ b/pkg/debuginfo/forwarder.go
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 The Parca Authors
+// Copyright 2024-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/debuginfo/metadata.go
+++ b/pkg/debuginfo/metadata.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/debuginfo/metadata_test.go
+++ b/pkg/debuginfo/metadata_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/debuginfo/reader.go
+++ b/pkg/debuginfo/reader.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/debuginfo/store.go
+++ b/pkg/debuginfo/store.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/debuginfo/store_test.go
+++ b/pkg/debuginfo/store_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/demangle/demangle.go
+++ b/pkg/demangle/demangle.go
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 The Parca Authors
+// Copyright 2024-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/demangle/rust_test.go
+++ b/pkg/demangle/rust_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 The Parca Authors
+// Copyright 2024-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/hash/hash.go
+++ b/pkg/hash/hash.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 The Parca Authors
+// Copyright 2023-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/kv/keymaker.go
+++ b/pkg/kv/keymaker.go
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 The Parca Authors
+// Copyright 2024-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/normalizer/arrow.go
+++ b/pkg/normalizer/arrow.go
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 The Parca Authors
+// Copyright 2024-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/normalizer/normalizer.go
+++ b/pkg/normalizer/normalizer.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/normalizer/normalizer_test.go
+++ b/pkg/normalizer/normalizer_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 The Parca Authors
+// Copyright 2024-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/normalizer/otel.go
+++ b/pkg/normalizer/otel.go
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 The Parca Authors
+// Copyright 2024-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/normalizer/validate.go
+++ b/pkg/normalizer/validate.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/parca/logger.go
+++ b/pkg/parca/logger.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/parca/parca.go
+++ b/pkg/parca/parca.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/parca/parca_test.go
+++ b/pkg/parca/parca_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/parca/testdata/pgotest.go
+++ b/pkg/parca/testdata/pgotest.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/parcacol/arrow.go
+++ b/pkg/parcacol/arrow.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/parcacol/arrow_test.go
+++ b/pkg/parcacol/arrow_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 The Parca Authors
+// Copyright 2023-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/parcacol/querier.go
+++ b/pkg/parcacol/querier.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/profile/decode.go
+++ b/pkg/profile/decode.go
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 The Parca Authors
+// Copyright 2024-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/profile/encode.go
+++ b/pkg/profile/encode.go
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 The Parca Authors
+// Copyright 2024-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/profile/encode_test.go
+++ b/pkg/profile/encode_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 The Parca Authors
+// Copyright 2024-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/profile/executableinfo.go
+++ b/pkg/profile/executableinfo.go
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 The Parca Authors
+// Copyright 2024-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/profile/reader.go
+++ b/pkg/profile/reader.go
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 The Parca Authors
+// Copyright 2023-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/profile/schema.go
+++ b/pkg/profile/schema.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/profile/uvarint.go
+++ b/pkg/profile/uvarint.go
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 The Parca Authors
+// Copyright 2024-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/profile/writer.go
+++ b/pkg/profile/writer.go
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 The Parca Authors
+// Copyright 2024-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/profilestore/grpc.go
+++ b/pkg/profilestore/grpc.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/profilestore/profilecolumnstore.go
+++ b/pkg/profilestore/profilecolumnstore.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/profilestore/profilestore_test.go
+++ b/pkg/profilestore/profilestore_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/query/callgraph.go
+++ b/pkg/query/callgraph.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/query/callgraph_test.go
+++ b/pkg/query/callgraph_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/query/columnquery.go
+++ b/pkg/query/columnquery.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/query/columnquery_test.go
+++ b/pkg/query/columnquery_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/query/flamegraph.go
+++ b/pkg/query/flamegraph.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/query/flamegraph_arrow.go
+++ b/pkg/query/flamegraph_arrow.go
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 The Parca Authors
+// Copyright 2023-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/query/flamegraph_arrow_test.go
+++ b/pkg/query/flamegraph_arrow_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 The Parca Authors
+// Copyright 2023-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/query/flamegraph_flat.go
+++ b/pkg/query/flamegraph_flat.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/query/flamegraph_flat_test.go
+++ b/pkg/query/flamegraph_flat_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/query/flamegraph_table.go
+++ b/pkg/query/flamegraph_table.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/query/flamegraph_table_test.go
+++ b/pkg/query/flamegraph_table_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/query/multiple_filters_test.go
+++ b/pkg/query/multiple_filters_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/query/pprof.go
+++ b/pkg/query/pprof.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/query/pprof_test.go
+++ b/pkg/query/pprof_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/query/query_test.go
+++ b/pkg/query/query_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/query/sources.go
+++ b/pkg/query/sources.go
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 The Parca Authors
+// Copyright 2023-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/query/sources_reader.go
+++ b/pkg/query/sources_reader.go
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 The Parca Authors
+// Copyright 2023-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/query/sources_reader_test.go
+++ b/pkg/query/sources_reader_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 The Parca Authors
+// Copyright 2023-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/query/sources_test.go
+++ b/pkg/query/sources_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 The Parca Authors
+// Copyright 2023-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/query/string_match_bench_test.go
+++ b/pkg/query/string_match_bench_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/query/table.go
+++ b/pkg/query/table.go
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 The Parca Authors
+// Copyright 2023-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/query/table_test.go
+++ b/pkg/query/table_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 The Parca Authors
+// Copyright 2023-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/query/top.go
+++ b/pkg/query/top.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/query/top_test.go
+++ b/pkg/query/top_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/runutil/runutil.go
+++ b/pkg/runutil/runutil.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/scrape/manager.go
+++ b/pkg/scrape/manager.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/scrape/scrape.go
+++ b/pkg/scrape/scrape.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/scrape/scrape_test.go
+++ b/pkg/scrape/scrape_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 The Parca Authors
+// Copyright 2023-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/scrape/service.go
+++ b/pkg/scrape/service.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/scrape/target.go
+++ b/pkg/scrape/target.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/scrape/target_test.go
+++ b/pkg/scrape/target_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 The Parca Authors
+// Copyright 2024-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/server/fallback.go
+++ b/pkg/server/fallback.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/server/grpc_codec.go
+++ b/pkg/server/grpc_codec.go
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 The Parca Authors
+// Copyright 2023-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/signedrequests/client.go
+++ b/pkg/signedrequests/client.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/signedrequests/gcs.go
+++ b/pkg/signedrequests/gcs.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/signedrequests/s3.go
+++ b/pkg/signedrequests/s3.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/symbol/addr2line/doc.go
+++ b/pkg/symbol/addr2line/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/symbol/addr2line/dwarf.go
+++ b/pkg/symbol/addr2line/dwarf.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/symbol/addr2line/dwarf_test.go
+++ b/pkg/symbol/addr2line/dwarf_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/symbol/addr2line/go.go
+++ b/pkg/symbol/addr2line/go.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/symbol/addr2line/symtab.go
+++ b/pkg/symbol/addr2line/symtab.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/symbol/addr2line/symtab_test.go
+++ b/pkg/symbol/addr2line/symtab_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/symbol/demangle/demangle.go
+++ b/pkg/symbol/demangle/demangle.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/symbol/demangle/demangle_test.go
+++ b/pkg/symbol/demangle/demangle_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/symbol/elfutils/debuginfofile.go
+++ b/pkg/symbol/elfutils/debuginfofile.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/symbol/elfutils/elfutils.go
+++ b/pkg/symbol/elfutils/elfutils.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/symbol/elfutils/elfutils_test.go
+++ b/pkg/symbol/elfutils/elfutils_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/symbol/elfutils/testdata/main.go
+++ b/pkg/symbol/elfutils/testdata/main.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/symbol/symbolsearcher/symbol_searcher.go
+++ b/pkg/symbol/symbolsearcher/symbol_searcher.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/symbolizer/cache.go
+++ b/pkg/symbolizer/cache.go
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 The Parca Authors
+// Copyright 2024-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/symbolizer/decode.go
+++ b/pkg/symbolizer/decode.go
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 The Parca Authors
+// Copyright 2024-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/symbolizer/encode.go
+++ b/pkg/symbolizer/encode.go
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 The Parca Authors
+// Copyright 2024-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/symbolizer/encode_test.go
+++ b/pkg/symbolizer/encode_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 The Parca Authors
+// Copyright 2024-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/symbolizer/normalize.go
+++ b/pkg/symbolizer/normalize.go
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 The Parca Authors
+// Copyright 2024-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/symbolizer/symbolizer.go
+++ b/pkg/symbolizer/symbolizer.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/symbolizer/symbolizer_test.go
+++ b/pkg/symbolizer/symbolizer_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/tracer/tracer.go
+++ b/pkg/tracer/tracer.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/scripts/check-license.sh
+++ b/scripts/check-license.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2022-2025 The Parca Authors
+# Copyright 2022-2026 The Parca Authors
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/scripts/free_disk_space.sh
+++ b/scripts/free_disk_space.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2024-2025 The Parca Authors
+# Copyright 2024-2026 The Parca Authors
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/scripts/install-minikube.sh
+++ b/scripts/install-minikube.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2022-2025 The Parca Authors
+# Copyright 2022-2026 The Parca Authors
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/scripts/local-dev.sh
+++ b/scripts/local-dev.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2022-2025 The Parca Authors
+# Copyright 2022-2026 The Parca Authors
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2022-2025 The Parca Authors
+# Copyright 2022-2026 The Parca Authors
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/snap/parca-wrapper
+++ b/snap/parca-wrapper
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2022-2025 The Parca Authors
+# Copyright 2022-2026 The Parca Authors
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/ui/packages/app/web/build/keep.go
+++ b/ui/packages/app/web/build/keep.go
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 The Parca Authors
+// Copyright 2023-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/ui/packages/app/web/public/keep.go
+++ b/ui/packages/app/web/public/keep.go
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 The Parca Authors
+// Copyright 2023-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/ui/packages/app/web/scripts/build-preview.sh
+++ b/ui/packages/app/web/scripts/build-preview.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2022-2025 The Parca Authors
+# Copyright 2022-2026 The Parca Authors
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The Parca Authors
+// Copyright 2022-2026 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at


### PR DESCRIPTION
- Automatically update all license headers to reflect the current year (2025 → 2026)

Ran the `pre-commit run insert-license --all-files` command locally.