### PR TITLE
*: Phase 1 of FrostDB removal — ClickHouse-only cmd path

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,93 +82,91 @@ Flags:
 Usage: parca [flags]
 
 Flags:
-  -h, --help                     Show context-sensitive help.
+  -h, --help                      Show context-sensitive help.
       --config-path="parca.yaml"
-                                 Path to config file.
-      --mode="all"               Scraper only runs a scraper that sends to a
-                                 remote gRPC endpoint. All runs all components.
-      --http-address=":7070"     Address to bind HTTP server to.
-      --http-read-timeout=5s     Timeout duration for HTTP server to read
-                                 request body.
-      --http-write-timeout=1m    Timeout duration for HTTP server to write
-                                 response body.
-      --port=""                  (DEPRECATED) Use http-address instead.
-      --log-level="info"         Log level.
-      --log-format="logfmt"      Configure if structured logging as JSON or as
-                                 logfmt
-      --otlp-address=STRING      The endpoint to send OTLP traces to.
-      --otlp-exporter="grpc"     The OTLP exporter to use.
-      --otlp-insecure            If true, disables TLS for OTLP exporters (both
-                                 gRPC and HTTP).
+                                  Path to config file.
+      --mode="all"                Scraper only runs a scraper that sends to a
+                                  remote gRPC endpoint. All runs all components.
+      --http-address=":7070"      Address to bind HTTP server to.
+      --http-read-timeout=5s      Timeout duration for HTTP server to read
+                                  request body.
+      --http-write-timeout=1m     Timeout duration for HTTP server to write
+                                  response body.
+      --port=""                   (DEPRECATED) Use http-address instead.
+      --log-level="info"          Log level.
+      --log-format="logfmt"       Configure if structured logging as JSON or as
+                                  logfmt
+      --otlp-address=STRING       The endpoint to send OTLP traces to.
+      --otlp-exporter="grpc"      The OTLP exporter to use.
+      --otlp-insecure             If true, disables TLS for OTLP exporters (both
+                                  gRPC and HTTP).
       --cors-allowed-origins=CORS-ALLOWED-ORIGINS,...
-                                 Allowed CORS origins.
-      --version                  Show application version.
-      --path-prefix=""           Path prefix for the UI
+                                  Allowed CORS origins.
+      --version                   Show application version.
+      --path-prefix=""            Path prefix for the UI
       --mutex-profile-fraction=0
-                                 Fraction of mutex profile samples to collect.
-      --block-profile-rate=0     Sample rate for block profile.
-      --enable-persistence       Turn on persistent storage for the metastore
-                                 and profile storage.
-      --storage-active-memory=536870912
-                                 Amount of memory to use for active storage.
-                                 Defaults to 512MB.
-      --storage-path="data"      Path to storage directory.
-      --storage-enable-wal       Enables write ahead log for profile storage.
-      --storage-snapshot-trigger-size=134217728
-                                 Number of bytes to trigger a snapshot. Defaults
-                                 to 1/4 of active memory. This is only used if
-                                 enable-wal is set.
-      --storage-row-group-size=8192
-                                 Number of rows in each row group during
-                                 compaction and persistence. Setting to <= 0
-                                 results in a single row group per file.
-      --storage-index-on-disk    Whether to store the index on disk instead
-                                 of in memory. Useful to reduce the memory
-                                 footprint of the store.
+                                  Fraction of mutex profile samples to collect.
+      --block-profile-rate=0      Sample rate for block profile.
+      --enable-persistence        Turn on persistent storage for the local
+                                  metastore (profile data is stored in
+                                  ClickHouse regardless).
+      --storage-path="data"       Path to storage directory used for the local
+                                  metastore.
       --symbolizer-demangle-mode="simple"
-                                 Mode to demangle C++ symbols. Default mode
-                                 is simplified: no parameters, no templates,
-                                 no return type
+                                  Mode to demangle C++ symbols. Default mode
+                                  is simplified: no parameters, no templates,
+                                  no return type
       --symbolizer-external-addr-2-line-path=""
-                                 Path to addr2line utility, to be used for
-                                 symbolization instead of native implementation
+                                  Path to addr2line utility, to be used for
+                                  symbolization instead of native implementation
       --symbolizer-number-of-tries=3
-                                 Number of tries to attempt to symbolize an
-                                 unsybolized location
+                                  Number of tries to attempt to symbolize an
+                                  unsybolized location
       --debuginfo-cache-dir="/tmp"
