### PR TITLE
ui: Handle Query.parse inputs without a profile-type prefix

### DIFF
--- a/ui/packages/shared/parser/src/index.test.ts
+++ b/ui/packages/shared/parser/src/index.test.ts
@@ -104,6 +104,14 @@ test('Partial Parsing ProfileName and rest', () => {
   });
 });
 
+test('QueryParseBareMatchers', () => {
+  const input = '{namespace=~"environment-afc16806", pod=~".*"}';
+  expect(() => Query.parse(input)).not.toThrow();
+  const q = Query.parse(input);
+  expect(q.profileName()).toBe('');
+  expect(q.matchersString()).toBe('namespace=~"environment-afc16806", pod=~".*"');
+});
+
 test('Parse Multiline query', () => {
   expect(
     Query.parse(`memory:alloc_objects:count:space:bytes:delta{

--- a/ui/packages/shared/parser/src/index.ts
+++ b/ui/packages/shared/parser/src/index.ts
@@ -185,7 +185,11 @@ export class Query {
       (e: any) =>
         new Matcher(e.key.value, matcherTypeFromString(e.matcherType.value), e.value.value)
     );
-    return new Query(ProfileType.fromString(ast.profileName.value), matchers, '');
+    const profileType =
+      ast.profileName?.value !== undefined
+        ? ProfileType.fromString(ast.profileName.value)
+        : new ProfileType('', '', '', '', '', false);
+    return new Query(profileType, matchers, '');
   }
 
   static parse(input: string): Query {
@@ -219,7 +223,7 @@ export class Query {
         (s: any) =>
           s.data !== undefined && Object.prototype.hasOwnProperty.call(s.data, 'profileName')
       ).data;
-      const rest = input.slice(column.lexerState.col - 2);
+      const rest = column.lexerState !== undefined ? input.slice(column.lexerState.col - 2) : input;
       return new Query(
         ProfileType.fromString(data.profileName),
         [],


### PR DESCRIPTION
Bare matcher inputs like `{namespace=~"a", pod=~".*"}` match the `_ matchers _` grammar rule, which returns `profileName: {}`. Both `Query.fromAst` and the partial-parse fallback then crash on undefined when constructing the `ProfileType` from the missing value, taking down callers like `ProfileSelector`. Default to an empty `ProfileType` in both paths.