### PR TITLE
ui: Flachette eliminating array copy during the table parsing

### DIFF
--- a/pkg/query/arrow_alignment.go
+++ b/pkg/query/arrow_alignment.go
@@ -1,0 +1,113 @@
+// Copyright 2024 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package query
+
+// Arrow IPC Alignment
+//
+// This file provides utilities to add padding to Arrow IPC bytes for 8-byte alignment.
+// This is required because Arrow's BigInt64Array/BigUint64Array require 8-byte aligned memory,
+// but protobuf's bytes field may have arbitrary alignment when deserialized.
+//
+// Padded format: [1 byte: padding length] [0-7 padding bytes] [Arrow IPC data]
+//
+// The client extracts the Arrow data by reading the first byte to get the padding length,
+// then using subarray(1 + padLen) to get the aligned Arrow IPC data.
+
+// GetAlignedFlamegraphArrowBytes returns padded Arrow IPC bytes for FlamegraphArrow.
+func GetAlignedFlamegraphArrowBytes(arrowBytes []byte, total, trimmed int64, unit string, height int32) []byte {
+	recordSize := len(arrowBytes)
+
+	// Calculate FlamegraphArrow message size (record + unit + height + trimmed)
+	innerMsgSize := 1 + varintSize(uint64(recordSize)) + recordSize // record field
+	innerMsgSize += 1 + varintSize(uint64(len(unit))) + len(unit)   // unit field
+	if height != 0 {
+		innerMsgSize += 1 + varintSize(uint64(height)) // height field
+	}
+	if trimmed != 0 {
+		innerMsgSize += 1 + varintSize(uint64(trimmed)) // trimmed field
+	}
+
+	offset := 5 // gRPC-web frame header
+	if total != 0 {
+		offset += 1 + varintSize(uint64(total)) // QueryResponse.total
+	}
+	offset += 1                                // oneof field tag
+	offset += varintSize(uint64(innerMsgSize)) // FlamegraphArrow message length
+	offset += 1                                // record field tag
+	offset += varintSize(uint64(recordSize))   // record length
+
+	return padForAlignment(arrowBytes, offset)
+}
+
+// GetAlignedTableArrowBytes returns padded Arrow IPC bytes for TableArrow.
+func GetAlignedTableArrowBytes(arrowBytes []byte, total int64, unit string) []byte {
+	recordSize := len(arrowBytes)
+
+	// Calculate TableArrow message size (record + unit)
+	innerMsgSize := 1 + varintSize(uint64(recordSize)) + recordSize // record field
+	innerMsgSize += 1 + varintSize(uint64(len(unit))) + len(unit)   // unit field
+
+	offset := 5 // gRPC-web frame header
+	if total != 0 {
+		offset += 1 + varintSize(uint64(total)) // QueryResponse.total
+	}
+	offset += 1                                // oneof field tag
+	offset += varintSize(uint64(innerMsgSize)) // TableArrow message length
+	offset += 1                                // record field tag
+	offset += varintSize(uint64(recordSize))   // record length
+
+	return padForAlignment(arrowBytes, offset)
+}
+
+// GetAlignedSourceArrowBytes returns padded Arrow IPC bytes for Source.
+func GetAlignedSourceArrowBytes(arrowBytes []byte, total int64, source, unit string) []byte {
+	recordSize := len(arrowBytes)
+
+	// Calculate Source message size (record + source + unit)
+	innerMsgSize := 1 + varintSize(uint64(recordSize)) + recordSize   // record field
+	innerMsgSize += 1 + varintSize(uint64(len(source))) + len(source) // source field
+	innerMsgSize += 1 + varintSize(uint64(len(unit))) + len(unit)     // unit field
+
+	offset := 5 // gRPC-web frame header
+	if total != 0 {
+		offset += 1 + varintSize(uint64(total)) // QueryResponse.total
+	}
+	offset += 1                                // oneof field tag
+	offset += varintSize(uint64(innerMsgSize)) // Source message length
+	offset += 1                                // record field tag
+	offset += varintSize(uint64(recordSize))   // record length
+
+	return padForAlignment(arrowBytes, offset)
+}
+
+func padForAlignment(arrowBytes []byte, estimatedOffset int) []byte {
+	arrowDataOffset := estimatedOffset + 1 // +1 for the padding length byte
+	padLen := (8 - (arrowDataOffset % 8)) % 8
+
+	result := make([]byte, 1+padLen+len(arrowBytes))
+	result[0] = byte(padLen)
+	copy(result[1+padLen:], arrowBytes)
+
+	return result
+}
+
+// varintSize returns the number of bytes needed to encode v as a varint.
+func varintSize(v uint64) int {
+	size := 1
+	for v >= 0x80 {
+		v >>= 7
+		size++
+	}
+	return size
+}

