### PR TITLE
Fix pprof validation: nil period_type and off-by-one string-table bounds

### DIFF
--- a/pkg/normalizer/validate.go
+++ b/pkg/normalizer/validate.go
@@ -37,10 +37,10 @@ func ValidatePprofProfile(p *pprofpb.Profile, ei []*profilestorepb.ExecutableInf
 		if m.Id != uint64(i+1) {
 			return fmt.Errorf("mapping id is not sequential")
 		}
-		if m.Filename != 0 && m.Filename > stringTableLen {
+		if m.Filename != 0 && m.Filename >= stringTableLen {
 			return fmt.Errorf("mapping (id: %d) has invalid filename index %d", m.Id, m.Filename)
 		}
-		if m.BuildId != 0 && m.BuildId > stringTableLen {
+		if m.BuildId != 0 && m.BuildId >= stringTableLen {
 			return fmt.Errorf("mapping (id: %d) has invalid buildid index %d", m.Id, m.Filename)
 		}
 	}
@@ -57,13 +57,13 @@ func ValidatePprofProfile(p *pprofpb.Profile, ei []*profilestorepb.ExecutableInf
 		if f.Id != uint64(i+1) {
 			return fmt.Errorf("function id is not sequential")
 		}
-		if f.Name != 0 && f.Name > stringTableLen {
+		if f.Name != 0 && f.Name >= stringTableLen {
 			return fmt.Errorf("function (id: %d) has invalid name index %d", f.Id, f.Name)
 		}
-		if f.SystemName != 0 && f.SystemName > stringTableLen {
+		if f.SystemName != 0 && f.SystemName >= stringTableLen {
 			return fmt.Errorf("function (id: %d) has invalid systemname index %d", f.Id, f.SystemName)
 		}
-		if f.Filename != 0 && f.Filename > stringTableLen {
+		if f.Filename != 0 && f.Filename >= stringTableLen {
 			return fmt.Errorf("function (id: %d) has invalid filename index %d", f.Id, f.Filename)
 		}
 	}
@@ -97,21 +97,23 @@ func ValidatePprofProfile(p *pprofpb.Profile, ei []*profilestorepb.ExecutableInf
 			return fmt.Errorf("profile has nil sample type")
 		}
 
-		if st.Type != 0 && st.Type > stringTableLen {
+		if st.Type != 0 && st.Type >= stringTableLen {
 			return fmt.Errorf("sample type %d has invalid type index %d", i, st.Type)
 		}
 
-		if st.Unit != 0 && st.Unit > stringTableLen {
+		if st.Unit != 0 && st.Unit >= stringTableLen {
 			return fmt.Errorf("sample type %d has invalid unit index %d", i, st.Unit)
 		}
 	}
 
-	if p.PeriodType.Type != 0 && p.PeriodType.Type > stringTableLen {
-		return fmt.Errorf("period type has invalid type index %d", p.PeriodType.Type)
-	}
+	if p.PeriodType != nil {
+		if p.PeriodType.Type != 0 && p.PeriodType.Type >= stringTableLen {
+			return fmt.Errorf("period type has invalid type index %d", p.PeriodType.Type)
+		}
 
-	if p.PeriodType.Unit != 0 && p.PeriodType.Unit > stringTableLen {
-		return fmt.Errorf("period type has invalid unit index %d", p.PeriodType.Unit)
+		if p.PeriodType.Unit != 0 && p.PeriodType.Unit >= stringTableLen {
+			return fmt.Errorf("period type has invalid unit index %d", p.PeriodType.Unit)
+		}
 	}
 
 	for i, s := range p.Sample {
@@ -133,10 +135,10 @@ func ValidatePprofProfile(p *pprofpb.Profile, ei []*profilestorepb.ExecutableInf
 			if label.Key == 0 {
 				return fmt.Errorf("sample %d label %d has no key", i, j)
 			}
-			if label.Key != 0 && label.Key > stringTableLen {
+			if label.Key != 0 && label.Key >= stringTableLen {
 				return fmt.Errorf("sample %d label %d has invalid key index %d", i, j, label.Key)
 			}
-			if label.Str != 0 && label.Str > stringTableLen {
+			if label.Str != 0 && label.Str >= stringTableLen {
 				return fmt.Errorf("sample %d label %d has invalid str index %d", i, j, label.Str)
 			}
 		}

--- a/pkg/normalizer/validate_test.go
+++ b/pkg/normalizer/validate_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package normalizer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	pprofpb "github.com/parca-dev/parca/gen/proto/go/google/pprof"
+)
+
+func TestValidatePprofProfile_StringTableBounds(t *testing.T) {
+	// String table has 3 entries, so the only valid indices are 0, 1 and 2.
+	// An index equal to len(StringTable) is one past the end.
+	stringTable := []string{"", "cpu", "nanoseconds"}
+
+	for _, tc := range []struct {
+		name    string
+		profile *pprofpb.Profile
+		wantErr bool
+	}{
+		{
+			name: "valid",
+			profile: &pprofpb.Profile{
+				StringTable: stringTable,
+				SampleType:  []*pprofpb.ValueType{{Type: 1, Unit: 2}},
+				PeriodType:  &pprofpb.ValueType{Type: 1, Unit: 2},
+			},
+			wantErr: false,
+		},
+		{
+			// period_type is optional; omitting it must validate cleanly,
+			// not panic inside the validator.
+			name: "nil period type",
+			profile: &pprofpb.Profile{
+				StringTable: stringTable,
+				SampleType:  []*pprofpb.ValueType{{Type: 1, Unit: 2}},
+				PeriodType:  nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "sample type index equal to string table length",
+			profile: &pprofpb.Profile{
+				StringTable: stringTable,
+				SampleType:  []*pprofpb.ValueType{{Type: int64(len(stringTable))}},
+				PeriodType:  &pprofpb.ValueType{Type: 1, Unit: 2},
+			},
+			wantErr: true,
+		},
+		{
+			name: "period type index equal to string table length",
+			profile: &pprofpb.Profile{
+				StringTable: stringTable,
+				SampleType:  []*pprofpb.ValueType{{Type: 1, Unit: 2}},
+				PeriodType:  &pprofpb.ValueType{Type: int64(len(stringTable))},
+			},
+			wantErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// require.NotPanics keeps a regression from crashing the whole
+			// test binary and reports it as a normal failure instead.
+			require.NotPanics(t, func() {
+				err := ValidatePprofProfile(tc.profile, nil)
+				if tc.wantErr {
+					require.Error(t, err)
+				} else {
+					require.NoError(t, err)
+				}
+			})
+		})
+	}
+}


### PR DESCRIPTION
While reading the pprof ingest path I hit two panics in ValidatePprofProfile (pkg/normalizer/validate.go). This validator runs on the WriteRaw gRPC ingest that every agent uses to push profiles, so the profile bytes are attacker-influenced, and both cases crash the validator (or the code just past it) rather than returning an error.

The first is a nil pointer deref. period_type is optional, so a profile that omits it arrives with a nil PeriodType. The rest of the function nil-checks its pointer fields, but the period_type branch dereferences p.PeriodType.Type directly, so merely leaving the field out panics inside the validator. I wrapped those two checks in a nil guard like everything else.

The second is an off-by-one in the string-table bounds checks. They use `> len(StringTable)`, but string indices are 0-based, so the valid range is 0..len-1. An index exactly equal to len slips through the check and is one past the end, and downstream code (MetaFromPprof, LabelsFromSample) then indexes it and panics with index out of range. I changed the eleven 0-based string-index checks to `>=`. I left the mapping/function/location id checks as `>` on purpose, since those ids are 1-based and len is a valid id.

Added a table-driven test in the normalizer package: an omitted period_type, and an index equal to the string-table length on both the sample-type and period-type paths, plus a valid control. The bad cases panic (or are wrongly accepted) before the change and return a clean error or validate fine after it. `go test ./pkg/normalizer/...` passes.

Happy to sign the CLA. Let me know if you would rather split the two fixes or send this against a release branch.