### PR TITLE
ci: upgrade pnpm to 11

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -17,10 +17,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: true
 
-env:
-  # renovate: datasource=npm depName=pnpm versioning=npm
-  PNPM_VERSION: '10.33.0'
-
 jobs:
   build-and-test:
     name: Test on ${{ matrix.arch }}
@@ -60,9 +56,7 @@ jobs:
       with:
         go-version-file: .go-version
 
-    - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
-      with:
-        version: ${{ env.PNPM_VERSION }}
+    - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
     - name: Set up Node.js
       if: ${{ steps.skip-check.outputs.should_skip != 'true' }}

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -21,10 +21,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: true
 
-env:
-  # renovate: datasource=npm depName=pnpm versioning=npm
-  PNPM_VERSION: '10.33.0'
-
 # List of jobs
 jobs:
   skip-check:
@@ -61,9 +57,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0 # Required to retrieve git history
-      - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
-        with:
-          version: ${{ env.PNPM_VERSION }}
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:

--- a/.github/workflows/codeql-analysis-go.yml
+++ b/.github/workflows/codeql-analysis-go.yml
@@ -19,10 +19,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: true
 
-env:
-  # renovate: datasource=npm depName=pnpm versioning=npm
-  PNPM_VERSION: '10.33.0'
-
 jobs:
   skip-check:
     name: Skip check
@@ -73,9 +69,7 @@ jobs:
         with:
           go-version-file: .go-version
 
-      - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
-        with:
-          version: ${{ env.PNPM_VERSION }}
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -20,8 +20,6 @@ concurrency:
 env:
   # renovate: datasource=go depName=github.com/goreleaser/goreleaser
   GORELEASER_VERSION: v1.26.2
-  # renovate: datasource=npm depName=pnpm versioning=npm
-  PNPM_VERSION: '10.33.0'
 
 jobs:
   skip-check:
@@ -76,9 +74,7 @@ jobs:
         with:
           go-version-file: .go-version
 
-      - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
-        with:
-          version: ${{ env.PNPM_VERSION }}
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,10 +17,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: true
 
-env:
-  # renovate: datasource=npm depName=pnpm versioning=npm
-  PNPM_VERSION: '10.33.0'
-
 jobs:
   skip-check:
     name: Skip check
@@ -62,9 +58,7 @@ jobs:
         with:
           go-version-file: .go-version
 
-      - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
-        with:
-          version: ${{ env.PNPM_VERSION }}
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -18,10 +18,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: true
 
-env:
-  # renovate: datasource=npm depName=pnpm versioning=npm
-  PNPM_VERSION: '10.33.0'
-
 jobs:
   skip-check:
     name: Skip check
@@ -67,9 +63,7 @@ jobs:
         run: |
           ./env.sh
 
-      - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
-        with:
-          version: ${{ env.PNPM_VERSION }}
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -20,8 +20,6 @@ concurrency:
 env:
   # renovate: datasource=go depName=github.com/goreleaser/goreleaser
   GORELEASER_VERSION: v1.26.2
-  # renovate: datasource=npm depName=pnpm versioning=npm
-  PNPM_VERSION: '10.33.0'
 
 permissions:
   contents: write
@@ -83,9 +81,7 @@ jobs:
         with:
           go-version-file: .go-version
 
-      - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
-        with:
-          version: ${{ env.PNPM_VERSION }}
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,6 @@ concurrency:
 env:
   # renovate: datasource=go depName=github.com/goreleaser/goreleaser
   GORELEASER_VERSION: v1.26.2
-  # renovate: datasource=npm depName=pnpm versioning=npm
-  PNPM_VERSION: '10.33.0'
 
 permissions:
   contents: write
@@ -39,9 +37,7 @@ jobs:
         with:
           go-version-file: .go-version
 
-      - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
-        with:
-          version: ${{ env.PNPM_VERSION }}
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -20,8 +20,6 @@ concurrency:
 env:
   # renovate: datasource=go depName=github.com/goreleaser/goreleaser
   GORELEASER_VERSION: v1.26.2
-  # renovate: datasource=npm depName=pnpm versioning=npm
-  PNPM_VERSION: '10.33.0'
 
 permissions:
   contents: write
@@ -86,9 +84,7 @@ jobs:
           check-latest: true
           cache: true
 
-      - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
-        with:
-          version: ${{ env.PNPM_VERSION }}
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/.github/workflows/ui-publish-components.yml
+++ b/.github/workflows/ui-publish-components.yml
@@ -9,10 +9,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: false
 
-env:
-  # renovate: datasource=npm depName=pnpm versioning=npm
-  PNPM_VERSION: '10.33.0'
-
 jobs:
   skip-check:
     name: Skip check
@@ -59,9 +55,7 @@ jobs:
           git fetch origin +refs/heads/main:refs/remotes/origin/main && \
           git checkout main
 
-      - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
-        with:
-          version: ${{ env.PNPM_VERSION }}
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Set up Node.js
         uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -17,10 +17,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: true
 