--- a/pkg/query/flamegraph_arrow.go
+++ b/pkg/query/flamegraph_arrow.go
@@ -101,8 +101,11 @@ func GenerateFlamegraphArrow(
 		span.SetAttributes(attribute.String("record_stats", recordStats(record)))
 	}
 
+	// Add padding to ensure 8-byte alignment for Arrow IPC data in the client.
+	paddedRecord := GetAlignedFlamegraphArrowBytes(buf.Bytes(), cumulative, trimmed, p.Meta.SampleType.Unit, height)
+
 	return &queryv1alpha1.FlamegraphArrow{
-		Record:  buf.Bytes(),
+		Record:  paddedRecord,
 		Unit:    p.Meta.SampleType.Unit,
 		Height:  height, // add one for the root
 		Trimmed: trimmed,

--- a/pkg/query/sources.go
+++ b/pkg/query/sources.go
@@ -63,8 +63,11 @@ func GenerateSourceReport(
 		return nil, 0, err
 	}
 
+	// Add padding to ensure 8-byte alignment for Arrow IPC data in the client.
+	paddedRecord := GetAlignedSourceArrowBytes(buf.Bytes(), cumulative, source, p.Meta.SampleType.Unit)
+
 	return &pb.Source{
-		Record: buf.Bytes(),
+		Record: paddedRecord,
 		Source: source,
 		Unit:   p.Meta.SampleType.Unit,
 	}, cumulative, nil

--- a/pkg/query/table.go
+++ b/pkg/query/table.go
@@ -85,8 +85,11 @@ func GenerateTable(
 		span.SetAttributes(attribute.String("record_stats", recordStats(record)))
 	}
 
+	// Add padding to ensure 8-byte alignment for Arrow IPC data in the client.
+	paddedRecord := GetAlignedTableArrowBytes(buf.Bytes(), cumulative, p.Meta.SampleType.Unit)
+
 	return &queryv1alpha1.TableArrow{
-		Record: buf.Bytes(),
+		Record: paddedRecord,
 		Unit:   p.Meta.SampleType.Unit,
 	}, cumulative, nil
 }

--- a/ui/packages/shared/components/src/Table/index.tsx
+++ b/ui/packages/shared/components/src/Table/index.tsx
@@ -273,7 +273,7 @@ const Table = <T,>({
                         },
                       ]);
                     }}
