### PR TITLE
fix: make HasProfileData an existence probe instead of a full-table scan

### DIFF
--- a/pkg/clickhouse/querier.go
+++ b/pkg/clickhouse/querier.go
@@ -264,11 +264,21 @@ func (q *Querier) ProfileTypes(
 
 // HasProfileData checks if there is any profile data in the store.
 func (q *Querier) HasProfileData(ctx context.Context) (bool, error) {
-	types, err := q.ProfileTypes(ctx, time.UnixMilli(0), time.UnixMilli(0))
+	ctx, span := q.tracer.Start(ctx, "ClickHouse/HasProfileData")
+	defer span.End()
+
+	// LIMIT 1 lets ClickHouse stop at the first granule instead of running
+	// the previous DISTINCT over the whole table.
+	rows, err := q.client.Query(ctx, fmt.Sprintf(`
+		SELECT 1 FROM %s
+		LIMIT 1
+	`, q.client.FullTableName()))
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("failed to query profile data existence: %w", err)
 	}
-	return len(types) > 0, nil
+	defer rows.Close()
+
+	return rows.Next(), rows.Err()
 }
 
 // QueryRange executes a range query and returns time series data.


### PR DESCRIPTION
## What does this PR do?

`HasProfileData` delegated to `ProfileTypes` with a zero time range. `ProfileTypes`
skips its time filter when start and end are zero, so every call executed:

    SELECT DISTINCT name, sample_type, sample_unit, period_type, period_unit, (duration > 0)
    FROM <table>

with no WHERE and no LIMIT — and the result was immediately reduced to
`len(types) > 0`. DISTINCT cannot terminate early, so this scanned the entire
table on every call just to answer a boolean. `HasProfileData` backs the UI's
empty-state check and runs on every page load; with hundreds of millions of rows
this made the UI landing screen take seconds to minutes.

This replaces it with `SELECT 1 FROM <table> LIMIT 1`, which reads one granule
and stops. Semantics are unchanged: both answer "does the table contain at
least one row", since any row necessarily has profile-type values (non-nullable
columns).

## Why is it needed?

Observed in production with ~426M rows: the empty-state check was the single
most expensive query hitting ClickHouse, and under load it held connection
pool slots long enough to starve all other queries.

## How to test it?

- `go test ./pkg/clickhouse/`
- Manually: with data in the store, the UI shows the explorer instead of the
  "no data yet" prompt; with an empty store, the prompt still shows. The
  response is now immediate regardless of table size.