-                                 Path to directory where debuginfo is cached.
+                                  Path to directory where debuginfo is cached.
       --debuginfo-upload-max-size=1000000000
-                                 Maximum size of debuginfo upload in bytes.
+                                  Maximum size of debuginfo upload in bytes.
       --debuginfo-upload-max-duration=15m
-                                 Maximum duration of debuginfo upload.
+                                  Maximum duration of debuginfo upload.
       --debuginfo-uploads-signed-url
-                                 Whether to use signed URLs for debuginfo
-                                 uploads.
+                                  Whether to use signed URLs for debuginfo
+                                  uploads.
       --debuginfod-upstream-servers=debuginfod.elfutils.org,...
-                                 Upstream debuginfod servers. Defaults to
-                                 debuginfod.elfutils.org. It is an ordered
-                                 list of servers to try. Learn more at
-                                 https://sourceware.org/elfutils/Debuginfod.html
+                                  Upstream debuginfod servers. Defaults to
+                                  debuginfod.elfutils.org. It is an ordered
+                                  list of servers to try. Learn more at
+                                  https://sourceware.org/elfutils/Debuginfod.html
       --debuginfod-http-request-timeout=5m
-                                 Timeout duration for HTTP request to upstream
-                                 debuginfod server. Defaults to 5m
+                                  Timeout duration for HTTP request to upstream
+                                  debuginfod server. Defaults to 5m
       --profile-share-server="api.pprof.me:443"
-                                 gRPC address to send share profile requests to.
-      --store-address=STRING     gRPC address to send profiles and symbols to.
-      --bearer-token=STRING      Bearer token to authenticate with store
-                                 ($PARCA_BEARER_TOKEN).
+                                  gRPC address to send share profile requests
+                                  to.
+      --store-address=STRING      gRPC address to send profiles and symbols to.
+      --bearer-token=STRING       Bearer token to authenticate with store
+                                  ($PARCA_BEARER_TOKEN).
       --bearer-token-file=STRING
-                                 File to read bearer token from to authenticate
-                                 with store.
-      --insecure                 Send gRPC requests via plaintext instead of
-                                 TLS.
-      --insecure-skip-verify     Skip TLS certificate verification.
+                                  File to read bearer token from to authenticate
+                                  with store.
+      --insecure                  Send gRPC requests via plaintext instead of
+                                  TLS.
+      --insecure-skip-verify      Skip TLS certificate verification.
       --external-label=KEY=VALUE;...
-                                 Label(s) to attach to all profiles in
-                                 scraper-only mode.
+                                  Label(s) to attach to all profiles in
+                                  scraper-only mode.
       --grpc-headers=KEY=VALUE;...
