### PR TITLE
pkg/query: Fix nil panic in flamegraph table + top

### DIFF
--- a/pkg/query/flamegraph_table.go
+++ b/pkg/query/flamegraph_table.go
@@ -279,6 +279,9 @@ func (c *tableConverter) AddProfileLocation(l *profile.Location) uint32 {
 
 	lines := make([]*metastorev1alpha1.Line, 0, len(l.Lines))
 	for _, line := range l.Lines {
+		if line.Function == nil {
+			continue
+		}
 		lines = append(lines, &metastorev1alpha1.Line{
 			Line:          line.Line,
 			FunctionIndex: c.AddFunction(line.Function),

--- a/pkg/query/top.go
+++ b/pkg/query/top.go
@@ -52,7 +52,7 @@ func GenerateTopTable(ctx context.Context, p parcaprofile.OldProfile) (*pb.Top, 
 						},
 					},
 				}
-				if len(location.Lines) > 0 {
+				if len(location.Lines) > 0 && location.Lines[0].Function != nil {
 					// TODO: Return or merge multiple lines for samples
 					node.Meta.Function = location.Lines[0].Function
 					node.Meta.Line = &metastorev1alpha1.Line{


### PR DESCRIPTION
## Summary

`GenerateFlamegraphTable` (`flamegraph_table.go`) and `GenerateTopTable` (`top.go`) both assume that every `location.Lines[i].Function` is non-nil and panic with

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x477e7c6]

goroutine 551 [running]:
github.com/parca-dev/parca/pkg/query.(*tableConverter).AddFunction(0xc00024e680, 0x0)
    github.com/parca-dev/parca/pkg/query/flamegraph_table.go:312 +0x26
github.com/parca-dev/parca/pkg/query.(*tableConverter).AddProfileLocation(0xc00024e680, 0xc00a90dac0)
    github.com/parca-dev/parca/pkg/query/flamegraph_table.go:284 +0x12f
github.com/parca-dev/parca/pkg/query.GenerateFlamegraphTable(...)
    github.com/parca-dev/parca/pkg/query/flamegraph_table.go:53 +0x79d
...
```

when a caller passes in an unsymbolized line (Line with no Function reference), which crashes the whole server process.

The same class of bug existed in `pkg/query/flamegraph.go` and was fixed in https://github.com/parca-dev/parca/pull/3892 ("Fix nil panic when building flat flamegraph", https://github.com/parca-dev/parca/commit/dd07a1214a) by guarding with `if line.Function != nil`. The analogous call sites in `flamegraph_table.go` and `top.go` were missed by that patch and remain on `main` today.

## How to reproduce

I hit this running parca v0.27.1 as the backend for the OpenTelemetry eBPF profiler. Profiles arrive via OTLP; a subset of locations are unsymbolized (no uploaded debuginfo for that build-id yet, or no match in kallsyms), producing Line records with nil `Function`.

Any of these then crash parca-server:

```
REPORT_TYPE_FLAMEGRAPH_TABLE
REPORT_TYPE_TOP
```

`REPORT_TYPE_PPROF` and `REPORT_TYPE_FLAMEGRAPH_ARROW` go through different code paths and are unaffected.

## Verification

Built a patched image from this branch (based on the v0.27.1 tag), deployed to our cluster, re-ran the same queries that were crashing:

- `REPORT_TYPE_TOP` — returns 142 nodes, 127 with resolved function names, no crash.
- `REPORT_TYPE_FLAMEGRAPH_TABLE` — returns valid tree (~297 KB payload), parca UI renders the flame graph correctly.
- Pod uptime since switch: clean (0 restarts vs. ~1 restart / 10 min before).

Existing `flamegraph_flat_test.go` / `top_test.go` continue to pass; nil-Line case isn't covered by existing tests — happy to add targeted cases here if that'd help.