-env:
-  # renovate: datasource=npm depName=pnpm versioning=npm
-  PNPM_VERSION: '10.33.0'
-
 jobs:
   skip-check:
     name: Skip check
@@ -54,9 +50,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
-        with:
-          version: ${{ env.PNPM_VERSION }}
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/package.json
+++ b/package.json
@@ -5,5 +5,5 @@
     "all-contributors-cli": "6.26.1",
     "ts-protoc-gen": "0.15.0"
   },
-  "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319"
+  "packageManager": "pnpm@11.5.2+sha512.71c631e382066efc25625d5cf029075de07b61b37f6e27350fbd84b1bda5864c8c1967adc280776b45c30a715c0359a3be08fef42d5bb09e2b99029979692916"
 }

--- a/ui/pnpm-workspace.yaml
+++ b/ui/pnpm-workspace.yaml
@@ -1,3 +1,62 @@
 packages:
   - "packages/app/*"
   - "packages/shared/*"
+
+# Control which dependencies may run install/build lifecycle scripts.
+# pnpm blocks dependency build scripts by default since v10; allow only the
+# ones that need native builds, deny the rest to keep installs lean & safe.
+allowBuilds:
+  "@parcel/watcher": true
+  "@swc/core": true
+  esbuild: true
+  nx: true
+  core-js: false
+  core-js-pure: false
+  glob-promise: false
+  puppeteer: false
+
+# Keep pnpm's 24h supply-chain protection (minimumReleaseAge) but allow
+# our own freshly-published packages to be installed without delay.
+minimumReleaseAgeExclude:
+  - "@parca/*"
+
+# pnpm 10+ reads overrides from here ("pnpm.overrides" in package.json is
+# ignored by pnpm 11). These are duplicated in package.json's pnpm.overrides
+# so Vercel's pnpm 9 (the default for a lockfileVersion 9.0 lockfile when
+# Corepack is off) still applies them. Keep both copies in sync.
+overrides:
+  fork-ts-checker-webpack-plugin: "^8.0.0"
+  "axios@>=1.14.0 <1.14.2": "1.15.2"
+  "axios@>=0.30.0 <0.30.5": "0.30.3"
+  "axios@>=1.0.0 <1.13.5": "1.15.2"
+  "rollup@>=4.0.0 <4.59.0": "4.60.1"
+  "rollup@<2.80.0": "2.80.0"
+  "handlebars@>=4.0.0 <4.7.9": "4.7.9"
+  "nth-check@<2.0.1": "2.1.1"
+  "minimatch@>=5.0.0 <5.1.8": "5.1.9"
+  "minimatch@>=9.0.0 <9.0.7": "9.0.9"
+  "basic-ftp@<5.2.0": "5.3.0"
+  "serialize-javascript@<7.0.5": "7.0.5"
+  "underscore@<=1.13.7": "1.13.8"
+  "svgo@>=2.1.0 <2.8.1": "2.8.2"
+  "immutable@>=5.0.0 <5.1.5": "5.1.5"
+  "flatted@<3.4.2": "3.4.2"
+  "koa@<2.16.4": "2.16.4"
+  "node-forge@<1.4.0": "1.4.0"
+  "picomatch@<2.3.2": "2.3.2"
+  "picomatch@>=4.0.0 <4.0.4": "4.0.4"
+  "jsonpath@<=1.2.1": "1.3.0"
+  "path-to-regexp@<0.1.13": "0.2.5"
+  "prismjs@<1.30.0": "1.30.0"
+  "postcss@<8.4.31": "8.5.10"
+  "ajv@<6.14.0": "6.14.0"
+  "ajv@>=7.0.0-alpha.0 <8.18.0": "8.18.0"
+  "yauzl@>=3.2.0 <3.2.1": "3.2.1"
+  "brace-expansion@<1.1.13": "1.1.13"
+  "brace-expansion@>=2.0.0 <2.0.3": "2.0.3"
+  "brace-expansion@>=4.0.0 <5.0.5": "5.0.5"
+  "yaml@>=1.0.0 <1.10.3": "1.10.3"
+  "yaml@>=2.0.0 <2.8.3": "2.8.3"
+  "diff@>=4.0.0 <4.0.4": "4.0.4"
+  "diff@>=5.0.0 <5.2.2": "5.2.2"
+  "qs@>=6.7.0 <=6.14.1": "6.15.0"


### PR DESCRIPTION
[NixOS is dropping the older pnpm packages](https://github.com/NixOS/nixpkgs/issues/529285), so this moves us to pnpm 11. The non-obvious part is that pnpm 11 stopped reading the `pnpm` field in `package.json`, which meant our security overrides were silently ignored and `pnpm install --frozen-lockfile` failed on a config mismatch. They now live in `pnpm-workspace.yaml` alongside the `allowBuilds` allowlist, with `@parca/*` excluded from pnpm 11's 24h release-age delay, and CI reads the version from `packageManager` via `action-setup@v6` instead of a pinned env var.