-                    style={{width: header.getSize()}}
+                    style={{width: Number.isNaN(header.getSize()) ? 'auto' : header.getSize()}}
                   >
                     <span
                       className={cx('flex items-center gap-2', {

--- a/ui/packages/shared/profile/src/ProfileFlameGraph/FlameGraphArrow/index.tsx
+++ b/ui/packages/shared/profile/src/ProfileFlameGraph/FlameGraphArrow/index.tsx
@@ -34,6 +34,7 @@ import {type ColorConfig} from '@parca/utilities';
 import {ProfileSource} from '../../ProfileSource';
 import {useProfileFilters} from '../../ProfileView/components/ProfileFilters/useProfileFilters';
 import {useProfileViewContext} from '../../ProfileView/context/ProfileViewContext';
+import {extractArrowData} from '../../utils';
 import ContextMenuWrapper, {ContextMenuWrapperRef} from './ContextMenuWrapper';
 import {FlameNode, RowHeight, colorByColors} from './FlameGraphNodes';
 import {MemoizedTooltip} from './MemoizedTooltip';
@@ -154,10 +155,9 @@ export const FlameGraphArrow = memo(function FlameGraphArrow({
   const {perf} = useParcaContext();
 
   const table: Table = useMemo(() => {
-    // Copy to aligned buffer only if byteOffset is not 8-byte aligned (required for BigUint64Array)
-    const record = arrow.record;
-    const aligned = record.byteOffset % 8 === 0 ? record : new Uint8Array(record);
-    const result = tableFromIPC(aligned, {useBigInt: true});
+    // Extract Arrow data from padded record (server adds padding for 8-byte alignment)
+    const arrowData = extractArrowData(arrow.record);
+    const result = tableFromIPC(arrowData, {useBigInt: true});
 
     if (perf?.setMeasurement != null) {
       perf.setMeasurement('flamegraph.node_count', result.numRows);

--- a/ui/packages/shared/profile/src/ProfileView/hooks/useProfileMetadata.ts
+++ b/ui/packages/shared/profile/src/ProfileView/hooks/useProfileMetadata.ts
@@ -20,6 +20,7 @@ import {FlamegraphArrow} from '@parca/client';
 import useMappingList, {
   useFilenamesList,
 } from '../../ProfileFlameGraph/FlameGraphArrow/useMappingList';
+import {extractArrowData} from '../../utils';
 
 interface UseProfileMetadataProps {
   flamegraphArrow?: FlamegraphArrow;
@@ -44,10 +45,9 @@ export const useProfileMetadata = ({
     if (flamegraphArrow === undefined) {
       return null;
     }
-    // Copy to aligned buffer only if byteOffset is not 8-byte aligned (required for BigUint64Array)
-    const record = flamegraphArrow.record;
-    const aligned = record.byteOffset % 8 === 0 ? record : new Uint8Array(record);
-    return tableFromIPC(aligned, {useBigInt: true});
+    // Extract Arrow data from padded record (server adds padding for 8-byte alignment)
+    const arrowData = extractArrowData(flamegraphArrow.record);
+    return tableFromIPC(arrowData, {useBigInt: true});
   }, [flamegraphArrow]);
 
   const mappingsList = useMappingList(metadataMappingFiles);

--- a/ui/packages/shared/profile/src/Sandwich/components/CallersSection.tsx
+++ b/ui/packages/shared/profile/src/Sandwich/components/CallersSection.tsx
@@ -23,6 +23,7 @@ import ProfileFlameGraph from '../../ProfileFlameGraph';
 import {type CurrentPathFrame} from '../../ProfileFlameGraph/FlameGraphArrow/utils';
 import {type ProfileSource} from '../../ProfileSource';
 import {FlamegraphData} from '../../ProfileView/types/visualization';
+import {extractArrowData} from '../../utils';
 
 const FIELD_DEPTH = 'depth';
 
@@ -60,10 +61,9 @@ export function CallersSection({
 }: CallersSectionProps): JSX.Element {
   const maxDepth = useMemo(() => {
     if (callersFlamegraphData?.arrow != null) {
-      // Copy to aligned buffer only if byteOffset is not 8-byte aligned (required for BigUint64Array)
-      const record = callersFlamegraphData.arrow.record;
-      const aligned = record.byteOffset % 8 === 0 ? record : new Uint8Array(record);
-      const table = tableFromIPC(aligned, {useBigInt: true});
+      // Extract Arrow data from padded record (server adds padding for 8-byte alignment)
+      const arrowData = extractArrowData(callersFlamegraphData.arrow.record);
+      const table = tableFromIPC(arrowData, {useBigInt: true});
       const depthColumn = table.getChild(FIELD_DEPTH);
       return getMaxDepth(depthColumn);
     }

--- a/ui/packages/shared/profile/src/SourceView/index.tsx
+++ b/ui/packages/shared/profile/src/SourceView/index.tsx
@@ -21,7 +21,7 @@ import {Source} from '@parca/client';
 import {SourceSkeleton, useParcaContext, useURLState, type ProfileData} from '@parca/components';
 
 import {ExpandOnHover} from '../GraphTooltipArrow/ExpandOnHoverValue';
-import {truncateStringReverse} from '../utils';
+import {extractArrowData, truncateStringReverse} from '../utils';
 import {Highlighter, profileAwareRenderer, type LineDataLookup} from './Highlighter';
 import useLineRange from './useSelectedLineRange';
 
@@ -63,10 +63,9 @@ export const SourceView = React.memo(function SourceView({
     if (data === undefined) {
       return null;
     }
-    // Copy to aligned buffer only if byteOffset is not 8-byte aligned (required for BigUint64Array)
-    const record = data.record;
-    const aligned = record.byteOffset % 8 === 0 ? record : new Uint8Array(record);
-    const table = tableFromIPC(aligned, {useBigInt: true});
+    // Extract Arrow data from padded record (server adds padding for 8-byte alignment)
+    const arrowData = extractArrowData(data.record);
+    const table = tableFromIPC(arrowData, {useBigInt: true});
     return {
       numRows: table.numRows,
       lineNumbers: table.getChild('line_number'),

--- a/ui/packages/shared/profile/src/Table/index.tsx
+++ b/ui/packages/shared/profile/src/Table/index.tsx
@@ -31,6 +31,7 @@ import useMappingList, {
   useFilenamesList,
 } from '../ProfileFlameGraph/FlameGraphArrow/useMappingList';
 import {useProfileViewContext} from '../ProfileView/context/ProfileViewContext';
+import {extractArrowData} from '../utils';
 import TableContextMenuWrapper, {TableContextMenuWrapperRef} from './TableContextMenuWrapper';
 import {useColorManagement} from './hooks/useColorManagement';
 import {useTableConfiguration} from './hooks/useTableConfiguration';
@@ -94,9 +95,9 @@ export const Table = React.memo(function Table({
       return null;
     }
 
-    // Copy to aligned buffer only if byteOffset is not 8-byte aligned (required for BigUint64Array)
-    const aligned = data.byteOffset % 8 === 0 ? data : new Uint8Array(data);
-    return tableFromIPC(aligned, {useBigInt: true});
+    // Extract Arrow data from padded record (server adds padding for 8-byte alignment)
+    const arrowData = extractArrowData(data);
+    return tableFromIPC(arrowData, {useBigInt: true});
   }, [data, loading]);
 
   const mappingsList = useMappingList(metadataMappingFiles);

--- a/ui/packages/shared/profile/src/utils.ts
+++ b/ui/packages/shared/profile/src/utils.ts
@@ -63,3 +63,17 @@ export const truncateStringReverse = (str: string, num: number): string => {
 
 export type NumberDuo = [number, number];
 export type BigIntDuo = [bigint, bigint];
+
+/**
+ * Extracts Arrow IPC data from a padded record.
+ *
+ * The server adds padding to ensure 8-byte alignment for typed arrays.
+ * Format: [1 byte: pad length] [0-7 padding bytes] [Arrow IPC data]
+ *
+ * @param record - The padded record bytes from the server
+ * @returns The Arrow IPC data, properly aligned
+ */
+export const extractArrowData = (record: Uint8Array): Uint8Array => {
+  const padLen = record[0];
+  return record.subarray(1 + padLen);
+};


### PR DESCRIPTION
Adding padding to make sure the arrow buffer array byte offset falls in the multiples of 8 in the frontend parsing. This speeds up the table parsing to 1.3x compared to the apache-arrow lib. 

Stacked to #6176