-                                 Additional gRPC headers to send with each
-                                 request to the remote store (key=value pairs).
+                                  Additional gRPC headers to send with each
+                                  request to the remote store (key=value pairs).
+      --clickhouse-address="localhost:9000"
+                                  ClickHouse server address.
+      --clickhouse-database="parca"
+                                  ClickHouse database name.
+      --clickhouse-username=""    ClickHouse username.
+      --clickhouse-password=""    ClickHouse password
+                                  ($PARCA_CLICKHOUSE_PASSWORD).
+      --clickhouse-table="stacktraces"
+                                  ClickHouse table name for profile data.
+      --clickhouse-secure         Use TLS for ClickHouse connection.
 ```
 <!-- prettier-ignore-end -->
 

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,6 @@ require (
 	github.com/parquet-go/parquet-go v0.24.0
 	github.com/planetscale/vtprotobuf v0.6.1-0.20250313105119-ba97887b0a25
 	github.com/polarsignals/frostdb v0.0.0-20260121113628-9e5cfe0171ad
-	github.com/polarsignals/iceberg-go v0.0.0-20240502213135-2ee70b71e76b
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/common v0.67.5
 	github.com/prometheus/prometheus v0.305.0
@@ -223,6 +222,7 @@ require (
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	github.com/polarsignals/iceberg-go v0.0.0-20240502213135-2ee70b71e76b // indirect
 	github.com/polarsignals/wal v0.0.0-20240619104840-9da940027f9c // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect

--- a/pkg/parca/parca.go
+++ b/pkg/parca/parca.go
@@ -859,4 +859,3 @@ func getDiscoveryConfigs(cfgs []*config.ScrapeConfig) map[string]discovery.Confi
 	}
 	return c
 }
-

--- a/pkg/parca/parca.go
+++ b/pkg/parca/parca.go
@@ -35,13 +35,7 @@ import (
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/oklog/run"
-	"github.com/polarsignals/frostdb"
 	"github.com/polarsignals/frostdb/dynparquet"
-	"github.com/polarsignals/frostdb/index"
-	"github.com/polarsignals/frostdb/query"
-	"github.com/polarsignals/frostdb/storage"
-	"github.com/polarsignals/iceberg-go"
-	"github.com/polarsignals/iceberg-go/catalog"
 	"github.com/prometheus/client_golang/prometheus"
 	promconfig "github.com/prometheus/common/config"
 	"github.com/prometheus/prometheus/discovery"
@@ -70,7 +64,6 @@ import (
 	"github.com/parca-dev/parca/pkg/clickhouse"
 	"github.com/parca-dev/parca/pkg/config"
 	"github.com/parca-dev/parca/pkg/debuginfo"
-	"github.com/parca-dev/parca/pkg/demangle"
 	"github.com/parca-dev/parca/pkg/ingester"
 	"github.com/parca-dev/parca/pkg/kv"
 	"github.com/parca-dev/parca/pkg/parcacol"
@@ -111,7 +104,7 @@ type Flags struct {
 	MutexProfileFraction int `default:"0" help:"Fraction of mutex profile samples to collect."`
 	BlockProfileRate     int `default:"0" help:"Sample rate for block profile."`
 
-	EnablePersistence bool `default:"false" help:"Turn on persistent storage for the metastore and profile storage."`
+	EnablePersistence bool `default:"false" help:"Turn on persistent storage for the local metastore (profile data is stored in ClickHouse regardless)."`
 
 	Storage FlagsStorage `embed:"" prefix:"storage-"`
 
@@ -130,6 +123,8 @@ type Flags struct {
 	ExternalLabel      map[string]string `kong:"help='Label(s) to attach to all profiles in scraper-only mode.'"`
 	GRPCHeaders        map[string]string `kong:"help='Additional gRPC headers to send with each request to the remote store (key=value pairs).'"`
 
+	ClickHouse FlagsClickHouse `embed:"" prefix:"clickhouse-"`
+
 	Hidden FlagsHidden `embed:"" prefix:""`
 }
 
@@ -146,12 +141,7 @@ type FlagsOTLP struct {
 }
 
 type FlagsStorage struct {
-	ActiveMemory        int64  `default:"536870912" help:"Amount of memory to use for active storage. Defaults to 512MB."`
-	Path                string `default:"data" help:"Path to storage directory."`
-	EnableWAL           bool   `default:"false" help:"Enables write ahead log for profile storage."`
-	SnapshotTriggerSize int64  `default:"134217728" help:"Number of bytes to trigger a snapshot. Defaults to 1/4 of active memory. This is only used if enable-wal is set."`
-	RowGroupSize        int    `default:"8192" help:"Number of rows in each row group during compaction and persistence. Setting to <= 0 results in a single row group per file."`
-	IndexOnDisk         bool   `default:"false" help:"Whether to store the index on disk instead of in memory. Useful to reduce the memory footprint of the store."`
+	Path string `default:"data" help:"Path to storage directory used for the local metastore."`
 }
 
 type FlagsSymbolizer struct {
@@ -176,23 +166,17 @@ type FlagsDebuginfod struct {
 
 // FlagsClickHouse configures the ClickHouse storage backend.
 type FlagsClickHouse struct {
-	Enabled  bool   `kong:"help='Enable ClickHouse storage backend instead of FrostDB.',default='false',hidden=''"`
-	Address  string `kong:"help='ClickHouse server address.',default='localhost:9000',hidden=''"`
-	Database string `kong:"help='ClickHouse database name.',default='parca',hidden=''"`
-	Username string `kong:"help='ClickHouse username.',default='',hidden=''"`
-	Password string `kong:"help='ClickHouse password.',default='',env='PARCA_CLICKHOUSE_PASSWORD',hidden=''"`
-	Table    string `kong:"help='ClickHouse table name for profile data.',default='stacktraces',hidden=''"`
-	Secure   bool   `kong:"help='Use TLS for ClickHouse connection.',default='false',hidden=''"`
+	Address  string `kong:"help='ClickHouse server address.',default='localhost:9000'"`
+	Database string `kong:"help='ClickHouse database name.',default='parca'"`
+	Username string `kong:"help='ClickHouse username.',default=''"`
+	Password string `kong:"help='ClickHouse password.',default='',env='PARCA_CLICKHOUSE_PASSWORD'"`
+	Table    string `kong:"help='ClickHouse table name for profile data.',default='stacktraces'"`
+	Secure   bool   `kong:"help='Use TLS for ClickHouse connection.',default='false'"`
 }
 
 // FlagsHidden contains hidden flags intended only for debugging or experimental features.
 type FlagsHidden struct {
 	DebugNormalizeAddresses bool `kong:"help='Normalize sampled addresses.',default='true',hidden=''"`
-
-	// IcebergStorage is a experimental feature that enables Apache Iceberg storage for profile storage. This can be used with the enable-persistence flag.
-	IcebergStorage bool `kong:"help='Use iceberg storage for profile storage. Requires enable-persistence flag.',default='false',hidden=''"`
-
-	ClickHouse FlagsClickHouse `embed:"" prefix:"clickhouse-"`
 }
 
 // Run the parca server.
@@ -329,197 +313,58 @@ func Run(ctx context.Context, logger log.Logger, reg *prometheus.Registry, flags
 		return err
 	}
 
-	// Initialize storage backend - either ClickHouse or FrostDB
-	var (
-		profileIngester ingester.Ingester
-		querier         queryservice.Querier
-		s               *profilestore.ProfileColumnStore
-		col             *frostdb.ColumnStore
-		chClient        *clickhouse.Client
+	// Initialize the ClickHouse storage backend.
+	level.Info(logger).Log("msg", "initializing ClickHouse storage backend", "address", flags.ClickHouse.Address)
+
+	chClient, err := clickhouse.NewClient(ctx, clickhouse.Config{
+		Address:  flags.ClickHouse.Address,
+		Database: flags.ClickHouse.Database,
+		Username: flags.ClickHouse.Username,
+		Password: flags.ClickHouse.Password,
+		Table:    flags.ClickHouse.Table,
+		Secure:   flags.ClickHouse.Secure,
+	})
+	if err != nil {
+		level.Error(logger).Log("msg", "failed to connect to ClickHouse", "err", err)
+		return fmt.Errorf("failed to connect to ClickHouse: %w", err)
+	}
+
+	if err := chClient.EnsureSchema(ctx); err != nil {
+		level.Error(logger).Log("msg", "failed to ensure ClickHouse schema", "err", err)
+		return fmt.Errorf("failed to ensure ClickHouse schema: %w", err)
+	}
+
+	var profileIngester ingester.Ingester = clickhouse.NewIngester(logger, chClient)
+	var querier queryservice.Querier = clickhouse.NewQuerier(
+		chClient,
+		logger,
+		tracerProvider.Tracer("clickhouse-querier"),
+		memory.DefaultAllocator,
+		symbolizer.New(
+			logger,
+			debuginfoMetadata,
+			symbolizer.NewBadgerCache(db),
+			debuginfo.NewFetcher(debuginfodClients, debuginfoBucket),
+			flags.Debuginfo.CacheDir,
+			flags.Symbolizer.ExternalAddr2linePath,
+			symbolizer.WithDemangleMode(flags.Symbolizer.DemangleMode),
+		),
 	)
 
-	if flags.Hidden.ClickHouse.Enabled {
-		// Initialize ClickHouse storage backend
-		level.Info(logger).Log("msg", "initializing ClickHouse storage backend", "address", flags.Hidden.ClickHouse.Address)
-
-		chClient, err = clickhouse.NewClient(ctx, clickhouse.Config{
-			Address:  flags.Hidden.ClickHouse.Address,
-			Database: flags.Hidden.ClickHouse.Database,
-			Username: flags.Hidden.ClickHouse.Username,
-			Password: flags.Hidden.ClickHouse.Password,
-			Table:    flags.Hidden.ClickHouse.Table,
-			Secure:   flags.Hidden.ClickHouse.Secure,
-		})
-		if err != nil {
-			level.Error(logger).Log("msg", "failed to connect to ClickHouse", "err", err)
-			return fmt.Errorf("failed to connect to ClickHouse: %w", err)
-		}
-
-		if err := chClient.EnsureSchema(ctx); err != nil {
-			level.Error(logger).Log("msg", "failed to ensure ClickHouse schema", "err", err)
-			return fmt.Errorf("failed to ensure ClickHouse schema: %w", err)
-		}
-
-		profileIngester = clickhouse.NewIngester(logger, chClient)
-		querier = clickhouse.NewQuerier(
-			chClient,
-			logger,
-			tracerProvider.Tracer("clickhouse-querier"),
-			memory.DefaultAllocator,
-			symbolizer.New(
-				logger,
-				debuginfoMetadata,
-				symbolizer.NewBadgerCache(db),
-				debuginfo.NewFetcher(debuginfodClients, debuginfoBucket),
-				flags.Debuginfo.CacheDir,
-				flags.Symbolizer.ExternalAddr2linePath,
-				symbolizer.WithDemangleMode(flags.Symbolizer.DemangleMode),
-			),
-		)
-
-		// We still need the schema for ProfileColumnStore
-		def := profile.SchemaDefinition()
-		schema, err := dynparquet.SchemaFromDefinition(def)
-		if err != nil {
-			level.Error(logger).Log("msg", "schema from definition", "err", err)
-			return err
-		}
-
-		s = profilestore.NewProfileColumnStore(
-			reg,
-			logger,
-			tracerProvider.Tracer("profilestore"),
-			profileIngester,
-			schema,
-			memory.DefaultAllocator,
-		)
-	} else {
-		// Initialize FrostDB storage backend (default)
-		frostdbOptions := []frostdb.Option{
-			frostdb.WithActiveMemorySize(flags.Storage.ActiveMemory),
-			frostdb.WithLogger(logger),
-			frostdb.WithRegistry(reg),
-			frostdb.WithTracer(tracerProvider.Tracer("frostdb")),
-		}
-
-		if flags.EnablePersistence {
-			blocksDirectory := "blocks"
-			prefixedBucket := objstore.NewPrefixedBucket(bucket, blocksDirectory)
-			var store frostdb.DataSinkSource
-			if flags.Hidden.IcebergStorage { // Experimental Iceberg storage.
-				// Optain the bucket URI from the config
-				uri, err := BucketURIFromConfig(bucketCfg)
-				if err != nil {
-					level.Error(logger).Log("msg", "failed to get bucket URI from config", "err", err)
-					return err
-				}
-				path := filepath.Join(uri, blocksDirectory)
-				store, err = storage.NewIceberg(path, catalog.NewHDFS(path, prefixedBucket), prefixedBucket,
-					storage.WithIcebergPartitionSpec(
-						iceberg.NewPartitionSpec( // Partition the table by timestamp.
-							iceberg.PartitionField{
-								Name:      profile.ColumnTimestamp,
-								Transform: iceberg.IdentityTransform{},
-							},
-						),
-					))
-				if err != nil {
-					level.Error(logger).Log("msg", "failed to initialize iceberg", "err", err)
-					return err
-				}
-			} else {
-				store = frostdb.NewDefaultObjstoreBucket(prefixedBucket)
-			}
-			frostdbOptions = append(
-				frostdbOptions,
-				frostdb.WithReadWriteStorage(store),
-			)
-		}
-
-		if flags.Storage.EnableWAL {
-			frostdbOptions = append(
-				frostdbOptions,
-				frostdb.WithWAL(),
-				frostdb.WithStoragePath(flags.Storage.Path),
-				frostdb.WithSnapshotTriggerSize(flags.Storage.SnapshotTriggerSize),
-			)
-
-			if flags.Storage.IndexOnDisk {
-				frostdbOptions = append(frostdbOptions, frostdb.WithIndexConfig(
-					[]*index.LevelConfig{
-						{Level: index.L0, MaxSize: 1024 * 1024 * 15, Type: index.CompactionTypeParquetDisk},
-						{Level: index.L1, MaxSize: 1024 * 1024 * 128, Type: index.CompactionTypeParquetDisk},
-						{Level: index.L2, MaxSize: 1024 * 1024 * 512},
-					}))
-			}
-		}
-
-		col, err = frostdb.New(frostdbOptions...)
-		if err != nil {
-			level.Error(logger).Log("msg", "failed to initialize storage", "err", err)
-			return err
-		}
-
-		colDB, err := col.DB(ctx, "parca")
-		if err != nil {
-			level.Error(logger).Log("msg", "failed to load database", "err", err)
-			return err
-		}
-
-		def := profile.SchemaDefinition()
-		table, err := colDB.Table("stacktraces",
-			frostdb.NewTableConfig(
-				def,
-				frostdb.WithRowGroupSize(flags.Storage.RowGroupSize),
-			),
-		)
-		if err != nil {
-			level.Error(logger).Log("msg", "create table", "err", err)
-			return err
-		}
-		schema, err := dynparquet.SchemaFromDefinition(def)
-		if err != nil {
-			level.Error(logger).Log("msg", "schema from definition", "err", err)
-			return err
-		}
-
-		profileIngester = ingester.NewIngester(logger, table)
-		queryDemangler, err := demangle.NewDefaultDemangler()
-		if err != nil {
-			level.Error(logger).Log("msg", "failed to initialize demangler", "err", err)
-			return err
-		}
-		querier = parcacol.NewQuerier(
-			logger,
-			tracerProvider.Tracer("querier"),
-			query.NewEngine(
-				memory.DefaultAllocator,
-				colDB.TableProvider(),
-				query.WithTracer(tracerProvider.Tracer("query-engine")),
-			),
-			"stacktraces",
-			symbolizer.New(
-				logger,
-				debuginfoMetadata,
-				symbolizer.NewBadgerCache(db),
-				debuginfo.NewFetcher(debuginfodClients, debuginfoBucket),
-				flags.Debuginfo.CacheDir,
-				flags.Symbolizer.ExternalAddr2linePath,
-				symbolizer.WithDemangleMode(flags.Symbolizer.DemangleMode),
-			),
-			queryDemangler,
-			memory.DefaultAllocator,
-		)
-
-		s = profilestore.NewProfileColumnStore(
-			reg,
-			logger,
-			tracerProvider.Tracer("profilestore"),
-			profileIngester,
-			schema,
-			memory.DefaultAllocator,
-		)
+	schema, err := dynparquet.SchemaFromDefinition(profile.SchemaDefinition())
+	if err != nil {
+		level.Error(logger).Log("msg", "schema from definition", "err", err)
+		return err
 	}
+
+	s := profilestore.NewProfileColumnStore(
+		reg,
+		logger,
+		tracerProvider.Tracer("profilestore"),
+		profileIngester,
+		schema,
+		memory.DefaultAllocator,
+	)
 
 	propagators := propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{})
 	opts := []grpc.DialOption{
@@ -732,17 +577,8 @@ func Run(ctx context.Context, logger log.Logger, reg *prometheus.Registry, flags
 			}
 
 			// Close the storage backend after the parcaserver has shutdown to ensure no more writes occur against it.
-
-			if col != nil {
-				if err := col.Close(); err != nil {
-					level.Error(logger).Log("msg", "error closing columnstore", "err", err)
-				}
-			}
-
-			if chClient != nil {
-				if err := chClient.Close(); err != nil {
-					level.Error(logger).Log("msg", "error closing ClickHouse client", "err", err)
-				}
+			if err := chClient.Close(); err != nil {
+				level.Error(logger).Log("msg", "error closing ClickHouse client", "err", err)
 			}
 		},
 	)
@@ -1024,50 +860,3 @@ func getDiscoveryConfigs(cfgs []*config.ScrapeConfig) map[string]discovery.Confi
 	return c
 }
 
-func BucketURIFromConfig(bucketCfg []byte) (string, error) {
-	bucketConf := &client.BucketConfig{}
-	if err := yaml.Unmarshal(bucketCfg, bucketConf); err != nil {
-		return "", fmt.Errorf("failed to unmarshal bucket config: %w", err)
-	}
-
-	type Config struct {
-		Bucket string `yaml:"bucket"`
-	}
-
-	config, err := yaml.Marshal(bucketConf.Config)
-	if err != nil {
-		return "", fmt.Errorf("failed to marshal content of bucket configuration: %w", err)
-	}
-
-	switch strings.ToUpper(string(bucketConf.Type)) {
-	case string(client.GCS):
-		var cfg Config
-		if err := yaml.Unmarshal(config, &cfg); err != nil {
-			return "", err
-		}
-		return filepath.Join("gs://", cfg.Bucket, bucketConf.Prefix), nil
-	case string(client.S3):
-		var cfg Config
-		if err := yaml.Unmarshal(config, &cfg); err != nil {
-			return "", err
-		}
-		return filepath.Join("s3://", cfg.Bucket, bucketConf.Prefix), nil
-	case string(client.FILESYSTEM):
-		type Config struct {
-			Directory string `yaml:"directory"`
-		}
-
-		var cfg Config
-		if err := yaml.Unmarshal(config, &cfg); err != nil {
-			return "", err
-		}
-
-		path, err := filepath.Abs(cfg.Directory)
-		if err != nil {
-			return "", err
-		}
-		return path, nil
-	default:
-		return "", fmt.Errorf("unknown bucket type: %s", bucketConf.Type)
-	}
-}

--- a/pkg/parca/parca_test.go
+++ b/pkg/parca/parca_test.go
@@ -60,6 +60,8 @@ func getShareServerConn(t Testing) sharepb.ShareServiceClient {
 }
 
 func benchmarkSetup(ctx context.Context, b *testing.B) (profilestorepb.ProfileStoreServiceClient, <-chan struct{}) {
+	b.Skip("Benchmark_WriteRaw drives Run() which now requires a ClickHouse backend; bring this back via testcontainers in the test rework phase.")
+
 	addr := "127.0.0.1:7077"
 
 	logger := log.NewNopLogger()
@@ -68,11 +70,8 @@ func benchmarkSetup(ctx context.Context, b *testing.B) (profilestorepb.ProfileSt
 	go func() {
 		defer close(done)
 		err := Run(ctx, logger, reg, &Flags{
-			ConfigPath: "testdata/parca.yaml",
-			Port:       addr,
-			Storage: FlagsStorage{
-				ActiveMemory: 512 * 1024 * 1024,
-			},
+			ConfigPath:         "testdata/parca.yaml",
+			Port:               addr,
 			ProfileShareServer: "api.pprof.dummy:443",
 			Hidden: FlagsHidden{
 				DebugNormalizeAddresses: true,

--- a/snap/README.md
+++ b/snap/README.md
@@ -36,11 +36,10 @@ $ snap start parca
 
 There are a small number of config options:
 
-| Name                    | Valid Options                    | Default     | Description                                                                                        |
-| :---------------------- | :------------------------------- | :---------- | :------------------------------------------------------------------------------------------------- |
-| `storage-active-memory` | Any `int`                        | `536870912` | Total bytes in memory used for active memory storage                                               |
-| `enable-persistence`    | `true`, `false`                  | `false`     | Persist data to disk (experimental). Profiles will be saved in `/var/snap/parca/current/profiles/` |
-| `log-level`             | `error`, `warn`, `info`, `debug` | `info`      | Log level for Parca                                                                                |
-| `port`                  | 1024 > `int` > 65534             | `7070`      | Port for Parca server to listen on                                                                 |
+| Name                 | Valid Options                    | Default | Description                                                                  |
+| :------------------- | :------------------------------- | :------ | :--------------------------------------------------------------------------- |
+| `enable-persistence` | `true`, `false`                  | `false` | Persist the local metastore to disk under `/var/snap/parca/current/profiles/` |
+| `log-level`          | `error`, `warn`, `info`, `debug` | `info`  | Log level for Parca                                                          |
+| `port`               | 1024 > `int` > 65534             | `7070`  | Port for Parca server to listen on                                           |
 
 Config options can be set with `sudo snap set parca <option>=<value>`

--- a/snap/README.md
+++ b/snap/README.md
@@ -36,10 +36,10 @@ $ snap start parca
 
 There are a small number of config options:
 
-| Name                 | Valid Options                    | Default | Description                                                                  |
-| :------------------- | :------------------------------- | :------ | :--------------------------------------------------------------------------- |
+| Name                 | Valid Options                    | Default | Description                                                                   |
+| :------------------- | :------------------------------- | :------ | :---------------------------------------------------------------------------- |
 | `enable-persistence` | `true`, `false`                  | `false` | Persist the local metastore to disk under `/var/snap/parca/current/profiles/` |
-| `log-level`          | `error`, `warn`, `info`, `debug` | `info`  | Log level for Parca                                                          |
-| `port`               | 1024 > `int` > 65534             | `7070`  | Port for Parca server to listen on                                           |
+| `log-level`          | `error`, `warn`, `info`, `debug` | `info`  | Log level for Parca                                                           |
+| `port`               | 1024 > `int` > 65534             | `7070`  | Port for Parca server to listen on                                            |
 
 Config options can be set with `sudo snap set parca <option>=<value>`

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -19,11 +19,6 @@ set -euo pipefail
 # We need to handle that case and reset $SNAP
 SNAP="${SNAP//\/var\/lib\/snapd/}"
 
-storage_active_memory="$(snapctl get storage-active-memory)"
-if [[ -z "$storage_active_memory" ]]; then
-    snapctl set storage-active-memory=536870912
-fi
-
 log_level="$(snapctl get log-level)"
 if [[ -z "$log_level" ]]; then
     snapctl set log-level=info

--- a/snap/parca-wrapper
+++ b/snap/parca-wrapper
@@ -19,7 +19,6 @@ set -euo pipefail
 "${SNAP}"/snap/hooks/configure
 
 # Grab the config options
-storage_active_memory="$(snapctl get storage-active-memory)"
 log_level="$(snapctl get log-level)"
 storage_persist="$(snapctl get enable-persistence)"
 http_address="$(snapctl get http-address)"
@@ -58,7 +57,8 @@ else
     # Only configure persistence and storage if we're not sending to a remote store.
 
     # Switch out command line options depending on whether the user has
-    # specified storage-persist=true
+    # specified storage-persist=true. The persistence flag now controls only
+    # the local metastore; profile data lives in ClickHouse.
     if [[ "${storage_persist}" == "true" ]]; then
         opts+=(
             "--enable-persistence=true"
@@ -67,7 +67,6 @@ else
     else
         opts+=(
             "--enable-persistence=false"
-            "--storage-active-memory=${storage_active_memory}"
         )
     fi
 fi


### PR DESCRIPTION
## Summary

Phase 1 of removing FrostDB from Parca (tracking issue / Discord thread). Collapses the dual-path init in `pkg/parca/parca.go` to ClickHouse-only and promotes the ClickHouse flags out of `FlagsHidden` so they're visible in `--help`.

- Removed FrostDB-only flags: `--storage-active-memory`, `--storage-enable-wal`, `--storage-snapshot-trigger-size`, `--storage-row-group-size`, `--storage-index-on-disk`, the experimental `--iceberg-storage` hidden flag, and `--clickhouse-enabled` (the toggle is gone since ClickHouse is now the only backend).
- `--enable-persistence` survives but now controls only the local badger metastore — profile data lives in ClickHouse.
- `pkg/ingester/` and `pkg/parcacol/querier.go` are dead from the cmd path but kept in tree because the existing test suite still exercises them; they get removed when those tests are reworked against testcontainers (Phase 3).
- `dynparquet`/`pqarrow` imports are still load-bearing on the ClickHouse path (schema definition, normalizer, profilestore) — those are untangled in Phase 2.
- `Benchmark_WriteRaw` is now `b.Skip`'d since it drove `Run()` which now requires ClickHouse. Restored via testcontainers in Phase 3.
- `snap/parca-wrapper` no longer plumbs `--storage-active-memory`. Wiring full ClickHouse config (address/credentials) into the snap is a separate follow-up.
- `README.md` regenerated via `make README.md`.

## Follow-ups

- **Phase 2** — untangle `dynparquet` + `pqarrow` from `pkg/normalizer/`, `pkg/profile/schema.go`, `pkg/profilestore/profilecolumnstore.go`, `pkg/query/{flamegraph_arrow,table,columnquery}.go`.
- **Phase 3** — rework the FrostDB-backed tests in `pkg/parca/parca_test.go`, `pkg/profilestore/profilestore_test.go`, `pkg/ingester/ingester_test.go`, `pkg/query/{query,columnquery}_test.go` against testcontainers ClickHouse; delete `pkg/ingester/` and `pkg/parcacol/querier.go`.
- **Phase 4** — `go mod tidy`; drop `frostdb` and `iceberg-go` from `go.mod`.
- **Snap follow-up** — add `clickhouse-*` snap config keys + hooks so the snap can boot a usable parca without command-line overrides.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -short ./...`
- [ ] CI green
- [ ] Manual smoke: `parca` boots against a local ClickHouse and ingests a profile
- [ ] Confirm `parca --help` reads cleanly (regenerated README)

🤖 Generated with [Claude Code](https://claude.com/claude-code)